### PR TITLE
feat: add fix support for MD047 and MD010 rules

### DIFF
--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -658,6 +658,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         }];
         assert!(!preprocessor.should_fail_build(&warning_violations));
 
@@ -669,6 +670,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Error,
+            fix: None,
         }];
         assert!(preprocessor.should_fail_build(&error_violations));
     }
@@ -683,6 +685,7 @@ mod tests {
             line: 2,
             column: 1,
             severity: Severity::Error,
+            fix: None,
         }];
 
         let output = preprocessor.format_violations(&violations, "test.md");

--- a/crates/mdbook-lint-core/src/deduplication.rs
+++ b/crates/mdbook-lint-core/src/deduplication.rs
@@ -167,6 +167,7 @@ mod tests {
             line,
             column,
             severity: Severity::Warning,
+            fix: None,
         }
     }
 

--- a/crates/mdbook-lint-core/src/rule.rs
+++ b/crates/mdbook-lint-core/src/rule.rs
@@ -171,6 +171,27 @@ pub trait Rule: Send + Sync {
             line,
             column,
             severity,
+            fix: None,
+        }
+    }
+    
+    /// Create a violation with a fix for this rule
+    fn create_violation_with_fix(
+        &self,
+        message: String,
+        line: usize,
+        column: usize,
+        severity: crate::violation::Severity,
+        fix: crate::violation::Fix,
+    ) -> Violation {
+        Violation {
+            rule_id: self.id().to_string(),
+            rule_name: self.name().to_string(),
+            message,
+            line,
+            column,
+            severity,
+            fix: Some(fix),
         }
     }
 }
@@ -261,6 +282,7 @@ pub trait Rule: Send + Sync {
 ///
 /// **Creating Violations:**
 /// - `self.create_violation(message, line, column, severity)` - Standard violation creation
+/// - `self.create_violation_with_fix(message, line, column, severity, fix)` - Violation with fix
 pub trait AstRule: Send + Sync {
     /// Unique identifier for the rule (e.g., "MD001")
     fn id(&self) -> &'static str;
@@ -302,6 +324,27 @@ pub trait AstRule: Send + Sync {
             line,
             column,
             severity,
+            fix: None,
+        }
+    }
+    
+    /// Create a violation with a fix for this rule
+    fn create_violation_with_fix(
+        &self,
+        message: String,
+        line: usize,
+        column: usize,
+        severity: crate::violation::Severity,
+        fix: crate::violation::Fix,
+    ) -> Violation {
+        Violation {
+            rule_id: self.id().to_string(),
+            rule_name: self.name().to_string(),
+            message,
+            line,
+            column,
+            severity,
+            fix: Some(fix),
         }
     }
 }

--- a/crates/mdbook-lint-core/src/rule.rs
+++ b/crates/mdbook-lint-core/src/rule.rs
@@ -174,7 +174,7 @@ pub trait Rule: Send + Sync {
             fix: None,
         }
     }
-    
+
     /// Create a violation with a fix for this rule
     fn create_violation_with_fix(
         &self,
@@ -327,7 +327,7 @@ pub trait AstRule: Send + Sync {
             fix: None,
         }
     }
-    
+
     /// Create a violation with a fix for this rule
     fn create_violation_with_fix(
         &self,

--- a/crates/mdbook-lint-core/src/rules/mdbook004.rs
+++ b/crates/mdbook-lint-core/src/rules/mdbook004.rs
@@ -159,6 +159,7 @@ impl MDBOOK004 {
                     line: *line,
                     column: *column,
                     severity: Severity::Error,
+                    fix: None,
                 };
                 (file_path.clone(), violation)
             })

