### PR TITLE
feat: add automated binary builds for releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,87 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # Linux
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: mdbook-lint
+            archive: mdbook-lint-linux-x86_64.tar.gz
+          
+          # Linux musl (static binary)
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            binary: mdbook-lint
+            archive: mdbook-lint-linux-x86_64-musl.tar.gz
+          
+          # Windows
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: mdbook-lint.exe
+            archive: mdbook-lint-windows-x86_64.zip
+          
+          # macOS Intel
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary: mdbook-lint
+            archive: mdbook-lint-macos-x86_64.tar.gz
+          
+          # macOS Apple Silicon
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary: mdbook-lint
+            archive: mdbook-lint-macos-aarch64.tar.gz
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install musl tools (Linux musl only)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Create archive (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.archive }} ${{ matrix.binary }}
+          cd ../../..
+          echo "ASSET=${{ matrix.archive }}" >> $GITHUB_ENV
+
+      - name: Create archive (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd target\${{ matrix.target }}\release
+          7z a ..\..\..\${{ matrix.archive }} ${{ matrix.binary }}
+          cd ..\..\..
+          echo "ASSET=${{ matrix.archive }}" >> $env:GITHUB_ENV
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary

Adds a separate GitHub Actions workflow that automatically builds and uploads binary artifacts when a release is created.

## Features

- Builds for multiple platforms:
  - Linux x86_64 (glibc)
  - Linux x86_64 (musl - static binary)
  - Windows x86_64
  - macOS x86_64 (Intel)
  - macOS aarch64 (Apple Silicon)

- Triggers on release creation (not on push to main)
- Won't interfere with release-plz workflow
- Automatically uploads binaries to the GitHub release

## Test Plan

- The workflow will run when the next release is created
- Can be manually tested by creating a draft release

This matches the binary distribution mentioned in the README and provides users with pre-built binaries they can download without needing Rust installed.