### PR TITLE
Fix MDBOOK010 false positives with shell prompts

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Performance benchmark script for mdbook-lint
+
+set -e
+
+LINTER="./target/release/mdbook-lint"
+TEST_DIR="/tmp/rust-book"
+
+echo "=== mdbook-lint Performance Benchmark ==="
+echo ""
+
+# Build release binary if needed
+if [ ! -f "$LINTER" ]; then
+    echo "Building release binary..."
+    cargo build --release
+fi
+
+# Clone test repo if needed
+if [ ! -d "$TEST_DIR" ]; then
+    echo "Cloning The Rust Book..."
+    git clone --depth 1 https://github.com/rust-lang/book.git "$TEST_DIR"
+fi
+
+echo ""
+echo "Test corpus: The Rust Book"
+echo "Location: $TEST_DIR"
+
+# Count files
+MD_COUNT=$(find "$TEST_DIR" -name "*.md" | wc -l | tr -d ' ')
+echo "Markdown files: $MD_COUNT"
+
+# Get total size
+TOTAL_SIZE=$(find "$TEST_DIR" -name "*.md" -exec wc -c {} + | tail -1 | awk '{print $1}')
+echo "Total size: $(echo "scale=2; $TOTAL_SIZE / 1024 / 1024" | bc) MB"
+
+echo ""
+echo "Running performance tests..."
+echo ""
+
+# Test 1: Single chapter
+echo "Test 1: Single chapter (ch01-*.md)"
+time $LINTER lint "$TEST_DIR"/src/ch01-*.md --quiet 2>&1 | tail -1
+
+echo ""
+
+# Test 2: First 10 chapters  
+echo "Test 2: First 10 chapters (ch0*.md, ch1*.md)"
+time $LINTER lint "$TEST_DIR"/src/ch0*.md "$TEST_DIR"/src/ch1*.md --quiet 2>&1 | tail -1
+
+echo ""
+
+# Test 3: All src files with timeout
+echo "Test 3: All src files (with 30s timeout)"
+timeout 30 time $LINTER lint "$TEST_DIR"/src/*.md --quiet 2>&1 | tail -1 || echo "Timeout after 30 seconds"
+
+echo ""
+
+# Test 4: Specific rules only
+echo "Test 4: All files with only MD rules (no MDBOOK rules)"
+time $LINTER lint "$TEST_DIR"/src/*.md --disable MDBOOK001,MDBOOK002,MDBOOK003,MDBOOK004,MDBOOK005,MDBOOK006,MDBOOK007,MDBOOK008,MDBOOK009,MDBOOK010,MDBOOK011,MDBOOK012,MDBOOK025 --quiet 2>&1 | tail -1
+
+echo ""
+echo "=== Benchmark Complete ==="


### PR DESCRIPTION
## Summary
- Fixed MDBOOK010 incorrectly flagging shell command prompts as unclosed math blocks
- Added intelligent detection of shell prompt patterns vs actual LaTeX math
- Added comprehensive test coverage for shell prompt detection

## Problem
MDBOOK010 was treating lines starting with `$` (common in shell documentation) as unclosed inline math blocks, causing false positives when linting documentation with shell examples.

## Solution
Added `is_likely_shell_prompt()` helper function that detects:
- Unix/Linux prompts (`$ command`)
- PowerShell prompts (`> command`)
- Lines with single `$` followed by common shell commands
- Numbered prompts and other shell patterns

## Test Results
Tested against The Rust Book - all false positives eliminated while still correctly detecting actual unclosed math blocks.

Before fix:
```
src/ch01-01-installation.md:31:1:error: MDBOOK010: Unclosed inline math block
```

After fix:
```
✓ No MDBOOK010 false positives on shell commands
✓ MD014 still correctly identifies shell prompts (as intended)
```

## Test Plan
- [x] Added unit tests for shell prompt detection
- [x] Added tests for PowerShell prompts
- [x] Tested against The Rust Book corpus
- [x] All existing tests still pass
- [x] `cargo fmt` and `cargo clippy` pass

Closes #124