### PR TITLE
fix: add docs/.mdbook-lint.toml to gitignore exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ mdbook-lint.toml
 # Keep documentation
 !docs/src/**/*.md
 !docs/book.toml
+!docs/.mdbook-lint.toml
 
 # Corpus test files (downloaded/generated)
 **/corpus/real_projects/


### PR DESCRIPTION
## Summary
- Fixes release-plz workflow failure by adding `docs/.mdbook-lint.toml` to gitignore exceptions
- The file is tracked in git but was matching the `*.toml` pattern, causing release-plz to detect uncommitted changes

## Context
This is the final blocker preventing release-plz from creating the v0.11.1 release PR with our performance fixes from #132.

## Test plan
- [x] Verify .gitignore now includes `!docs/.mdbook-lint.toml` exception
- [ ] After merge, release-plz workflow should succeed and create v0.11.1 release PR