### PR TITLE
feat: implement mdBook rules MDBOOK008-012

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "comrak",
  "mdbook",
  "mdbook-lint-core",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -37,6 +37,7 @@ mdbook = { workspace = true, optional = true }
 
 # Utilities
 walkdir = { workspace = true }
+regex = "1.10"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook008.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook008.rs
@@ -1,0 +1,268 @@
+//! MDBOOK008: Invalid {{#rustdoc_include}} paths or syntax
+//!
+//! This rule checks for invalid rustdoc_include directives in mdBook files.
+//! The rustdoc_include directive allows including portions of Rust files with rustdoc annotations.
+
+use mdbook_lint_core::error::Result;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::{
+    Document,
+    violation::{Severity, Violation},
+};
+use regex::Regex;
+use std::path::Path;
+
+/// Rule to check for invalid {{#rustdoc_include}} directives
+pub struct MDBOOK008;
+
+impl Rule for MDBOOK008 {
+    fn id(&self) -> &'static str {
+        "MDBOOK008"
+    }
+
+    fn name(&self) -> &'static str {
+        "rustdoc-include-validation"
+    }
+
+    fn description(&self) -> &'static str {
+        "Invalid {{#rustdoc_include}} paths or syntax"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::experimental(RuleCategory::MdBook).introduced_in("mdbook-lint v0.11.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        // Regex to match {{#rustdoc_include path:line_range}}
+        // Supports various formats:
+        // {{#rustdoc_include file.rs}}
+        // {{#rustdoc_include file.rs:10}}
+        // {{#rustdoc_include file.rs:10:20}}
+        // {{#rustdoc_include file.rs:10-20}}
+        let rustdoc_include_re = Regex::new(r"\{\{#rustdoc_include\s*([^}]*)\}\}").unwrap();
+
+        for (line_num, line) in document.lines.iter().enumerate() {
+            for capture in rustdoc_include_re.captures_iter(line) {
+                if let Some(args) = capture.get(1) {
+                    let args_str = args.as_str().trim();
+
+                    // Check for empty directive
+                    if args_str.is_empty() {
+                        violations.push(self.create_violation(
+                            "Empty file path in {{#rustdoc_include}} directive".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                        continue;
+                    }
+
+                    // Parse the arguments
+                    let parts: Vec<&str> = args_str.split(':').collect();
+                    if parts.is_empty() {
+                        violations.push(self.create_violation(
+                            "Missing file path in {{#rustdoc_include}} directive".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                        continue;
+                    }
+
+                    let file_path = parts[0].trim();
+
+                    // Check if file path is empty
+                    if file_path.is_empty() {
+                        violations.push(self.create_violation(
+                            "Empty file path in {{#rustdoc_include}} directive".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                        continue;
+                    }
+
+                    // Check if it's a Rust file
+                    if !file_path.ends_with(".rs") {
+                        violations.push(self.create_violation(
+                            format!("{{#rustdoc_include}} should reference a Rust file (.rs), found: {}", file_path),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Warning,
+                        ));
+                    }
+
+                    // Check relative path format
+                    let path = Path::new(file_path);
+                    if path.is_absolute() {
+                        violations.push(self.create_violation(
+                            format!("{{#rustdoc_include}} should use relative paths, found absolute: {}", file_path),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                    }
+
+                    // Validate line range format if present
+                    if parts.len() > 1 {
+                        for part in parts.iter().skip(1) {
+                            let range_part = part.trim();
+
+                            // Check for valid line number or range
+                            if !Self::is_valid_line_spec(range_part) {
+                                violations.push(self.create_violation(
+                                    format!(
+                                        "Invalid line specification in {{#rustdoc_include}}: '{}'",
+                                        range_part
+                                    ),
+                                    line_num + 1,
+                                    args.start() + 1,
+                                    Severity::Error,
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+impl MDBOOK008 {
+    /// Check if a string is a valid line specification
+    fn is_valid_line_spec(spec: &str) -> bool {
+        // Valid formats:
+        // - Single number: "10"
+        // - Range with dash: "10-20"
+        // - Range with colon: "20" (when it's the second part after a start line)
+
+        // Check if it's a single number
+        if spec.parse::<usize>().is_ok() {
+            return true;
+        }
+
+        // Check if it's a range with dash
+        if let Some(dash_pos) = spec.find('-') {
+            let start = &spec[..dash_pos];
+            let end = &spec[dash_pos + 1..];
+
+            return start.parse::<usize>().is_ok() && end.parse::<usize>().is_ok();
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdbook_lint_core::Document;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_valid_rustdoc_include() {
+        let content = r#"# Chapter
+        
+Here's some code:
+
+{{#rustdoc_include ../src/main.rs}}
+
+With line range:
+
+{{#rustdoc_include ../src/lib.rs:10:20}}
+
+Another format:
+
+{{#rustdoc_include ../src/lib.rs:10-20}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK008;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_empty_file_path() {
+        let content = "{{#rustdoc_include }}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK008;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Empty file path"));
+    }
+
+    #[test]
+    fn test_non_rust_file() {
+        let content = "{{#rustdoc_include ../docs/README.md}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK008;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("should reference a Rust file")
+        );
+    }
+
+    #[test]
+    fn test_absolute_path() {
+        let content = "{{#rustdoc_include /usr/src/main.rs}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK008;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("should use relative paths"));
+    }
+
+    #[test]
+    fn test_invalid_line_range() {
+        let content = r#"
+{{#rustdoc_include ../src/main.rs:abc}}
+{{#rustdoc_include ../src/main.rs:10:xyz}}
+{{#rustdoc_include ../src/main.rs:10-}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK008;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 3);
+        assert!(violations[0].message.contains("Invalid line specification"));
+        assert!(violations[1].message.contains("Invalid line specification"));
+        assert!(violations[2].message.contains("Invalid line specification"));
+    }
+
+    #[test]
+    fn test_multiple_rustdoc_includes() {
+        let content = r#"
+# Examples
+
+{{#rustdoc_include ../src/lib.rs:1:10}}
+
+Some text.
+
+{{#rustdoc_include ../src/main.rs}}
+
+More text.
+
+{{#rustdoc_include ../examples/demo.rs:5-15}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK008;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook008.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook008.rs
@@ -98,8 +98,10 @@ impl Rule for MDBOOK008 {
                     }
 
                     // Check relative path format (cross-platform)
-                    if file_path.starts_with('/') || file_path.starts_with('\\') 
-                        || (file_path.len() > 1 && file_path.chars().nth(1) == Some(':')) {
+                    if file_path.starts_with('/')
+                        || file_path.starts_with('\\')
+                        || (file_path.len() > 1 && file_path.chars().nth(1) == Some(':'))
+                    {
                         violations.push(self.create_violation(
                             format!("{{#rustdoc_include}} should use relative paths, found absolute: {}", file_path),
                             line_num + 1,

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook008.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook008.rs
@@ -10,7 +10,6 @@ use mdbook_lint_core::{
     violation::{Severity, Violation},
 };
 use regex::Regex;
-use std::path::Path;
 
 /// Rule to check for invalid {{#rustdoc_include}} directives
 pub struct MDBOOK008;
@@ -98,9 +97,9 @@ impl Rule for MDBOOK008 {
                         ));
                     }
 
-                    // Check relative path format
-                    let path = Path::new(file_path);
-                    if path.is_absolute() {
+                    // Check relative path format (cross-platform)
+                    if file_path.starts_with('/') || file_path.starts_with('\\') 
+                        || (file_path.len() > 1 && file_path.chars().nth(1) == Some(':')) {
                         violations.push(self.create_violation(
                             format!("{{#rustdoc_include}} should use relative paths, found absolute: {}", file_path),
                             line_num + 1,

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook009.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook009.rs
@@ -10,7 +10,6 @@ use mdbook_lint_core::{
     violation::{Severity, Violation},
 };
 use regex::Regex;
-use std::path::Path;
 
 /// Rule to check for invalid {{#playground}} directives
 pub struct MDBOOK009;
@@ -78,9 +77,9 @@ impl Rule for MDBOOK009 {
                         ));
                     }
 
-                    // Check relative path format
-                    let path = Path::new(base_path);
-                    if path.is_absolute() {
+                    // Check relative path format (cross-platform)
+                    if base_path.starts_with('/') || base_path.starts_with('\\') 
+                        || (base_path.len() > 1 && base_path.chars().nth(1) == Some(':')) {
                         violations.push(self.create_violation(
                             format!(
                                 "{{#playground}} should use relative paths, found absolute: {}",

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook009.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook009.rs
@@ -78,8 +78,10 @@ impl Rule for MDBOOK009 {
                     }
 
                     // Check relative path format (cross-platform)
-                    if base_path.starts_with('/') || base_path.starts_with('\\') 
-                        || (base_path.len() > 1 && base_path.chars().nth(1) == Some(':')) {
+                    if base_path.starts_with('/')
+                        || base_path.starts_with('\\')
+                        || (base_path.len() > 1 && base_path.chars().nth(1) == Some(':'))
+                    {
                         violations.push(self.create_violation(
                             format!(
                                 "{{#playground}} should use relative paths, found absolute: {}",

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook009.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook009.rs
@@ -1,0 +1,239 @@
+//! MDBOOK009: Invalid {{#playground}} configuration
+//!
+//! This rule checks for invalid playground directives in mdBook files.
+//! The playground directive allows embedding Rust playground links.
+
+use mdbook_lint_core::error::Result;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::{
+    Document,
+    violation::{Severity, Violation},
+};
+use regex::Regex;
+use std::path::Path;
+
+/// Rule to check for invalid {{#playground}} directives
+pub struct MDBOOK009;
+
+impl Rule for MDBOOK009 {
+    fn id(&self) -> &'static str {
+        "MDBOOK009"
+    }
+
+    fn name(&self) -> &'static str {
+        "playground-validation"
+    }
+
+    fn description(&self) -> &'static str {
+        "Invalid {{#playground}} configuration"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::experimental(RuleCategory::MdBook).introduced_in("mdbook-lint v0.11.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        // Regex to match {{#playground path}} directives
+        let playground_re = Regex::new(r"\{\{#playground\s*([^}]*)\}\}").unwrap();
+
+        for (line_num, line) in document.lines.iter().enumerate() {
+            for capture in playground_re.captures_iter(line) {
+                if let Some(args) = capture.get(1) {
+                    let file_path = args.as_str().trim();
+
+                    // Check if file path is empty
+                    if file_path.is_empty() {
+                        violations.push(self.create_violation(
+                            "Empty file path in {{#playground}} directive".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                        continue;
+                    }
+
+                    // Extract just the file path part (before any colon for line ranges)
+                    let base_path = if file_path.contains(':') && !file_path.contains("://") {
+                        file_path.split(':').next().unwrap_or(file_path)
+                    } else {
+                        file_path
+                    };
+
+                    // Check if it's a Rust file
+                    if !base_path.ends_with(".rs") {
+                        violations.push(self.create_violation(
+                            format!(
+                                "{{#playground}} should reference a Rust file (.rs), found: {}",
+                                base_path
+                            ),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                    }
+
+                    // Check relative path format
+                    let path = Path::new(base_path);
+                    if path.is_absolute() {
+                        violations.push(self.create_violation(
+                            format!(
+                                "{{#playground}} should use relative paths, found absolute: {}",
+                                base_path
+                            ),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                    }
+
+                    // Check for common mistakes
+                    if file_path.contains("{{") || file_path.contains("}}") {
+                        violations.push(self.create_violation(
+                            "Nested mdBook directives not allowed in {{#playground}}".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                    }
+
+                    // Warn about line numbers (not supported)
+                    if file_path.contains(':') && !file_path.contains("://") {
+                        violations.push(self.create_violation(
+                            "{{#playground}} does not support line ranges, use {{#include}} instead for partial content".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Warning,
+                        ));
+                    }
+                }
+            }
+
+            // Also check for common misspellings
+            if (line.contains("{{#play ") || line.contains("{{#play}}"))
+                || line.contains("{{#plaground")
+                || line.contains("{{#payground")
+            {
+                violations.push(self.create_violation(
+                    "Possible misspelling of {{#playground}} directive".to_string(),
+                    line_num + 1,
+                    1,
+                    Severity::Warning,
+                ));
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdbook_lint_core::Document;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_valid_playground() {
+        let content = r#"# Playground Examples
+
+Here's a playground example:
+
+{{#playground ../examples/hello.rs}}
+
+Another one:
+
+{{#playground examples/demo.rs}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK009;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_empty_file_path() {
+        let content = "{{#playground }}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK009;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Empty file path"));
+    }
+
+    #[test]
+    fn test_non_rust_file() {
+        let content = "{{#playground ../docs/README.md}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK009;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("should reference a Rust file")
+        );
+    }
+
+    #[test]
+    fn test_absolute_path() {
+        let content = "{{#playground /usr/src/main.rs}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK009;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("should use relative paths"));
+    }
+
+    #[test]
+    fn test_line_ranges_not_supported() {
+        let content = "{{#playground ../src/main.rs:10:20}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK009;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("does not support line ranges")
+        );
+    }
+
+    #[test]
+    fn test_nested_directives() {
+        let content = "{{#playground {{#include ../src/main.rs}}}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK009;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Nested mdBook directives"));
+    }
+
+    #[test]
+    fn test_misspellings() {
+        let content = r#"
+{{#play ../src/main.rs}}
+{{#plaground ../src/main.rs}}
+{{#payground ../src/main.rs}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK009;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 3);
+        for violation in &violations {
+            assert!(violation.message.contains("misspelling"));
+        }
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook010.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook010.rs
@@ -1,0 +1,285 @@
+//! MDBOOK010: Missing or invalid preprocessor configuration
+//!
+//! This rule checks for invalid preprocessor directives in mdBook files.
+//! Preprocessors like mermaid, katex, and others require specific syntax.
+
+use mdbook_lint_core::error::Result;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::{
+    Document,
+    violation::{Severity, Violation},
+};
+use regex::Regex;
+
+/// Rule to check for invalid preprocessor configuration
+pub struct MDBOOK010;
+
+impl Rule for MDBOOK010 {
+    fn id(&self) -> &'static str {
+        "MDBOOK010"
+    }
+
+    fn name(&self) -> &'static str {
+        "preprocessor-validation"
+    }
+
+    fn description(&self) -> &'static str {
+        "Missing or invalid preprocessor configuration"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::experimental(RuleCategory::MdBook).introduced_in("mdbook-lint v0.11.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        // Check for common preprocessor patterns
+        self.check_mermaid_blocks(document, &mut violations);
+        self.check_katex_blocks(document, &mut violations);
+        self.check_admonish_blocks(document, &mut violations);
+
+        Ok(violations)
+    }
+}
+
+impl MDBOOK010 {
+    /// Check for invalid mermaid blocks
+    fn check_mermaid_blocks(&self, document: &Document, violations: &mut Vec<Violation>) {
+        let _mermaid_re = Regex::new(r"```mermaid\s*\n([\s\S]*?)```").unwrap();
+
+        for (line_num, line) in document.lines.iter().enumerate() {
+            if line.trim() == "```mermaid" {
+                // Check if the block is empty
+                if line_num + 1 < document.lines.len() {
+                    let next_line = &document.lines[line_num + 1];
+                    if next_line.trim() == "```" {
+                        violations.push(self.create_violation(
+                            "Empty mermaid block detected".to_string(),
+                            line_num + 1,
+                            1,
+                            Severity::Warning,
+                        ));
+                    }
+                }
+            }
+
+            // Check for common mermaid syntax errors
+            if line.contains("```mermaid") && !line.trim().eq("```mermaid") {
+                violations.push(self.create_violation(
+                    "Mermaid blocks should start with '```mermaid' on its own line".to_string(),
+                    line_num + 1,
+                    1,
+                    Severity::Error,
+                ));
+            }
+        }
+    }
+
+    /// Check for invalid KaTeX blocks
+    fn check_katex_blocks(&self, document: &Document, violations: &mut Vec<Violation>) {
+        // Check for inline math
+        let _inline_math_re = Regex::new(r"\$([^$\n]+)\$").unwrap();
+        // Check for display math
+        let _display_math_re = Regex::new(r"\$\$([^$]+)\$\$").unwrap();
+
+        for (line_num, line) in document.lines.iter().enumerate() {
+            // Check for unclosed inline math
+            let dollar_count = line.chars().filter(|&c| c == '$').count();
+            if dollar_count % 2 != 0 && !line.contains("$$") {
+                violations.push(self.create_violation(
+                    "Unclosed inline math block (odd number of $ signs)".to_string(),
+                    line_num + 1,
+                    1,
+                    Severity::Error,
+                ));
+            }
+
+            // Check for empty math blocks
+            if line.contains("$$$$") {
+                violations.push(self.create_violation(
+                    "Empty display math block detected".to_string(),
+                    line_num + 1,
+                    line.find("$$$$").unwrap() + 1,
+                    Severity::Warning,
+                ));
+            }
+
+            if line.contains("$ $") {
+                violations.push(self.create_violation(
+                    "Empty inline math block detected".to_string(),
+                    line_num + 1,
+                    line.find("$ $").unwrap() + 1,
+                    Severity::Warning,
+                ));
+            }
+        }
+    }
+
+    /// Check for invalid admonish blocks
+    fn check_admonish_blocks(&self, document: &Document, violations: &mut Vec<Violation>) {
+        let admonish_re = Regex::new(r"```admonish\s+(\w+)(.*)").unwrap();
+        let valid_types = [
+            "note",
+            "tip",
+            "info",
+            "warning",
+            "danger",
+            "important",
+            "caution",
+            "bug",
+            "example",
+            "quote",
+        ];
+
+        for (line_num, line) in document.lines.iter().enumerate() {
+            if line.starts_with("```admonish") {
+                if let Some(captures) = admonish_re.captures(line) {
+                    if let Some(admonish_type) = captures.get(1) {
+                        let type_str = admonish_type.as_str();
+                        if !valid_types.contains(&type_str) {
+                            violations.push(self.create_violation(
+                                format!(
+                                    "Invalid admonish type '{}'. Valid types are: {}",
+                                    type_str,
+                                    valid_types.join(", ")
+                                ),
+                                line_num + 1,
+                                admonish_type.start() + 1,
+                                Severity::Error,
+                            ));
+                        }
+                    }
+                } else if line.trim() == "```admonish" {
+                    violations.push(self.create_violation(
+                        "Admonish block missing type. Use format: ```admonish <type>".to_string(),
+                        line_num + 1,
+                        1,
+                        Severity::Error,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdbook_lint_core::Document;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_valid_preprocessors() {
+        let content = r#"# Chapter
+
+Here's a mermaid diagram:
+
+```mermaid
+graph TD
+    A --> B
+```
+
+Some math: $x = y^2$
+
+Display math:
+$$
+E = mc^2
+$$
+
+```admonish note
+This is a note.
+```
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK010;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_empty_mermaid_block() {
+        let content = r#"```mermaid
+```"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK010;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Empty mermaid block"));
+    }
+
+    #[test]
+    fn test_invalid_mermaid_syntax() {
+        let content = "```mermaid with extra text";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK010;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("should start with '```mermaid' on its own line")
+        );
+    }
+
+    #[test]
+    fn test_unclosed_inline_math() {
+        let content = "This is $unclosed math";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK010;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Unclosed inline math"));
+    }
+
+    #[test]
+    fn test_empty_math_blocks() {
+        let content = r#"Empty inline: $ $
+Empty display: $$$$"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK010;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        assert!(violations[0].message.contains("Empty inline math"));
+        assert!(violations[1].message.contains("Empty display math"));
+    }
+
+    #[test]
+    fn test_invalid_admonish_type() {
+        let content = "```admonish invalid";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK010;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("Invalid admonish type 'invalid'")
+        );
+    }
+
+    #[test]
+    fn test_missing_admonish_type() {
+        let content = "```admonish";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK010;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("Admonish block missing type")
+        );
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook011.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook011.rs
@@ -112,9 +112,10 @@ impl Rule for MDBOOK011 {
 
                     let template_path = &parts[0];
 
-                    // Check if path is absolute
-                    let path = Path::new(template_path.as_str());
-                    if path.is_absolute() {
+                    // Check if path is absolute (cross-platform)
+                    let path_str = template_path.as_str();
+                    if path_str.starts_with('/') || path_str.starts_with('\\') 
+                        || (path_str.len() > 1 && path_str.chars().nth(1) == Some(':')) {
                         violations.push(self.create_violation(
                             format!(
                                 "{{#template}} should use relative paths, found absolute: {}",
@@ -127,6 +128,7 @@ impl Rule for MDBOOK011 {
                     }
 
                     // Check for valid file extension (should be .md or .hbs)
+                    let path = Path::new(template_path.as_str());
                     if let Some(ext) = path.extension() {
                         let ext_str = ext.to_string_lossy();
                         if !matches!(ext_str.as_ref(), "md" | "hbs" | "html") {

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook011.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook011.rs
@@ -1,0 +1,346 @@
+//! MDBOOK011: Invalid {{#template}} syntax
+//!
+//! This rule checks for invalid template directives in mdBook files.
+//! The template directive allows reusing content snippets.
+
+use mdbook_lint_core::error::Result;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::{
+    Document,
+    violation::{Severity, Violation},
+};
+use regex::Regex;
+use std::path::Path;
+
+/// Rule to check for invalid {{#template}} directives
+pub struct MDBOOK011;
+
+impl MDBOOK011 {
+    /// Parse template arguments, handling quoted strings properly
+    fn parse_template_args(args: &str) -> Vec<String> {
+        let mut result = Vec::new();
+        let mut current = String::new();
+        let mut in_quotes = false;
+        let mut quote_char = ' ';
+
+        for ch in args.chars() {
+            match ch {
+                '"' | '\'' if !in_quotes => {
+                    in_quotes = true;
+                    quote_char = ch;
+                    current.push(ch);
+                }
+                c if c == quote_char && in_quotes => {
+                    in_quotes = false;
+                    current.push(c);
+                }
+                ' ' | '\t' if !in_quotes => {
+                    if !current.is_empty() {
+                        result.push(current.clone());
+                        current.clear();
+                    }
+                }
+                c => current.push(c),
+            }
+        }
+
+        if !current.is_empty() {
+            result.push(current);
+        }
+
+        result
+    }
+}
+
+impl Rule for MDBOOK011 {
+    fn id(&self) -> &'static str {
+        "MDBOOK011"
+    }
+
+    fn name(&self) -> &'static str {
+        "template-validation"
+    }
+
+    fn description(&self) -> &'static str {
+        "Invalid {{#template}} syntax"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::experimental(RuleCategory::MdBook).introduced_in("mdbook-lint v0.11.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        // Regex to match {{#template path args...}}
+        let template_re = Regex::new(r"\{\{#template\s*([^}]*)\}\}").unwrap();
+
+        for (line_num, line) in document.lines.iter().enumerate() {
+            for capture in template_re.captures_iter(line) {
+                if let Some(args) = capture.get(1) {
+                    let args_str = args.as_str().trim();
+
+                    // Check if arguments are empty
+                    if args_str.is_empty() {
+                        violations.push(
+                            self.create_violation(
+                                "Empty {{#template}} directive - must specify template file"
+                                    .to_string(),
+                                line_num + 1,
+                                args.start() + 1,
+                                Severity::Error,
+                            ),
+                        );
+                        continue;
+                    }
+
+                    // Parse template arguments (handle quoted strings)
+                    let parts = Self::parse_template_args(args_str);
+                    if parts.is_empty() {
+                        violations.push(self.create_violation(
+                            "Missing template file path in {{#template}} directive".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                        continue;
+                    }
+
+                    let template_path = &parts[0];
+
+                    // Check if path is absolute
+                    let path = Path::new(template_path.as_str());
+                    if path.is_absolute() {
+                        violations.push(self.create_violation(
+                            format!(
+                                "{{#template}} should use relative paths, found absolute: {}",
+                                template_path
+                            ),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                    }
+
+                    // Check for valid file extension (should be .md or .hbs)
+                    if let Some(ext) = path.extension() {
+                        let ext_str = ext.to_string_lossy();
+                        if !matches!(ext_str.as_ref(), "md" | "hbs" | "html") {
+                            violations.push(self.create_violation(
+                                format!("{{#template}} should reference a template file (.md, .hbs, or .html), found: .{}", ext_str),
+                                line_num + 1,
+                                args.start() + 1,
+                                Severity::Warning,
+                            ));
+                        }
+                    } else {
+                        violations.push(self.create_violation(
+                            "{{#template}} file path missing extension".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Warning,
+                        ));
+                    }
+
+                    // Check template arguments format (key=value pairs)
+                    for arg in parts.iter().skip(1) {
+                        if !arg.contains('=') {
+                            violations.push(self.create_violation(
+                                format!("Invalid template argument '{}' - should be in key=value format", arg),
+                                line_num + 1,
+                                args.start() + 1,
+                                Severity::Error,
+                            ));
+                        } else {
+                            let kv: Vec<&str> = arg.splitn(2, '=').collect();
+                            if kv.len() != 2 || kv[0].is_empty() || kv[1].is_empty() {
+                                violations.push(self.create_violation(
+                                    format!("Invalid template argument '{}' - key and value must not be empty", arg),
+                                    line_num + 1,
+                                    args.start() + 1,
+                                    Severity::Error,
+                                ));
+                            }
+                        }
+                    }
+
+                    // Check for nested directives
+                    if args_str.contains("{{#") {
+                        violations.push(
+                            self.create_violation(
+                                "Nested mdBook directives not allowed in {{#template}} path"
+                                    .to_string(),
+                                line_num + 1,
+                                args.start() + 1,
+                                Severity::Error,
+                            ),
+                        );
+                    }
+                }
+            }
+
+            // Check for common misspellings
+            if line.contains("{{#tempalte")
+                || line.contains("{{#tempate")
+                || line.contains("{{#templte")
+            {
+                violations.push(self.create_violation(
+                    "Possible misspelling of {{#template}} directive".to_string(),
+                    line_num + 1,
+                    1,
+                    Severity::Warning,
+                ));
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdbook_lint_core::Document;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_valid_template() {
+        let content = r#"# Chapter
+
+{{#template ../templates/header.md title="My Title" author="John Doe"}}
+
+Some content.
+
+{{#template templates/footer.hbs year=2024}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_empty_template() {
+        let content = "{{#template }}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("Empty {{#template}} directive")
+        );
+    }
+
+    #[test]
+    fn test_absolute_path() {
+        let content = "{{#template /usr/templates/header.md}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("should use relative paths"));
+    }
+
+    #[test]
+    fn test_invalid_extension() {
+        let content = "{{#template templates/header.txt}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("should reference a template file")
+        );
+    }
+
+    #[test]
+    fn test_missing_extension() {
+        let content = "{{#template templates/header}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing extension"));
+    }
+
+    #[test]
+    fn test_invalid_arguments() {
+        let content = r#"{{#template templates/header.md invalid_arg title=Valid}}"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("should be in key=value format")
+        );
+    }
+
+    #[test]
+    fn test_empty_key_value() {
+        let content = "{{#template templates/header.md =value key=}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        assert!(
+            violations[0]
+                .message
+                .contains("key and value must not be empty")
+        );
+        assert!(
+            violations[1]
+                .message
+                .contains("key and value must not be empty")
+        );
+    }
+
+    #[test]
+    fn test_nested_directives() {
+        let content = "{{#template {{#include ../path.md}}}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        // We expect at least one violation for nested directives (may have other parse errors too)
+        assert!(!violations.is_empty());
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.message.contains("Nested mdBook directives"))
+        );
+    }
+
+    #[test]
+    fn test_misspellings() {
+        let content = r#"
+{{#tempalte templates/header.md}}
+{{#tempate templates/header.md}}
+{{#templte templates/header.md}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK011;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 3);
+        for violation in &violations {
+            assert!(violation.message.contains("misspelling"));
+        }
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook011.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook011.rs
@@ -114,8 +114,10 @@ impl Rule for MDBOOK011 {
 
                     // Check if path is absolute (cross-platform)
                     let path_str = template_path.as_str();
-                    if path_str.starts_with('/') || path_str.starts_with('\\') 
-                        || (path_str.len() > 1 && path_str.chars().nth(1) == Some(':')) {
+                    if path_str.starts_with('/')
+                        || path_str.starts_with('\\')
+                        || (path_str.len() > 1 && path_str.chars().nth(1) == Some(':'))
+                    {
                         violations.push(self.create_violation(
                             format!(
                                 "{{#template}} should use relative paths, found absolute: {}",

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook012.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook012.rs
@@ -77,8 +77,10 @@ impl Rule for MDBOOK012 {
                     }
 
                     // Check if path is absolute (cross-platform)
-                    if file_path.starts_with('/') || file_path.starts_with('\\') 
-                        || (file_path.len() > 1 && file_path.chars().nth(1) == Some(':')) {
+                    if file_path.starts_with('/')
+                        || file_path.starts_with('\\')
+                        || (file_path.len() > 1 && file_path.chars().nth(1) == Some(':'))
+                    {
                         violations.push(self.create_violation(
                             format!(
                                 "{{#include}} should use relative paths, found absolute: {}",

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook012.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook012.rs
@@ -1,0 +1,383 @@
+//! MDBOOK012: Broken {{#include}} line ranges
+//!
+//! This rule checks for invalid line ranges in {{#include}} directives.
+//! Line ranges can be specified with colons or dashes.
+
+use mdbook_lint_core::error::Result;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::{
+    Document,
+    violation::{Severity, Violation},
+};
+use regex::Regex;
+use std::path::Path;
+
+/// Rule to check for broken {{#include}} line ranges
+pub struct MDBOOK012;
+
+impl Rule for MDBOOK012 {
+    fn id(&self) -> &'static str {
+        "MDBOOK012"
+    }
+
+    fn name(&self) -> &'static str {
+        "include-line-range-validation"
+    }
+
+    fn description(&self) -> &'static str {
+        "Broken {{#include}} line ranges"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::experimental(RuleCategory::MdBook).introduced_in("mdbook-lint v0.11.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        // Regex to match {{#include path:line_range}}
+        let include_re = Regex::new(r"\{\{#include\s*([^}]*)\}\}").unwrap();
+
+        for (line_num, line) in document.lines.iter().enumerate() {
+            for capture in include_re.captures_iter(line) {
+                if let Some(args) = capture.get(1) {
+                    let args_str = args.as_str().trim();
+
+                    // Check if arguments are empty
+                    if args_str.is_empty() {
+                        violations.push(self.create_violation(
+                            "Empty file path in {{#include}} directive".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                        continue;
+                    }
+
+                    // Parse the arguments (file path and optional line ranges)
+                    let parts: Vec<&str> = args_str.split(':').collect();
+                    if parts.is_empty() {
+                        continue;
+                    }
+
+                    let file_path = parts[0].trim();
+
+                    // Check if file path is empty
+                    if file_path.is_empty() {
+                        violations.push(self.create_violation(
+                            "Empty file path in {{#include}} directive".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                        continue;
+                    }
+
+                    // Check if path is absolute
+                    let path = Path::new(file_path);
+                    if path.is_absolute() {
+                        violations.push(self.create_violation(
+                            format!(
+                                "{{#include}} should use relative paths, found absolute: {}",
+                                file_path
+                            ),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                    }
+
+                    // Validate line ranges if present
+                    if parts.len() > 1 {
+                        // Check if this is an anchor format
+                        if parts.len() >= 2
+                            && (parts[1].trim() == "ANCHOR" || parts[1].trim() == "ANCHOR_END")
+                        {
+                            // This is an anchor format like file.rs:ANCHOR:name or file.rs:ANCHOR_END:name
+                            if parts.len() < 3 || parts[2].trim().is_empty() {
+                                violations.push(self.create_violation(
+                                    "Anchor name missing after ANCHOR: or ANCHOR_END:".to_string(),
+                                    line_num + 1,
+                                    args.start() + 1,
+                                    Severity::Error,
+                                ));
+                            }
+                        } else {
+                            // Regular line range format
+                            for part in parts.iter().skip(1) {
+                                let range_part = part.trim();
+
+                                if !Self::is_valid_line_range(range_part) {
+                                    violations.push(self.create_violation(
+                                        format!("Invalid line range in {{#include}}: '{}'. Use formats like :10, :10:20, :10-20", range_part),
+                                        line_num + 1,
+                                        args.start() + 1,
+                                        Severity::Error,
+                                    ));
+                                }
+                            }
+                        }
+
+                        // Check for logical errors in ranges
+                        if parts.len() == 3 {
+                            if let (Ok(start), Ok(end)) = (
+                                parts[1].trim().parse::<usize>(),
+                                parts[2].trim().parse::<usize>(),
+                            ) {
+                                if start > end {
+                                    violations.push(self.create_violation(
+                                        format!("Invalid line range: start line {} is greater than end line {}", start, end),
+                                        line_num + 1,
+                                        args.start() + 1,
+                                        Severity::Error,
+                                    ));
+                                }
+                                if start == 0 {
+                                    violations.push(self.create_violation(
+                                        "Line numbers start at 1, not 0".to_string(),
+                                        line_num + 1,
+                                        args.start() + 1,
+                                        Severity::Error,
+                                    ));
+                                }
+                            }
+                        } else if parts.len() == 2 {
+                            // Check for dash-separated ranges
+                            if parts[1].contains('-') {
+                                let dash_parts: Vec<&str> = parts[1].split('-').collect();
+                                if dash_parts.len() == 2
+                                    && let (Ok(start), Ok(end)) = (
+                                        dash_parts[0].trim().parse::<usize>(),
+                                        dash_parts[1].trim().parse::<usize>(),
+                                    )
+                                {
+                                    if start > end {
+                                        violations.push(self.create_violation(
+                                            format!("Invalid line range: start line {} is greater than end line {}", start, end),
+                                            line_num + 1,
+                                            args.start() + 1,
+                                            Severity::Error,
+                                        ));
+                                    }
+                                    if start == 0 {
+                                        violations.push(self.create_violation(
+                                            "Line numbers start at 1, not 0".to_string(),
+                                            line_num + 1,
+                                            args.start() + 1,
+                                            Severity::Error,
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Check for nested directives
+                    if args_str.contains("{{#") {
+                        violations.push(self.create_violation(
+                            "Nested mdBook directives not allowed in {{#include}}".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Error,
+                        ));
+                    }
+                    // Check for anchor syntax (but not if it's a nested directive)
+                    else if args_str.contains('#') && !args_str.contains("ANCHOR") {
+                        violations.push(self.create_violation(
+                            "Invalid anchor syntax. Use ANCHOR:name or ANCHOR_END:name".to_string(),
+                            line_num + 1,
+                            args.start() + 1,
+                            Severity::Warning,
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+impl MDBOOK012 {
+    /// Check if a string is a valid line range specification
+    fn is_valid_line_range(spec: &str) -> bool {
+        // Valid formats:
+        // - Single number: "10"
+        // - Range with dash: "10-20"
+        // - Empty (for end of range in colon format)
+        // - ANCHOR:name or ANCHOR_END:name
+
+        if spec.is_empty() {
+            return true; // Empty is valid for end range
+        }
+
+        if spec.starts_with("ANCHOR:") || spec.starts_with("ANCHOR_END:") {
+            return true;
+        }
+
+        // Check if it's a single number
+        if spec.parse::<usize>().is_ok() {
+            return true;
+        }
+
+        // Check if it's a range with dash
+        if spec.contains('-') {
+            let parts: Vec<&str> = spec.split('-').collect();
+            if parts.len() == 2 {
+                let start_valid = parts[0].is_empty() || parts[0].parse::<usize>().is_ok();
+                let end_valid = parts[1].is_empty() || parts[1].parse::<usize>().is_ok();
+                return start_valid && end_valid;
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdbook_lint_core::Document;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_valid_include() {
+        let content = r#"# Chapter
+
+{{#include ../src/main.rs}}
+
+With line range:
+
+{{#include ../src/lib.rs:10:20}}
+
+Another format:
+
+{{#include ../src/lib.rs:10-20}}
+
+With anchors:
+
+{{#include ../src/lib.rs:ANCHOR:example}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_empty_file_path() {
+        let content = "{{#include }}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Empty file path"));
+    }
+
+    #[test]
+    fn test_absolute_path() {
+        let content = "{{#include /usr/src/main.rs}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("should use relative paths"));
+    }
+
+    #[test]
+    fn test_invalid_line_range() {
+        let content = r#"
+{{#include ../src/main.rs:abc}}
+{{#include ../src/main.rs:10:xyz}}
+{{#include ../src/main.rs:10-}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 2); // "10-" is valid (open-ended range)
+        assert!(violations[0].message.contains("Invalid line range"));
+        assert!(violations[1].message.contains("Invalid line range"));
+    }
+
+    #[test]
+    fn test_inverted_range() {
+        let content = r#"
+{{#include ../src/main.rs:20:10}}
+{{#include ../src/main.rs:20-10}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        assert!(
+            violations[0]
+                .message
+                .contains("start line 20 is greater than end line 10")
+        );
+        assert!(
+            violations[1]
+                .message
+                .contains("start line 20 is greater than end line 10")
+        );
+    }
+
+    #[test]
+    fn test_zero_line_number() {
+        let content = r#"
+{{#include ../src/main.rs:0:10}}
+{{#include ../src/main.rs:0-10}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        assert!(violations[0].message.contains("Line numbers start at 1"));
+        assert!(violations[1].message.contains("Line numbers start at 1"));
+    }
+
+    #[test]
+    fn test_nested_directives() {
+        let content = "{{#include {{#rustdoc_include ../src/main.rs}}}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Nested mdBook directives"));
+    }
+
+    #[test]
+    fn test_invalid_anchor_syntax() {
+        let content = "{{#include ../src/main.rs#invalid}}";
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Invalid anchor syntax"));
+    }
+
+    #[test]
+    fn test_valid_open_ended_ranges() {
+        let content = r#"
+{{#include ../src/main.rs:10:}}
+{{#include ../src/main.rs:10-}}
+{{#include ../src/main.rs:-20}}
+"#;
+        let doc = Document::new(content.to_string(), PathBuf::from("chapter.md")).unwrap();
+        let rule = MDBOOK012;
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook012.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook012.rs
@@ -10,7 +10,6 @@ use mdbook_lint_core::{
     violation::{Severity, Violation},
 };
 use regex::Regex;
-use std::path::Path;
 
 /// Rule to check for broken {{#include}} line ranges
 pub struct MDBOOK012;
@@ -77,9 +76,9 @@ impl Rule for MDBOOK012 {
                         continue;
                     }
 
-                    // Check if path is absolute
-                    let path = Path::new(file_path);
-                    if path.is_absolute() {
+                    // Check if path is absolute (cross-platform)
+                    if file_path.starts_with('/') || file_path.starts_with('\\') 
+                        || (file_path.len() > 1 && file_path.chars().nth(1) == Some(':')) {
                         violations.push(self.create_violation(
                             format!(
                                 "{{#include}} should use relative paths, found absolute: {}",

--- a/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
@@ -10,6 +10,11 @@ mod mdbook004;
 mod mdbook005;
 mod mdbook006;
 mod mdbook007;
+mod mdbook008;
+mod mdbook009;
+mod mdbook010;
+mod mdbook011;
+mod mdbook012;
 mod mdbook025;
 
 use crate::{RuleProvider, RuleRegistry};
@@ -38,6 +43,11 @@ impl RuleProvider for MdBookRuleProvider {
         registry.register(Box::new(mdbook005::MDBOOK005::default()));
         registry.register(Box::new(mdbook006::MDBOOK006::default()));
         registry.register(Box::new(mdbook007::MDBOOK007::default()));
+        registry.register(Box::new(mdbook008::MDBOOK008));
+        registry.register(Box::new(mdbook009::MDBOOK009));
+        registry.register(Box::new(mdbook010::MDBOOK010));
+        registry.register(Box::new(mdbook011::MDBOOK011));
+        registry.register(Box::new(mdbook012::MDBOOK012));
         registry.register(Box::new(mdbook025::MDBOOK025));
     }
 
@@ -50,6 +60,11 @@ impl RuleProvider for MdBookRuleProvider {
             "MDBOOK005",
             "MDBOOK006",
             "MDBOOK007",
+            "MDBOOK008",
+            "MDBOOK009",
+            "MDBOOK010",
+            "MDBOOK011",
+            "MDBOOK012",
             "MDBOOK025",
         ]
     }


### PR DESCRIPTION
## Summary

This PR implements 5 new high-priority mdBook-specific rules from issue #108:

- **MDBOOK008**: Invalid `{{#rustdoc_include}}` paths or syntax
- **MDBOOK009**: Invalid `{{#playground}}` configuration  
- **MDBOOK010**: Missing or invalid preprocessor configuration
- **MDBOOK011**: Invalid `{{#template}}` syntax
- **MDBOOK012**: Broken `{{#include}}` line ranges

## Implementation Details

### MDBOOK008 - rustdoc_include validation
- Validates that paths reference `.rs` files
- Checks line range formats (`:10`, `:10:20`, `:10-20`)
- Ensures relative paths are used

### MDBOOK009 - playground validation
- Validates Rust file paths
- Warns about unsupported line ranges (playground doesn't support them)
- Detects common misspellings (`{{#play`, `{{#plaground`, etc.)

### MDBOOK010 - preprocessor validation
- Validates mermaid blocks (checks for empty blocks, incorrect syntax)
- Validates KaTeX math syntax (unclosed `$`, empty blocks)
- Validates admonish block types against known valid types

### MDBOOK011 - template validation
- Validates template file extensions (`.md`, `.hbs`, `.html`)
- Checks template arguments are in `key=value` format
- Properly handles quoted strings in arguments

### MDBOOK012 - include line range validation
- Validates various line range formats
- Supports anchor syntax (`ANCHOR:name`, `ANCHOR_END:name`)
- Detects logical errors (inverted ranges, zero line numbers)
- Supports open-ended ranges (`:10-`, `:-20`)

## Testing

- ✅ All unit tests pass (755 rule tests total)
- ✅ All integration tests pass
- ✅ `cargo clippy` passes with no warnings
- ✅ Code formatted with `cargo fmt`

## Checklist

- [x] Tests added for all new rules
- [x] Rules registered in MdBookRuleProvider
- [x] Follows existing code patterns and conventions
- [x] Clippy and fmt checks pass

Closes #108