--- a/crates/mdbook-lint-core/src/rules/standard/md010.rs
+++ b/crates/mdbook-lint-core/src/rules/standard/md010.rs
@@ -64,18 +64,24 @@ impl Rule for MD010 {
             // Check for tab characters
             if let Some(tab_pos) = line.find('\t') {
                 let column = tab_pos + 1; // Convert to 1-based column
-                
+
                 // Create replacement string with spaces
                 let replacement = " ".repeat(self.spaces_per_tab);
-                
+
                 // Find all tabs in the line to create a complete fix
                 let fixed_line = line.replace('\t', &replacement);
-                
+
                 let fix = Fix {
                     description: format!("Replace tab with {} spaces", self.spaces_per_tab),
                     replacement: Some(fixed_line),
-                    start: Position { line: line_num, column: 1 },
-                    end: Position { line: line_num, column: line.len() + 1 },
+                    start: Position {
+                        line: line_num,
+                        column: 1,
+                    },
+                    end: Position {
+                        line: line_num,
+                        column: line.len() + 1,
+                    },
                 };
 
                 violations.push(self.create_violation_with_fix(
@@ -93,7 +99,7 @@ impl Rule for MD010 {
 
         Ok(violations)
     }
-    
+
     fn can_fix(&self) -> bool {
         true
     }
@@ -132,7 +138,7 @@ mod tests {
         assert_eq!(violations[0].column, 10);
         assert!(violations[0].message.contains("Hard tab character"));
         assert!(violations[0].message.contains("4 spaces"));
-        
+
         // Check fix is present
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();

--- a/crates/mdbook-lint-core/src/rules/standard/md047.rs
+++ b/crates/mdbook-lint-core/src/rules/standard/md047.rs
@@ -68,7 +68,7 @@ impl Rule for MD047 {
         if let Some(message) = self.check_file_ending(&document.content) {
             let line_count = document.lines.len();
             let line_number = if line_count == 0 { 1 } else { line_count };
-            
+
             // Create fix based on the specific issue
             let fix = if document.content.is_empty() {
                 // Empty file: add a single newline
@@ -84,18 +84,35 @@ impl Rule for MD047 {
                 Fix {
                     description: "Add newline at end of file".to_string(),
                     replacement: Some("\n".to_string()),
-                    start: Position { line: line_number, column: last_line_len },
-                    end: Position { line: line_number, column: last_line_len },
+                    start: Position {
+                        line: line_number,
+                        column: last_line_len,
+                    },
+                    end: Position {
+                        line: line_number,
+                        column: last_line_len,
+                    },
                 }
             } else {
                 // Multiple trailing newlines: remove extras
-                let trailing_newlines = document.content.chars().rev().take_while(|&c| c == '\n').count();
+                let trailing_newlines = document
+                    .content
+                    .chars()
+                    .rev()
+                    .take_while(|&c| c == '\n')
+                    .count();
                 let start_line = line_count - trailing_newlines + 2;
                 Fix {
                     description: "Remove extra trailing newlines".to_string(),
                     replacement: Some("\n".to_string()),
-                    start: Position { line: start_line, column: 1 },
-                    end: Position { line: line_count + 1, column: 1 },
+                    start: Position {
+                        line: start_line,
+                        column: 1,
+                    },
+                    end: Position {
+                        line: line_count + 1,
+                        column: 1,
+                    },
                 }
             };
 
@@ -110,7 +127,7 @@ impl Rule for MD047 {
 
         Ok(violations)
     }
-    
+
     fn can_fix(&self) -> bool {
         true
     }
@@ -150,7 +167,7 @@ mod tests {
                 .message
                 .contains("File should end with a single newline character")
         );
-        
+
         // Check fix is present
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();

--- a/crates/mdbook-lint-core/src/rules/standard/md047.rs
+++ b/crates/mdbook-lint-core/src/rules/standard/md047.rs
@@ -6,7 +6,7 @@ use crate::error::Result;
 use crate::rule::{Rule, RuleCategory, RuleMetadata};
 use crate::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// Rule to check that files end with a single newline
@@ -68,11 +68,51 @@ impl Rule for MD047 {
         if let Some(message) = self.check_file_ending(&document.content) {
             let line_count = document.lines.len();
             let line_number = if line_count == 0 { 1 } else { line_count };
+            
+            // Create fix based on the specific issue
+            let fix = if document.content.is_empty() {
+                // Empty file: add a single newline
+                Fix {
+                    description: "Add newline at end of file".to_string(),
+                    replacement: Some("\n".to_string()),
+                    start: Position { line: 1, column: 1 },
+                    end: Position { line: 1, column: 1 },
+                }
+            } else if !document.content.ends_with('\n') {
+                // No trailing newline: add one
+                let last_line_len = document.lines.last().map(|l| l.len()).unwrap_or(0) + 1;
+                Fix {
+                    description: "Add newline at end of file".to_string(),
+                    replacement: Some("\n".to_string()),
+                    start: Position { line: line_number, column: last_line_len },
+                    end: Position { line: line_number, column: last_line_len },
+                }
+            } else {
+                // Multiple trailing newlines: remove extras
+                let trailing_newlines = document.content.chars().rev().take_while(|&c| c == '\n').count();
+                let start_line = line_count - trailing_newlines + 2;
+                Fix {
+                    description: "Remove extra trailing newlines".to_string(),
+                    replacement: Some("\n".to_string()),
+                    start: Position { line: start_line, column: 1 },
+                    end: Position { line: line_count + 1, column: 1 },
+                }
+            };
 
-            violations.push(self.create_violation(message, line_number, 1, Severity::Warning));
+            violations.push(self.create_violation_with_fix(
+                message,
+                line_number,
+                1,
+                Severity::Warning,
+                fix,
+            ));
         }
 
         Ok(violations)
+    }
+    
+    fn can_fix(&self) -> bool {
+        true
     }
 }
 
@@ -110,6 +150,12 @@ mod tests {
                 .message
                 .contains("File should end with a single newline character")
         );
+        
+        // Check fix is present
+        assert!(violations[0].fix.is_some());
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.description, "Add newline at end of file");
+        assert_eq!(fix.replacement, Some("\n".to_string()));
     }
 
     #[test]

--- a/crates/mdbook-lint-core/src/test_helpers.rs
+++ b/crates/mdbook-lint-core/src/test_helpers.rs
@@ -357,6 +357,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         }];
 
         assert_violation_contains_message(&violations, "test violation");
@@ -461,6 +462,7 @@ mod tests {
                 line: 5,
                 column: 1,
                 severity: Severity::Warning,
+                fix: None,
             },
             Violation {
                 rule_id: "TEST002".to_string(),
@@ -469,6 +471,7 @@ mod tests {
                 line: 10,
                 column: 1,
                 severity: Severity::Error,
+                fix: None,
             },
         ];
 
@@ -486,6 +489,7 @@ mod tests {
                 line: 1,
                 column: 1,
                 severity: Severity::Warning,
+                fix: None,
             },
             Violation {
                 rule_id: "MD013".to_string(),
@@ -494,6 +498,7 @@ mod tests {
                 line: 2,
                 column: 1,
                 severity: Severity::Error,
+                fix: None,
             },
         ];
 
@@ -511,6 +516,7 @@ mod tests {
                 line: 1,
                 column: 1,
                 severity: Severity::Warning,
+                fix: None,
             },
             Violation {
                 rule_id: "TEST002".to_string(),
@@ -519,6 +525,7 @@ mod tests {
                 line: 2,
                 column: 1,
                 severity: Severity::Error,
+                fix: None,
             },
         ];
 
@@ -731,6 +738,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         }];
         assert_violation_contains_message(&violations, "nonexistent message");
     }
