### PR TITLE
fix: handle UTF-8 character boundaries correctly in MD030 rule

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md030.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md030.rs
@@ -248,16 +248,16 @@ impl MD030 {
         // Check for italic syntax that's not a list: *text* (but allow "* text" as list)
         if marker == '*' {
             // If there's immediately non-whitespace after the *, it's likely emphasis
-            if let Some(second_char) = trimmed.chars().nth(1)
-                && !second_char.is_whitespace()
-                && second_char != '*'
-                && let Some(closing_pos) = trimmed[2..].find('*')
-            {
-                // Make sure it's not just another list item with * in the text
-                let text_between = &trimmed[1..closing_pos + 2];
-                if !text_between.contains('\n') && closing_pos < 50 {
-                    // Likely emphasis if reasonably short and no newlines
-                    return true;
+            let chars: Vec<char> = trimmed.chars().collect();
+            if chars.len() > 1 && !chars[1].is_whitespace() && chars[1] != '*' {
+                // Look for closing * after position 2
+                let remaining: String = chars.iter().skip(2).collect();
+                if let Some(closing_pos) = remaining.find('*') {
+                    // Make sure it's not just another list item with * in the text
+                    if closing_pos < 50 && !remaining[..closing_pos].contains('\n') {
+                        // Likely emphasis if reasonably short and no newlines
+                        return true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes a panic in the MD030 rule when processing text with multi-byte UTF-8 characters like emojis.

## Problem

The MD030 rule was using byte-based string slicing without checking for UTF-8 character boundaries. When processing text like `*⚡ indicates automatic fix support*`, it would try to slice at byte position 2, which is in the middle of the emoji character (emojis take 3-4 bytes).

This caused CI failures with:
```
thread 'test_project_files_corpus' panicked at crates/mdbook-lint-rulesets/src/standard/md030.rs:254:51:
byte index 2 is not a char boundary; it is inside '⚡' (bytes 1..4) of `*⚡ indicates automatic fix support*`
```

## Solution

Changed the implementation to use character-based indexing instead of byte-based slicing:
- Collect characters into a vector for safe indexing
- Use character iterators and collection for substring operations
- Properly handle multi-byte UTF-8 characters

## Test Plan

- [x] The failing test `test_project_files_corpus` now passes
- [x] All integration tests pass
- [x] No regressions in existing MD030 functionality

This fix unblocks PR #117 (documentation improvements) which uses emojis in the documentation.