### PR TITLE
fix: disable changelog updates in release-plz to fix CI

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,10 +2,6 @@
 # Keep it simple - let release-plz do its job
 
 [workspace]
-# Update changelogs using git-cliff
-changelog_update = true
-changelog_config = "cliff.toml"
-
 # Don't update all dependencies automatically
 dependencies_update = false
 


### PR DESCRIPTION
The release-plz workflow is failing because it modifies CHANGELOG.md and then complains about uncommitted changes. This PR disables automatic changelog updates to fix the CI pipeline. 

We can manage changelogs separately or use GitHub releases for release notes.