### PR TITLE
feat: add automatic config file discovery

### DIFF
--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -496,8 +496,9 @@ fn run_cli_mode(
         ));
     }
 
-    // Load configuration
+    // Load configuration - try discovery if no explicit path
     let mut config = if let Some(path) = config_path {
+        // Explicit config path provided
         let config_content = std::fs::read_to_string(path).map_err(|e| {
             mdbook_lint::error::MdBookLintError::config_error(format!(
                 "Failed to read config file {path}: {e}"
@@ -515,7 +516,12 @@ fn run_cli_mode(
             // Try to auto-detect format
             config_content.parse()?
         }
+    } else if let Some(discovered_path) = Config::discover_config(None) {
+        // Try to discover config file
+        eprintln!("Using config: {}", discovered_path.display());
+        Config::from_file(&discovered_path)?
     } else {
+        // No config found, use defaults
         Config::default()
     };
 


### PR DESCRIPTION
## Summary
Implements automatic config file discovery for both CLI and preprocessor modes, fixing the issue where config files were being silently ignored.

## Background
Users reported that config files (`.mdbook-lint.toml`) were not being picked up automatically in either CLI or preprocessor mode. The only way to use a config was to explicitly specify it with the `--config` flag. This was inconsistent with user expectations from similar tools like ESLint and Prettier.

## Changes
- Added `Config::discover_config()` function to search for config files
- Updated CLI mode to automatically discover config when no `--config` flag is provided
- Updated preprocessor to discover config from the book root directory
- Added debug output showing where config was found or if search failed
- Searches parent directories up to root for config files

## Config Discovery Order
Searches for these filenames in order:
1. `.mdbook-lint.toml` (preferred)
2. `mdbook-lint.toml`
3. `.mdbook-lint.yaml`
4. `.mdbook-lint.yml`
5. `.mdbook-lint.json`

## Test Results
```bash
# With config file present
$ mdbook-lint lint test.md
DEBUG: Found config at /path/to/.mdbook-lint.toml
Using config: /path/to/.mdbook-lint.toml

# Without config file
$ mdbook-lint lint test.md  
DEBUG: No config file found searching from /current/dir
```

## Impact
- Config files are now automatically discovered as users expect
- No breaking changes - explicit `--config` flag still works
- Debug output helps users understand what's happening
- Works in both CLI and preprocessor modes

Fixes #148