### PR TITLE
hotfix: fix CLI crate dependency version to 0.4.0

### DIFF
--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -40,7 +40,7 @@ tower-lsp = { version = "0.20", optional = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-util", "io-std", "net", "time"], optional = true }
 
 # Local workspace crates  
-mdbook-lint-core = { version = "0.3.0", path = "../mdbook-lint-core" }
+mdbook-lint-core = { version = "0.4.0", path = "../mdbook-lint-core" }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## Problem

The v0.4.0 release failed CI because the CLI crate was still referencing  while the workspace version was bumped to  by release-please.

## Fix

Update the CLI crate dependency to reference  to match the released version.

## Testing

- ✅ Local build passes
- ✅ Pre-commit hooks pass (780+ tests)  
- ✅ Fixes the CI build failures seen in release workflow

This is a critical hotfix to unblock the v0.4.0 release.