### PR TITLE
feat: add fix support for MD009, MD012, MD018, MD023, and MD034

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md009.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md009.rs
@@ -6,7 +6,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// Rule to check for trailing spaces at the end of lines
@@ -109,9 +109,30 @@ impl AstRule for MD009 {
                 continue;
             }
 
-            // Create violation
+            // Create violation with fix
             let column = line.len() - trailing_spaces + 1;
-            violations.push(self.create_violation(
+
+            // Create the fixed line by removing trailing whitespace
+            let fixed_line = line.trim_end().to_string() + "\n";
+
+            let fix = Fix {
+                description: format!(
+                    "Remove {} trailing space{}",
+                    trailing_spaces,
+                    if trailing_spaces == 1 { "" } else { "s" }
+                ),
+                replacement: Some(fixed_line),
+                start: Position {
+                    line: line_num,
+                    column: 1,
+                },
+                end: Position {
+                    line: line_num,
+                    column: line.len() + 1,
+                },
+            };
+
+            violations.push(self.create_violation_with_fix(
                 format!(
                     "Trailing spaces detected (found {} trailing space{})",
                     trailing_spaces,
@@ -120,6 +141,7 @@ impl AstRule for MD009 {
                 line_num,
                 column,
                 Severity::Warning,
+                fix,
             ));
         }
 

--- a/crates/mdbook-lint-rulesets/src/standard/md009.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md009.rs
@@ -313,4 +313,156 @@ mod tests {
         // In strict mode, should catch trailing spaces everywhere
         assert_eq!(violations.len(), 2);
     }
+
+    #[test]
+    fn test_md009_fix_single_trailing_space() {
+        let content = "Line with trailing space ";
+        let document = create_test_document(content);
+        let rule = MD009::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(
+            fix.replacement.as_ref().unwrap(),
+            "Line with trailing space\n"
+        );
+        assert_eq!(fix.description, "Remove 1 trailing space");
+    }
+
+    #[test]
+    fn test_md009_fix_multiple_trailing_spaces() {
+        let content = "Line with spaces    ";
+        let document = create_test_document(content);
+        let rule = MD009::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with spaces\n");
+        assert_eq!(fix.description, "Remove 4 trailing spaces");
+    }
+
+    #[test]
+    fn test_md009_fix_trailing_tabs() {
+        let content = "Line with tab\t";
+        let document = create_test_document(content);
+        let rule = MD009::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with tab\n");
+        assert_eq!(fix.description, "Remove 1 trailing space");
+    }
+
+    #[test]
+    fn test_md009_fix_mixed_trailing_whitespace() {
+        let content = "Line with mixed \t  \t";
+        let document = create_test_document(content);
+        let rule = MD009::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with mixed\n");
+        assert_eq!(fix.description, "Remove 5 trailing spaces");
+    }
+
+    #[test]
+    fn test_md009_fix_preserves_line_content() {
+        let content = "Important content with spaces   "; // 3 spaces to trigger violation
+        let document = create_test_document(content);
+        let rule = MD009::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert!(
+            fix.replacement
+                .as_ref()
+                .unwrap()
+                .starts_with("Important content with spaces")
+        );
+        assert!(!fix.replacement.as_ref().unwrap().contains("   \n"));
+    }
+
+    #[test]
+    fn test_md009_fix_position_accuracy() {
+        let content = "Line with trailing spaces   ";
+        let document = create_test_document(content);
+        let rule = MD009::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.start.line, 1);
+        assert_eq!(fix.start.column, 1);
+        assert_eq!(fix.end.line, 1);
+        assert_eq!(fix.end.column, content.len() + 1);
+    }
+
+    #[test]
+    fn test_md009_no_fix_for_allowed_line_breaks() {
+        let content = "Line with two spaces for break  ";
+        let document = create_test_document(content);
+        let rule = MD009::new(); // Default allows 2 spaces for line breaks
+        let violations = rule.check(&document).unwrap();
+
+        // Should not create violations for exactly 2 trailing spaces
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md009_fix_multiple_lines() {
+        let content = "First line with space \nSecond line with tabs\t\nThird line with many     ";
+        let document = create_test_document(content);
+        let rule = MD009::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 3);
+
+        // Check first line fix
+        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            violations[0]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "First line with space\n"
+        );
+
+        // Check second line fix
+        assert_eq!(violations[1].line, 2);
+        assert_eq!(
+            violations[1]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "Second line with tabs\n"
+        );
+
+        // Check third line fix
+        assert_eq!(violations[2].line, 3);
+        assert_eq!(
+            violations[2]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "Third line with many\n"
+        );
+    }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md018.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md018.rs
@@ -6,7 +6,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// Rule to check for missing space after hash on ATX style headings
@@ -54,11 +54,30 @@ impl Rule for MD018 {
                     if !after_hashes.is_empty() && !after_hashes.starts_with(' ') {
                         let column = line.len() - line.trim_start().len() + hash_count + 1;
 
-                        violations.push(self.create_violation(
+                        // Create fixed line by adding a space after the hashes
+                        let indent = &line[..line.len() - trimmed.len()];
+                        let hashes = &trimmed[..hash_count];
+                        let fixed_line = format!("{}{} {}\n", indent, hashes, after_hashes.trim());
+
+                        let fix = Fix {
+                            description: "Add space after hash on atx style heading".to_string(),
+                            replacement: Some(fixed_line),
+                            start: Position {
+                                line: line_num,
+                                column: 1,
+                            },
+                            end: Position {
+                                line: line_num,
+                                column: line.len() + 1,
+                            },
+                        };
+
+                        violations.push(self.create_violation_with_fix(
                             "No space after hash on atx style heading".to_string(),
                             line_num,
                             column,
                             Severity::Warning,
+                            fix,
                         ));
                     }
                 }

--- a/crates/mdbook-lint-rulesets/src/standard/md034.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md034.rs
@@ -370,4 +370,196 @@ Normal text without URLs should be fine.
 
         assert_eq!(violations.len(), 0);
     }
+
+    #[test]
+    fn test_md034_fix_simple_url() {
+        let content = "Visit https://example.com for more info.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.replacement.as_ref().unwrap(), "<https://example.com>");
+        assert_eq!(fix.description, "Wrap URL in angle brackets");
+    }
+
+    #[test]
+    fn test_md034_fix_multiple_urls() {
+        let content = "Check https://first.com and http://second.com for details.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 2);
+
+        // First URL
+        let fix1 = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix1.replacement.as_ref().unwrap(), "<https://first.com>");
+
+        // Second URL
+        let fix2 = violations[1].fix.as_ref().unwrap();
+        assert_eq!(fix2.replacement.as_ref().unwrap(), "<http://second.com>");
+    }
+
+    #[test]
+    fn test_md034_fix_complex_url() {
+        let content =
+            "API docs: https://api.example.com/v1/users?limit=10&offset=0#pagination here.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(
+            fix.replacement.as_ref().unwrap(),
+            "<https://api.example.com/v1/users?limit=10&offset=0#pagination>"
+        );
+    }
+
+    #[test]
+    fn test_md034_fix_ftp_url() {
+        let content = "Download from ftp://files.example.com/path/file.txt today.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(
+            fix.replacement.as_ref().unwrap(),
+            "<ftp://files.example.com/path/file.txt>"
+        );
+    }
+
+    #[test]
+    fn test_md034_fix_mailto() {
+        let content = "Contact us at mailto:support@example.com for help.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(
+            fix.replacement.as_ref().unwrap(),
+            "<mailto:support@example.com>"
+        );
+    }
+
+    #[test]
+    fn test_md034_fix_url_with_trailing_punctuation() {
+        let content = "Visit https://example.com. Also check https://test.com, please.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        // URLs should not include trailing punctuation
+        assert_eq!(
+            violations[0]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "<https://example.com>"
+        );
+        assert_eq!(
+            violations[1]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "<https://test.com>"
+        );
+    }
+
+    #[test]
+    fn test_md034_fix_position_accuracy() {
+        let content = "Text before https://example.com text after.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.start.line, 1);
+        assert_eq!(fix.start.column, 13); // Start of URL (1-based)
+        assert_eq!(fix.end.line, 1);
+        assert_eq!(fix.end.column, 32); // End of URL (1-based, exclusive)
+    }
+
+    #[test]
+    fn test_md034_fix_multiple_lines() {
+        let content = "First line with https://first.com\nSecond line with http://second.com\nThird line with ftp://third.com";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 3);
+        assert_eq!(violations[0].line, 1);
+        assert_eq!(
+            violations[0]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "<https://first.com>"
+        );
+        assert_eq!(violations[1].line, 2);
+        assert_eq!(
+            violations[1]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "<http://second.com>"
+        );
+        assert_eq!(violations[2].line, 3);
+        assert_eq!(
+            violations[2]
+                .fix
+                .as_ref()
+                .unwrap()
+                .replacement
+                .as_ref()
+                .unwrap(),
+            "<ftp://third.com>"
+        );
+    }
+
+    #[test]
+    fn test_md034_fix_url_at_start_of_line() {
+        let content = "https://example.com is a great site.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.replacement.as_ref().unwrap(), "<https://example.com>");
+        assert_eq!(fix.start.column, 1);
+    }
+
+    #[test]
+    fn test_md034_fix_url_at_end_of_line() {
+        let content = "Check out this site: https://example.com";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD034;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.replacement.as_ref().unwrap(), "<https://example.com>");
+    }
 }


### PR DESCRIPTION
## Summary
- Add fix support for MD009 (trailing spaces) - removes trailing whitespace
- Add fix support for MD012 (multiple consecutive blank lines) - removes extra blank lines
- Add fix support for MD018 (no space after hash on atx style heading) - adds missing space
- Add fix support for MD023 (headings must start at the beginning of the line) - removes indentation
- Add fix support for MD034 (bare URL without angle brackets) - wraps URLs in angle brackets

Closes #107

## Test plan
- [ ] Run cargo test to verify all tests pass
- [ ] Test fix functionality for each rule manually
- [ ] Verify fixes don't break existing functionality
- [ ] Check that violations include proper fix information