### PR TITLE
fix: configure release-plz to avoid tag conflicts

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,24 +5,32 @@
 # Don't update all dependencies automatically
 dependencies_update = false
 
-# Create git tags and releases
-git_release_enable = true
-git_tag_name = "v{{ version }}"
-
 # Publishing to crates.io
 publish = true
 
+# Ensure all packages are published before creating the tag
+publish_timeout = "10m"
+
+# Only create a single tag/release for the workspace after all crates are published
+git_release_enable = true
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+
+# Disable individual package releases to avoid tag conflicts
 [[package]]
 name = "mdbook-lint"
-# Main binary gets GitHub releases
-git_release_enable = true
+# No individual release - handled at workspace level
+git_release_enable = false
+git_tag_enable = false
 
 [[package]]
 name = "mdbook-lint-core"
-# Internal library - no separate releases
+# No individual release - handled at workspace level
 git_release_enable = false
+git_tag_enable = false
 
 [[package]]
 name = "mdbook-lint-rulesets"
-# Internal library - no separate releases
+# No individual release - handled at workspace level
 git_release_enable = false
+git_tag_enable = false


### PR DESCRIPTION
## Problem
In v0.11.2, release-plz only published `mdbook-lint-core` before creating the git tag, which prevented the other crates from being published. We had to manually publish the remaining crates.

## Root Cause
The release-plz configuration had conflicting settings:
- Workspace-level git release was enabled
- Individual package releases were also partially enabled
- This caused the tag to be created after the first crate was published

## Solution
Updated `release-plz.toml` to:
- Only create a single workspace-level tag/release after ALL crates are published
- Explicitly disable individual package tags/releases to avoid conflicts
- Add `publish_timeout` to ensure adequate time for all crates

## Configuration Changes
- Set `git_release_enable = false` and `git_tag_enable = false` for all individual packages
- Keep workspace-level `git_release_enable = true` and `git_tag_enable = true`
- Added `publish_timeout = "10m"` to allow time for publishing all crates

This should prevent future releases from encountering the same issue where only some crates get published before the tag is created.