### PR TITLE
feat: add simple release workflow as alternative to release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,9 +5,11 @@ permissions:
   contents: write
 
 on:
-  push:
-    branches:
-      - main
+  # Disabled - using simple-release.yml instead
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
 
 jobs:
   release-plz:

--- a/.github/workflows/simple-release.yml
+++ b/.github/workflows/simple-release.yml
@@ -1,0 +1,104 @@
+name: Simple Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version_bump: ${{ steps.check.outputs.version_bump }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Check for release commits
+        id: check
+        run: |
+          # Get commits since last tag
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --format=%s)
+          else
+            COMMITS=$(git log $LAST_TAG..HEAD --format=%s)
+          fi
+          
+          # Check for conventional commits
+          if echo "$COMMITS" | grep -qE "^(feat|fix|perf)(\(.+\))?:"; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            
+            # Determine version bump
+            if echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
+              echo "version_bump=minor" >> $GITHUB_OUTPUT
+            else
+              echo "version_bump=patch" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          fi
+
+  create-release-pr:
+    needs: check-commits
+    if: needs.check-commits.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      
+      - name: Calculate next version
+        id: version
+        run: |
+          CURRENT_VERSION=$(grep "^version" Cargo.toml | head -1 | cut -d'"' -f2)
+          BUMP_TYPE="${{ needs.check-commits.outputs.version_bump }}"
+          
+          # Parse version
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          
+          # Bump version
+          if [ "$BUMP_TYPE" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+          
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Update versions
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          
+          # Update workspace version
+          sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" Cargo.toml
+          
+          # Update all workspace dependencies
+          find . -name "Cargo.toml" -exec sed -i "s/version = \"0.4.1\"/version = \"$NEW_VERSION\"/g" {} \;
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: release v${{ steps.version.outputs.new_version }}"
+          title: "chore: release v${{ steps.version.outputs.new_version }}"
+          body: |
+            ## Release v${{ steps.version.outputs.new_version }}
+            
+            This PR was automatically generated to release version ${{ steps.version.outputs.new_version }}.
+            
+            ### Changes included:
+            - Updated version in Cargo.toml files
+            
+            When merged, this will trigger a GitHub release with built binaries.
+          branch: release/v${{ steps.version.outputs.new_version }}
+          labels: release


### PR DESCRIPTION
## Summary
Created a simple release workflow that doesn't depend on crates.io, avoiding the chicken-and-egg problem with unpublished workspace crates.

## Problem
Release-plz keeps failing because:
- The workspace was restructured into multiple crates (mdbook-lint-core, mdbook-lint-rulesets, mdbook-lint-cli)
- These crates have never been published to crates.io
- Release-plz expects packages to exist on crates.io to determine version bumps
- We can't publish without a release, and can't release without publishing

## Solution
Created `simple-release.yml` that:
1. Detects conventional commits (feat/fix/perf) since last tag
2. Calculates appropriate version bump (minor for feat, patch for fix/perf)  
3. Updates all Cargo.toml files with new version
4. Creates a release PR automatically
5. When merged, triggers GitHub release with binaries

## Benefits
- No dependency on crates.io
- Works with unpublished workspace crates
- Still uses conventional commits for versioning
- Automatic PR creation for releases
- Simple and maintainable

## Next Steps
1. Merge this PR
2. The workflow will detect your pending fix commit and create a v0.4.2 release PR
3. Later, when ready to publish to crates.io, we can switch back to release-plz