### PR TITLE
fix: update mdBook rules help text to reflect current count

### DIFF
--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -71,7 +71,7 @@ enum Commands {
         /// Show only standard rules (MD001-MD059)
         #[arg(long)]
         standard_only: bool,
-        /// Show only mdBook rules (MDBOOK001-004)
+        /// Show only mdBook-specific rules
         #[arg(long)]
         mdbook_only: bool,
         /// Output format for rule information


### PR DESCRIPTION
## Summary
- Updated the CLI help text for `--mdbook-only` flag to be more generic
- Previously referenced '(MDBOOK001-004)' but we now have 8 mdBook-specific rules
- Changed to "Show only mdBook-specific rules" to avoid future maintenance issues

## Test plan
- Ran all tests: `cargo test --lib --all-features`
- Verified help output: `cargo run --bin mdbook-lint -- rules --help`
- Confirmed 8 mdBook rules exist: `cargo run --bin mdbook-lint -- rules --mdbook-only`

This fix will trigger a patch release (0.4.2) when merged.