### PR TITLE
feat: add markdownlint compatibility mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ enum Commands {
         /// Fail on warnings (in addition to errors)
         #[arg(long)]
         fail_on_warnings: bool,
+        /// Enable markdownlint compatibility mode (disables rules that are disabled by default in markdownlint)
+        #[arg(long)]
+        markdownlint_compatible: bool,
         /// Output format
         #[arg(long, value_enum, default_value = "default")]
         output: OutputFormat,
@@ -119,6 +122,7 @@ fn main() {
             standard_only,
             mdbook_only,
             fail_on_warnings,
+            markdownlint_compatible,
             output,
         }) => run_cli_mode(
             &files,
@@ -126,6 +130,7 @@ fn main() {
             standard_only,
             mdbook_only,
             fail_on_warnings,
+            markdownlint_compatible,
             output,
         ),
         Some(Commands::Rules {
@@ -167,6 +172,7 @@ fn run_cli_mode(
     standard_only: bool,
     mdbook_only: bool,
     fail_on_warnings: bool,
+    markdownlint_compatible: bool,
     output_format: OutputFormat,
 ) -> Result<()> {
     // Validate mutually exclusive flags
@@ -202,6 +208,9 @@ fn run_cli_mode(
     // Override config with CLI flags
     if fail_on_warnings {
         config.fail_on_warnings = true;
+    }
+    if markdownlint_compatible {
+        config.markdownlint_compatible = true;
     }
 
     // Create appropriate engine based on flags

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -83,6 +83,11 @@ impl RuleRegistry {
             return false;
         }
 
+        // Check markdownlint compatibility mode - disable rules that are disabled by default in markdownlint
+        if config.markdownlint_compatible && rule_id == "MD044" {
+            return false; // proper-names: disabled by default in markdownlint
+        }
+
         // Check category-based filtering
         let category_name = self.category_to_string(&metadata.category);
 


### PR DESCRIPTION
## Summary

Adds markdownlint compatibility mode to reduce noise from rules that are disabled by default in markdownlint, addressing issue #23.

## Problem

mdbook-lint was generating **12.5x more violations** than markdownlint on the same files, primarily due to MD044 (proper-names) rule flagging capitalization issues like:
- `github` → `GitHub`  
- `https` → `HTTPS`
- Other proper name capitalizations

This created a poor migration experience for users switching from markdownlint.

## Solution

### Configuration Option
- Added `markdownlint-compatible` boolean to Config struct
- Supports TOML/YAML/JSON configuration files
- Defaults to `false` (preserving current behavior)

### CLI Flag  
- Added `--markdownlint-compatible` command-line flag
- Makes compatibility mode easily accessible without config files

### Rule Filtering
- Disables MD044 (proper-names) when compatibility mode is enabled
- Preserves explicit rule configuration (enabled/disabled rules override compatibility mode)
- Integrated into both Config and RuleRegistry rule filtering logic

## Testing

**Before (default mode)**:
```bash
$ mdbook-lint lint test.md
# 3 violations: MD034, MD047, MD044  
```

**After (compatibility mode)**:
```bash
$ mdbook-lint lint --markdownlint-compatible test.md  
# 2 violations: MD034, MD047 (MD044 suppressed)
```

Achieves **parity with markdownlint** behavior on test files.

## Usage

**CLI Flag**:
```bash
mdbook-lint lint --markdownlint-compatible README.md
```

**Configuration File**:
```toml
# .mdbook-lint.toml
markdownlint-compatible = true
```

## Implementation Notes

- Only disables MD044 based on research showing it's disabled by default in markdownlint
- MD034 remains enabled (confirmed enabled by default in markdownlint)  
- Comprehensive unit tests cover all scenarios
- Maintains full backward compatibility
- Explicit rule configuration always takes precedence

## Closes

Closes #23