### PR TITLE
fix: implement rule override mechanism for MDBOOK025/MD025

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -40,7 +40,7 @@ tower-lsp = { version = "0.20", optional = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-util", "io-std", "net", "time"], optional = true }
 
 # Local workspace crates  
-mdbook-lint-core = { version = "0.4.0", path = "../mdbook-lint-core" }
+mdbook-lint-core = { version = "0.4.1", path = "../mdbook-lint-core" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "mdbook-lint-rulesets"
+description = "Modular rulesets for mdbook-lint - standard and mdBook-specific linting rules"
+keywords = ["markdown", "linter", "mdbook", "rules", "rulesets"]
+categories = ["development-tools", "text-processing"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "mdbook_lint_rulesets"
+path = "src/lib.rs"
+
+[features]
+default = ["standard", "mdbook"]
+standard = []  # Standard markdown rules (MD001-MD059)
+mdbook = ["dep:mdbook"]   # mdBook-specific rules (MDBOOK001-007)
+
+[dependencies]
+# Local workspace crates
+mdbook-lint-core = { version = "0.4.1", path = "../mdbook-lint-core" }
+
+# Core dependencies
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Markdown parsing
+comrak = { workspace = true }
+
+# mdBook integration (for mdbook rules)
+mdbook = { workspace = true, optional = true }
+
+# Utilities
+walkdir = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/mdbook-lint-rulesets/src/lib.rs
+++ b/crates/mdbook-lint-rulesets/src/lib.rs
@@ -1,0 +1,39 @@
+//! Modular rulesets for mdbook-lint
+//!
+//! This crate provides rule implementations organized by category:
+//! - Standard markdown rules (MD001-MD059) under the `standard` feature
+//! - mdBook-specific rules (MDBOOK001-007) under the `mdbook` feature
+//!
+//! # Features
+//!
+//! - `standard` (default): Standard markdown linting rules
+//! - `mdbook` (default): mdBook-specific linting rules
+//!
+//! # Usage
+//!
+//! ```rust
+//! use mdbook_lint_rulesets::StandardRuleProvider;
+//! use mdbook_lint_core::PluginRegistry;
+//!
+//! let mut registry = PluginRegistry::new();
+//! registry.register_provider(Box::new(StandardRuleProvider))?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+// Re-export core types for convenience
+pub use mdbook_lint_core::{
+    Document, Result, Rule, RuleCategory, RuleMetadata, RuleProvider, RuleRegistry, RuleStability,
+    Violation,
+};
+
+// Standard markdown rules
+#[cfg(feature = "standard")]
+pub mod standard;
+#[cfg(feature = "standard")]
+pub use standard::StandardRuleProvider;
+
+// mdBook-specific rules
+#[cfg(feature = "mdbook")]
+pub mod mdbook;
+#[cfg(feature = "mdbook")]
+pub use mdbook::MdBookRuleProvider;

--- a/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
@@ -1,0 +1,32 @@
+//! mdBook-specific linting rules (MDBOOK001-007)
+//!
+//! This module contains implementations of mdBook-specific linting rules
+//! that extend standard markdown linting for mdBook projects.
+
+use crate::{RuleProvider, RuleRegistry};
+
+/// Provider for mdBook-specific rules (MDBOOK001-007)
+pub struct MdBookRuleProvider;
+
+impl RuleProvider for MdBookRuleProvider {
+    fn provider_id(&self) -> &'static str {
+        "mdbook"
+    }
+
+    fn description(&self) -> &'static str {
+        "mdBook-specific linting rules (MDBOOK001-007)"
+    }
+
+    fn version(&self) -> &'static str {
+        "0.4.1"
+    }
+
+    fn register_rules(&self, _registry: &mut RuleRegistry) {
+        // TODO: Register actual rules once moved from core
+    }
+
+    fn rule_ids(&self) -> Vec<&'static str> {
+        // TODO: Return actual rule IDs once moved from core
+        vec![]
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/standard/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/mod.rs
@@ -1,0 +1,32 @@
+//! Standard markdown linting rules (MD001-MD059)
+//!
+//! This module contains implementations of the standard markdown linting rules
+//! as defined by the markdownlint specification.
+
+use crate::{RuleProvider, RuleRegistry};
+
+/// Provider for standard markdown rules (MD001-MD059)
+pub struct StandardRuleProvider;
+
+impl RuleProvider for StandardRuleProvider {
+    fn provider_id(&self) -> &'static str {
+        "standard"
+    }
+
+    fn description(&self) -> &'static str {
+        "Standard markdown linting rules (MD001-MD059)"
+    }
+
+    fn version(&self) -> &'static str {
+        "0.4.1"
+    }
+
+    fn register_rules(&self, _registry: &mut RuleRegistry) {
+        // TODO: Register actual rules once moved from core
+    }
+
+    fn rule_ids(&self) -> Vec<&'static str> {
+        // TODO: Return actual rule IDs once moved from core
+        vec![]
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes rule override mechanism where MDBOOK025 wasn't properly overriding MD025 for SUMMARY.md files
- Adds `mdbook-lint-rulesets` workspace member for future modular rulesets architecture
- Both rules were running instead of MDBOOK025 preventing MD025 from executing

## Changes
- Add `get_enabled_rules_with_overrides()` method to handle rule overrides per document  
- Add `is_override_applicable()` method to determine when overrides apply based on document context
- MDBOOK025 now correctly overrides MD025 for SUMMARY.md files only
- MD025 continues to work normally for other files
- Create foundation for modular rulesets architecture with placeholder providers

## Fixes
- Multiple H1 headings false positives in SUMMARY.md files
- Rule override metadata was defined but not implemented in execution logic

## Testing
- All existing tests pass
- Manual verification shows MD025 violations removed from SUMMARY.md files
- MD025 still works correctly for regular markdown files
- Command line flag parsing in code blocks continues to work properly

## Related Issues
This addresses the SUMMARY.md multiple H1 heading issue and sets up the foundation for modular rulesets work.