@@ -745,6 +753,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         }];
         assert_violation_at_line(&violations, 999);
     }
@@ -759,6 +768,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         }];
         assert_violation_rule_id(&violations, "NONEXISTENT");
     }
@@ -773,6 +783,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         }];
         assert_violation_severity(&violations, Severity::Error);
     }
@@ -796,6 +807,7 @@ mod tests {
             line: 42,
             column: 1,
             severity: Severity::Error,
+            fix: None,
         }];
 
         assert_violation_contains_message(&test_violations, "specific text");

--- a/crates/mdbook-lint-core/src/violation.rs
+++ b/crates/mdbook-lint-core/src/violation.rs
@@ -229,8 +229,14 @@ mod tests {
         let fix = Fix {
             description: "Replace tab with spaces".to_string(),
             replacement: Some("    ".to_string()),
-            start: Position { line: 5, column: 10 },
-            end: Position { line: 5, column: 11 },
+            start: Position {
+                line: 5,
+                column: 10,
+            },
+            end: Position {
+                line: 5,
+                column: 11,
+            },
         };
 
         let violation = Violation {
@@ -245,7 +251,7 @@ mod tests {
 
         assert_eq!(violation.fix, Some(fix));
         assert!(violation.fix.is_some());
-        
+
         let fix_ref = violation.fix.as_ref().unwrap();
         assert_eq!(fix_ref.description, "Replace tab with spaces");
         assert_eq!(fix_ref.replacement, Some("    ".to_string()));
@@ -259,9 +265,15 @@ mod tests {
     fn test_fix_delete_operation() {
         let fix = Fix {
             description: "Remove extra newlines".to_string(),
-            replacement: None,  // None means delete
-            start: Position { line: 10, column: 1 },
-            end: Position { line: 12, column: 1 },
+            replacement: None, // None means delete
+            start: Position {
+                line: 10,
+                column: 1,
+            },
+            end: Position {
+                line: 12,
+                column: 1,
+            },
         };
 
         assert_eq!(fix.replacement, None);

--- a/crates/mdbook-lint-core/src/violation.rs
+++ b/crates/mdbook-lint-core/src/violation.rs
@@ -2,6 +2,28 @@
 //!
 //! This module contains the core types for representing linting violations.
 
+/// A suggested fix for a violation
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct Fix {
+    /// Description of what the fix does
+    pub description: String,
+    /// The replacement text (None means delete)
+    pub replacement: Option<String>,
+    /// Start position of the text to replace
+    pub start: Position,
+    /// End position of the text to replace  
+    pub end: Position,
+}
+
+/// Position in a document
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct Position {
+    /// Line number (1-based)
+    pub line: usize,
+    /// Column number (1-based)
+    pub column: usize,
+}
+
 /// A violation found during linting
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct Violation {
@@ -17,6 +39,8 @@ pub struct Violation {
     pub column: usize,
     /// Severity level
     pub severity: Severity,
+    /// Optional fix for this violation
+    pub fix: Option<Fix>,
 }
 
 /// Severity levels for violations
@@ -79,6 +103,7 @@ mod tests {
             line: 5,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         };
 
         assert_eq!(violation.rule_id, "MD001");
@@ -86,6 +111,7 @@ mod tests {
         assert_eq!(violation.line, 5);
         assert_eq!(violation.column, 1);
         assert_eq!(violation.severity, Severity::Warning);
+        assert_eq!(violation.fix, None);
     }
 
     #[test]
@@ -97,6 +123,7 @@ mod tests {
             line: 10,
             column: 81,
             severity: Severity::Error,
+            fix: None,
         };
 
         let expected = "10:81:error: MD013/line-length: Line too long";
@@ -112,6 +139,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         };
 
         let violation2 = Violation {
@@ -121,6 +149,7 @@ mod tests {
             line: 1,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         };
 
         let violation3 = Violation {
@@ -130,6 +159,7 @@ mod tests {
             line: 2,
             column: 1,
             severity: Severity::Error,
+            fix: None,
         };
 
         assert_eq!(violation1, violation2);
@@ -145,6 +175,7 @@ mod tests {
             line: 15,
             column: 3,
             severity: Severity::Info,
+            fix: None,
         };
 
         let cloned = original.clone();
@@ -160,6 +191,7 @@ mod tests {
             line: 20,
             column: 1,
             severity: Severity::Warning,
+            fix: None,
         };
 
         let debug_str = format!("{violation:?}");
@@ -183,11 +215,56 @@ mod tests {
                 line: 1,
                 column: 1,
                 severity: *severity,
+                fix: None,
             };
 
             // Test that display format includes severity
             let display_str = format!("{violation}");
             assert!(display_str.contains(&format!("{severity}")));
         }
+    }
+
+    #[test]
+    fn test_violation_with_fix() {
+        let fix = Fix {
+            description: "Replace tab with spaces".to_string(),
+            replacement: Some("    ".to_string()),
+            start: Position { line: 5, column: 10 },
+            end: Position { line: 5, column: 11 },
+        };
+
+        let violation = Violation {
+            rule_id: "MD010".to_string(),
+            rule_name: "no-hard-tabs".to_string(),
+            message: "Hard tab found".to_string(),
+            line: 5,
+            column: 10,
+            severity: Severity::Warning,
+            fix: Some(fix.clone()),
+        };
+
+        assert_eq!(violation.fix, Some(fix));
+        assert!(violation.fix.is_some());
+        
+        let fix_ref = violation.fix.as_ref().unwrap();
+        assert_eq!(fix_ref.description, "Replace tab with spaces");
+        assert_eq!(fix_ref.replacement, Some("    ".to_string()));
+        assert_eq!(fix_ref.start.line, 5);
+        assert_eq!(fix_ref.start.column, 10);
+        assert_eq!(fix_ref.end.line, 5);
+        assert_eq!(fix_ref.end.column, 11);
+    }
+
+    #[test]
+    fn test_fix_delete_operation() {
+        let fix = Fix {
+            description: "Remove extra newlines".to_string(),
+            replacement: None,  // None means delete
+            start: Position { line: 10, column: 1 },
+            end: Position { line: 12, column: 1 },
+        };
+
+        assert_eq!(fix.replacement, None);
+        assert_eq!(fix.description, "Remove extra newlines");
     }
 }


### PR DESCRIPTION
## Summary
This PR implements the foundational infrastructure for automatic fixes in mdbook-lint and adds fix support for two rules as a proof of concept.

Addresses #19 

## Changes

### Core Infrastructure
- Added `Fix` struct with description, replacement text, and position range
- Added `Position` struct for line/column coordinates  
- Added optional `fix` field to `Violation` struct
- Added `create_violation_with_fix` helper methods to Rule and AstRule traits

### Rule Implementations
- **MD047 (single-trailing-newline)**: Automatically adds or removes newlines to ensure files end with exactly one newline
- **MD010 (no-hard-tabs)**: Replaces hard tab characters with configurable number of spaces (default: 4)

### Testing
- Added comprehensive tests for fix functionality
- Updated all existing Violation creation sites to include the new fix field
- All tests passing, clippy clean

## Test Plan
- [x] Run `cargo test --lib test_md047` - all tests pass
- [x] Run `cargo test --lib test_md010` - all tests pass  
- [x] Run `cargo clippy --all-targets --all-features -- -D warnings` - no warnings
- [x] Manually verify fix suggestions are correct for both rules

## Next Steps
Once this PR is merged, we can:
1. Add fix support to more rules incrementally
2. Implement CLI command to apply fixes automatically
3. Add fix support to the LSP server for editor integration