### PR TITLE
fix: add example-mdbook-lint.toml to gitignore exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ debug_input_*.json
 !release-please-config.json
 !release-plz.toml
 !cliff.toml
+!example-mdbook-lint.toml
 !tests/fixtures/**/*.md
 !tests/fixtures/**/*.json
 !tests/fixtures/**/*.toml


### PR DESCRIPTION
Fixes the release-plz workflow failure by properly excluding the example configuration file from the *.toml ignore pattern.

## Problem
The release-plz workflow was failing with:
> the working directory of this project has uncommitted changes: ["example-mdbook-lint.toml"]

This happened because:
1.  is in .gitignore (line 6)
2. We force-added  to the repo
3. release-plz detected this as an uncommitted change

## Solution
Add  to .gitignore exceptions, similar to how we handle other config files like , , etc.

This should fix the release workflow and allow crates.io publishing to proceed.