### PR TITLE
fix: configure release-plz to allow dirty working directory

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,22 +22,20 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       
-      - name: Clean workspace
+      - name: Initial workspace cleanup
         run: |
-          # Remove any generated test corpus files
-          rm -rf crates/mdbook-lint-cli/tests/corpus/real_projects/
-          rm -rf crates/mdbook-lint-cli/tests/corpus/edge_cases/
-          rm -rf crates/mdbook-lint-cli/tests/corpus/mdbook_projects/
+          # Remove any pre-existing generated files
+          rm -rf crates/mdbook-lint-cli/tests/corpus/
           rm -rf tests/corpus/
-          # Remove any generated test files
-          rm -f crates/mdbook-lint-cli/tests/fixtures/*/debug_input_*.json
-          # Remove any generated CHANGELOG if it exists
+          find . -name "debug_input_*.json" -delete
           rm -f CHANGELOG.md
-          # Ensure working directory is clean
-          git status --porcelain
       
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          config: release-plz.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # Allow dirty working directory for generated test files
+          RELEASE_PLZ_ALLOW_DIRTY: true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,6 +5,8 @@ dependencies_update = true
 changelog_update = true
 # Use conventional commits for changelog
 changelog_config = "cliff.toml"
+# Allow dirty working directory (for generated test files)
+allow_dirty = true
 
 # Tag pattern for releases
 git_tag_name = "v{{ version }}"


### PR DESCRIPTION
## Summary
Configure release-plz to allow dirty working directories to handle generated test files.

## Problem
The release-plz workflow was failing with "uncommitted changes" errors for:
- CHANGELOG.md (generated by release-plz itself)
- debug_input_*.json files (generated by tests)

## Solution
1. Add `allow_dirty = true` to release-plz.toml configuration
2. Set `RELEASE_PLZ_ALLOW_DIRTY=true` environment variable in workflow
3. Simplify cleanup to just remove known generated files before running

This is a common pattern for Rust projects where tests generate temporary files.

## Test plan
- [x] Verify configuration is valid
- [ ] Workflow should succeed after merge
- [ ] Release PR should be created for v0.4.2

Fixes the final issue with release-plz workflow.