### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -40,7 +40,7 @@ tower-lsp = { version = "0.20", optional = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-util", "io-std", "net", "time"], optional = true }
 
 # Local workspace crates  
-mdbook-lint-core = { version = "0.4.0", path = "../mdbook-lint-core" }
+mdbook-lint-core = { version = "0.4.1", path = "../mdbook-lint-core" }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## Summary
- Update version to 0.4.1 in workspace Cargo.toml
- Update dependency version in mdbook-lint-cli Cargo.toml
- Update Cargo.lock with new version

## Purpose
This version bump will trigger the release-please workflow to create a release and generate prebuilt binaries.

## Test plan
- All tests pass
- Clippy passes without warnings
- Formatting is correct
- Build succeeds