### PR TITLE
docs: update documentation for auto-fix functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ mdbook-lint --version
 # Lint files
 mdbook-lint lint README.md src/*.md
 
+# Auto-fix violations where possible
+mdbook-lint lint --fix src/*.md
+
 # Show available rules
 mdbook-lint rules
 ```
@@ -69,7 +72,7 @@ disabled-rules = ["MD013"]  # Disable line length rule
 ## Rules
 
 - **59 standard rules** (MD001-MD059) - All the usual markdown linting
-- **4 mdBook rules** (MDBOOK001-004) - mdBook-specific checks
+- **7 mdBook rules** (MDBOOK001-007) - mdBook-specific checks
 
 Run `mdbook-lint rules --detailed` to see all available rules.
 

--- a/docs/src/cli-usage.md
+++ b/docs/src/cli-usage.md
@@ -39,6 +39,10 @@ mdbook-lint help [COMMAND]
 - `--config <FILE>`: Use specific configuration file
 - `--fail-on-warnings`: Exit with error code on warnings
 - `--disable <RULES>`: Disable specific rules (comma-separated)
+- `--fix`: Automatically fix violations where possible
+- `--fix-unsafe`: Apply all fixes, including potentially unsafe ones
+- `--dry-run`: Show what would be fixed without applying changes (requires --fix or --fix-unsafe)
+- `--no-backup`: Skip creating backup files when applying fixes
 
 ### Rules Options
 
@@ -57,6 +61,18 @@ mdbook-lint lint README.md src/chapter1.md
 
 # Lint with custom config
 mdbook-lint lint --config custom-lint.toml src/
+
+# Auto-fix violations where possible
+mdbook-lint lint --fix docs/
+
+# Preview fixes without applying them
+mdbook-lint lint --fix --dry-run docs/
+
+# Apply all fixes including potentially unsafe ones
+mdbook-lint lint --fix-unsafe docs/
+
+# Fix without creating backup files
+mdbook-lint lint --fix --no-backup docs/
 
 # Show all rules with descriptions
 mdbook-lint rules --detailed

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -15,6 +15,9 @@ mdbook-lint lint src/*.md docs/*.md
 
 # Lint all markdown files in a directory
 mdbook-lint lint .
+
+# Auto-fix violations where possible
+mdbook-lint lint --fix src/*.md
 ```
 
 ## Understanding the Output
@@ -63,15 +66,35 @@ To integrate mdbook-lint with your mdBook project:
 
 mdbook-lint will now check your markdown files every time you build your book.
 
+## Automatic Fixing
+
+mdbook-lint can automatically fix some common violations:
+
+```bash
+# Fix violations automatically
+mdbook-lint lint --fix docs/
+
+# Preview what would be fixed without applying changes
+mdbook-lint lint --fix --dry-run docs/
+
+# Apply all fixes, including potentially risky ones
+mdbook-lint lint --fix-unsafe docs/
+```
+
+Currently supported fixes:
+- **MD009**: Removes trailing whitespace
+- More fixes coming in future releases!
+
 ## Common Workflow
 
 Here's a typical workflow for using mdbook-lint:
 
 1. **Initial setup**: Add configuration file and run first lint
-2. **Fix major issues**: Address structural problems first
-3. **Customize rules**: Disable rules that don't fit your style
-4. **Integrate with build**: Add to mdBook or CI pipeline
-5. **Maintain quality**: Regular linting keeps documentation clean
+2. **Auto-fix simple issues**: Use `--fix` to handle common problems
+3. **Fix remaining issues**: Address structural problems manually
+4. **Customize rules**: Disable rules that don't fit your style
+5. **Integrate with build**: Add to mdBook or CI pipeline
+6. **Maintain quality**: Regular linting keeps documentation clean
 
 ## Exploring Rules
 

--- a/docs/src/rules/mdbook/mdbook001.md
+++ b/docs/src/rules/mdbook/mdbook001.md
@@ -1,6 +1,80 @@
 # MDBOOK001 - Code Blocks Should Have Language Tags
 
-{{#rustdoc_include ../../../../crates/mdbook-lint-rulesets/src/mdbook/mdbook001.rs:8:83}}
+Code blocks should have language tags.
+
+This rule is triggered when code blocks don't have language tags for syntax highlighting.
+Proper language tags help with documentation clarity and proper rendering in mdBook.
+
+## Why This Rule Exists
+
+mdBook uses language tags for:
+- Syntax highlighting in rendered output
+- Proper code formatting and display
+- Enabling language-specific features (like line numbers, highlighting specific lines)
+- Improving accessibility for screen readers
+- Better SEO and content understanding
+
+## Examples
+
+### ❌ Incorrect (violates rule)
+
+````markdown
+```
+fn main() {
+    println!("Hello, world!");
+}
+```
+````
+
+### ✅ Correct
+
+````markdown
+```rust
+fn main() {
+    println!("Hello, world!");
+}
+```
+````
+
+Other valid examples:
+
+````markdown
+```bash
+cargo build --release
+```
+
+```toml
+[dependencies]
+serde = "1.0"
+```
+
+```json
+{
+  "name": "example",
+  "version": "1.0.0"
+}
+```
+````
+
+## Special Language Tags
+
+mdBook supports special language tags:
+- `text` or `plain` - for plain text without highlighting
+- `console` - for command-line output
+- `diff` - for showing differences
+- `ignore` - for Rust code that shouldn't be tested
+- `no_run` - for Rust code that compiles but shouldn't run
+- `should_panic` - for Rust code expected to panic
+
+## Configuration
+
+This rule has no configuration options. All code blocks should have language tags.
+
+## When to Disable
+
+Consider disabling this rule if:
+- You have many legacy code blocks without language tags
+- You're using a custom mdBook renderer that doesn't require language tags
 
 ## Rule Details
 

--- a/docs/src/rules/standard/md001.md
+++ b/docs/src/rules/standard/md001.md
@@ -1,6 +1,54 @@
 # MD001 - Heading Increment
 
-{{#rustdoc_include ../../../../crates/mdbook-lint-rulesets/src/standard/md001.rs:9:57}}
+Heading levels should only increment by one level at a time.
+
+This rule is triggered when you skip heading levels in a markdown document.
+For example, a heading level 1 should be followed by level 2, not level 3.
+
+## Why This Rule Exists
+
+Proper heading hierarchy improves document structure, accessibility, and navigation.
+Screen readers and document outlines rely on sequential heading levels to convey
+the document's organization to users.
+
+## Examples
+
+### ❌ Incorrect (violates rule)
+
+```markdown
+# Title
+
+### Subsection (skips h2)
+
+## Back to h2
+
+##### Deep section (skips h3 and h4)
+```
+
+### ✅ Correct
+
+```markdown
+# Title
+
+## Section
+
+### Subsection
+
+#### Subsubsection
+
+##### Deep section
+```
+
+## Configuration
+
+This rule has no configuration options. It always enforces strict sequential heading levels.
+
+## When to Disable
+
+Consider disabling this rule if:
+- You're working with generated content that doesn't follow strict hierarchy
+- You're importing documentation from external sources with different conventions
+- Your project has specific heading level requirements
 
 ## Rule Details
 

--- a/docs/src/rules/standard/md009.md
+++ b/docs/src/rules/standard/md009.md
@@ -1,6 +1,55 @@
 # MD009 - No Trailing Spaces
 
-{{#rustdoc_include ../../../../crates/mdbook-lint-rulesets/src/standard/md009.rs:1:52}}
+This rule checks for trailing spaces at the end of lines.
+
+## Why This Rule Exists
+
+Trailing spaces are usually unintentional and can cause issues:
+- They're invisible in most editors, making them hard to spot
+- They can cause unexpected behavior in version control systems
+- They may render differently across different markdown processors
+- They increase file size unnecessarily
+
+## Examples
+
+### ❌ Incorrect (violates rule)
+
+```text
+This line has trailing spaces   ← spaces
+This one has a tab at the end	← tab
+Multiple spaces here    ← spaces
+```
+
+(Where arrows indicate invisible whitespace characters)
+
+### ✅ Correct
+
+```markdown
+This line has no trailing spaces
+This one is clean too
+Two spaces for line break are allowed  
+when configured (br_spaces = 2)
+```
+
+## Configuration
+
+```toml
+[rules.MD009]
+br_spaces = 2  # Number of trailing spaces allowed for line breaks (default: 2)
+strict = false # If true, disallow even configured line break spaces (default: false)
+```
+
+## Automatic Fix
+
+This rule supports automatic fixing. The fix will:
+- Remove all trailing whitespace from lines
+- Preserve configured line break spaces (typically 2 spaces)
+- Maintain the line's content and structure
+
+## When to Disable
+
+Consider disabling this rule if:
+- Your project intentionally uses trailing spaces for formatting
 
 ## Rule Details
 


### PR DESCRIPTION
## Summary

- Updates CLI documentation with new auto-fix flags (`--fix`, `--fix-unsafe`, `--dry-run`, `--no-backup`)
- Adds auto-fix examples to README and getting-started guide  
- Fixes broken rustdoc_include directives in rule documentation pages
- Corrects mdBook rule count from 4 to 7 rules in README

## Key Changes

### Documentation Updates
- **CLI Usage**: Added comprehensive documentation for all new auto-fix flags with examples
- **README**: Added auto-fix example and corrected mdBook rule count 
- **Getting Started**: Added new "Automatic Fixing" section with examples and updated workflow

### Rule Documentation Fixes
- **Fixed broken rustdoc_include directives** in MD001, MD009, and MDBOOK001 rule pages
- Replaced problematic `{{#rustdoc_include ...}}` with actual formatted content
- Rule pages now render correctly on the documentation website

### Content Improvements  
- Updated common workflow to include auto-fix as step 2
- Listed currently supported fixes (MD009 trailing spaces)
- Fixed the original issue where rule documentation pages "didn't look right"

## Test Plan

- [x] Documentation builds successfully with `mdbook build`
- [x] All rule pages render correctly without rustdoc_include issues
- [x] Code formatting and linting pass
- [x] All tests pass (library + integration)

This addresses the documentation issues mentioned after merging the auto-fix functionality and ensures all rule documentation displays properly.