### PR TITLE
fix(ci): resolve GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout
@@ -49,17 +44,26 @@ jobs:
           cd docs
           mdbook build
 
-      - name: Setup Pages
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/configure-pages@v4
-
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/book
 
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ jobs:
       contents: read
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout
@@ -56,14 +59,7 @@ jobs:
         with:
           path: docs/book
 
-  deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: docs
-    steps:
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The GitHub Pages deployment is failing with:


This is a common issue with GitHub Pages workflows when using separate jobs for deployment.

## Solution

- **Update to deploy-pages@v4** for better permissions handling
- **Consolidate deployment into single job** - removes permission issues between jobs
- **Proper environment configuration** - moves environment to job level
- **Fix OIDC token handling** - resolves the ID token request issue

## Technical Details

The issue occurs because the  permission and environment context need to be in the same job as the deployment step. The separate  job was causing permission inheritance issues.

## Changes

- Remove separate  job
- Move deployment step into main  job
- Update to  (latest version)
- Move  configuration to job level
- Maintain conditional deployment (main branch only)

## Testing

This fix addresses the specific error in the workflow logs and follows GitHub's current best practices for Pages deployment.

## Type of Change

- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [x] CI/CD enhancement