### PR TITLE
feat: implement rule configuration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "toml",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -41,8 +41,8 @@ tower-lsp = { version = "0.20", optional = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-util", "io-std", "net", "time"], optional = true }
 
 # Local workspace crates  
-mdbook-lint-core = { version = "0.11.2", path = "../mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.11.2", path = "../mdbook-lint-rulesets" }
+mdbook-lint-core = { version = "0.11.3", path = "../mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.11.3", path = "../mdbook-lint-rulesets" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mdbook-lint-cli/src/lib.rs
+++ b/crates/mdbook-lint-cli/src/lib.rs
@@ -23,6 +23,9 @@
 pub mod config;
 pub mod preprocessor;
 
+#[cfg(test)]
+mod rule_config_test;
+
 // Re-export everything from core
 pub use mdbook_lint_core::*;
 

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -568,7 +568,7 @@ fn run_cli_mode(
         registry.register_provider(Box::new(MdBookRuleProvider))?;
     }
 
-    let engine = registry.create_engine()?;
+    let engine = registry.create_engine_with_config(Some(&config.core))?;
 
     let mut total_violations = 0;
     let mut has_errors = false;

--- a/crates/mdbook-lint-cli/src/rule_config_test.rs
+++ b/crates/mdbook-lint-cli/src/rule_config_test.rs
@@ -74,7 +74,7 @@ enabled-rules = ["MD013"]
             !violations_default.is_empty()
                 && violations_default[0].message.contains("92 characters"),
             "Expected violation message to contain '92 characters', got: {:?}",
-            violations_default.get(0).map(|v| &v.message)
+            violations_default.first().map(|v| &v.message)
         );
     }
 

--- a/crates/mdbook-lint-cli/src/rule_config_test.rs
+++ b/crates/mdbook-lint-cli/src/rule_config_test.rs
@@ -1,0 +1,244 @@
+//! Tests for rule configuration functionality
+
+#[cfg(test)]
+mod tests {
+    use crate::config::Config;
+    use mdbook_lint_core::{Document, PluginRegistry};
+    use mdbook_lint_rulesets::StandardRuleProvider;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_md013_configuration_works() {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(StandardRuleProvider))
+            .unwrap();
+
+        // Create config with MD013 line-length = 120 and only MD013 enabled
+        let config_toml = r#"
+enabled-rules = ["MD013"]
+[MD013]
+line-length = 120
+ignore-code-blocks = true
+ignore-tables = false
+ignore-headings = false
+"#;
+        let config = Config::from_toml_str(config_toml).unwrap();
+
+        // Create engine with configuration
+        let engine = registry
+            .create_engine_with_config(Some(&config.core))
+            .unwrap();
+
+        // Test with 100-character line (should pass with line-length = 120)
+        let content = "This line is exactly 100 characters long to test if MD013 configuration works properly here.";
+        let document = create_test_document(content);
+
+        let violations = engine
+            .lint_document_with_config(&document, &config.core)
+            .unwrap();
+
+        // Should have no violations because line is under 120 characters
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations with line-length=120"
+        );
+
+        // Test with default configuration (should fail)
+        let engine_default = registry.create_engine().unwrap();
+        let violations_default = engine_default
+            .lint_document_with_config(&document, &mdbook_lint_core::Config::default())
+            .unwrap();
+
+        // Should have 1 violation because line is over default 80 characters
+        assert_eq!(
+            violations_default.len(),
+            1,
+            "Expected 1 violation with default line-length=80"
+        );
+        assert!(violations_default[0].message.contains("100 characters"));
+    }
+
+    #[test]
+    fn test_md009_configuration_works() {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(StandardRuleProvider))
+            .unwrap();
+
+        // Create config with MD009 br-spaces = 4 and only MD009 enabled
+        let config_toml = r#"
+enabled-rules = ["MD009"]
+[MD009]
+br-spaces = 4
+strict = false
+"#;
+        let config = Config::from_toml_str(config_toml).unwrap();
+
+        // Create engine with configuration
+        let engine = registry
+            .create_engine_with_config(Some(&config.core))
+            .unwrap();
+
+        // Test with 3 trailing spaces (should pass with br-spaces = 4)
+        let content = "Line with 3 trailing spaces   \nAnother line\n";
+        let document = create_test_document(content);
+
+        let violations = engine
+            .lint_document_with_config(&document, &config.core)
+            .unwrap();
+
+        // Should have no violations because 3 spaces < 4 allowed
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations with br-spaces=4"
+        );
+
+        // Test with 5 trailing spaces (should fail)
+        let content_5_spaces = "Line with 5 trailing spaces     \nAnother line\n";
+        let document_5_spaces = create_test_document(content_5_spaces);
+
+        let violations_5_spaces = engine
+            .lint_document_with_config(&document_5_spaces, &config.core)
+            .unwrap();
+
+        // Should have 1 violation because 5 spaces > 4 allowed
+        assert_eq!(
+            violations_5_spaces.len(),
+            1,
+            "Expected 1 violation with 5 trailing spaces"
+        );
+    }
+
+    #[test]
+    fn test_md004_configuration_works() {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(StandardRuleProvider))
+            .unwrap();
+
+        // Create config with MD004 style = "asterisk" and only MD004 enabled
+        let config_toml = r#"
+enabled-rules = ["MD004"]
+[MD004]
+style = "asterisk"
+"#;
+        let config = Config::from_toml_str(config_toml).unwrap();
+
+        // Create engine with configuration
+        let engine = registry
+            .create_engine_with_config(Some(&config.core))
+            .unwrap();
+
+        // Test with mixed list styles (should fail for non-asterisk items)
+        let content = r#"* First item with asterisk
++ Second item with plus
+- Third item with dash
+"#;
+        let document = create_test_document(content);
+
+        let violations = engine
+            .lint_document_with_config(&document, &config.core)
+            .unwrap();
+
+        // Should have 2 violations for + and - items
+        assert_eq!(
+            violations.len(),
+            2,
+            "Expected 2 violations for non-asterisk items"
+        );
+        assert!(violations[0].message.contains("expected '*'"));
+        assert!(violations[1].message.contains("expected '*'"));
+
+        // Test with all asterisk items (should pass)
+        let content_asterisk = r#"* First item
+* Second item
+* Third item
+"#;
+        let document_asterisk = create_test_document(content_asterisk);
+
+        let violations_asterisk = engine
+            .lint_document_with_config(&document_asterisk, &config.core)
+            .unwrap();
+
+        // Should have no violations
+        assert_eq!(
+            violations_asterisk.len(),
+            0,
+            "Expected no violations with all asterisk items"
+        );
+    }
+
+    #[test]
+    fn test_configuration_file_loading() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create a config file
+        let config_path = temp_dir.path().join(".mdbook-lint.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[MD013]
+line-length = 100
+
+[MD009]
+br-spaces = 3
+
+[MD004]
+style = "dash"
+"#,
+        )
+        .unwrap();
+
+        // Load config from file
+        let config = Config::from_file(&config_path).unwrap();
+
+        // Verify configuration values are loaded correctly
+        let md013_config = config.core.rule_configs.get("MD013").unwrap();
+        assert_eq!(
+            md013_config.get("line-length").unwrap().as_integer(),
+            Some(100)
+        );
+
+        let md009_config = config.core.rule_configs.get("MD009").unwrap();
+        assert_eq!(md009_config.get("br-spaces").unwrap().as_integer(), Some(3));
+
+        let md004_config = config.core.rule_configs.get("MD004").unwrap();
+        assert_eq!(md004_config.get("style").unwrap().as_str(), Some("dash"));
+    }
+
+    #[test]
+    fn test_backward_compatibility() {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(StandardRuleProvider))
+            .unwrap();
+
+        // Create engine without configuration (should use old register_rules method)
+        let engine = registry.create_engine().unwrap();
+
+        // Test that rules work with default values
+        let content = "Line that is longer than the default 80 characters to test backward compatibility here.";
+        let document = create_test_document(content);
+
+        let violations = engine
+            .lint_document_with_config(&document, &mdbook_lint_core::Config::default())
+            .unwrap();
+
+        // Should have 1 violation with default MD013 settings
+        let md013_violations: Vec<_> = violations.iter().filter(|v| v.rule_id == "MD013").collect();
+        assert_eq!(md013_violations.len(), 1);
+        assert!(
+            md013_violations[0]
+                .message
+                .contains("expected no more than 80")
+        );
+    }
+}

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -21,7 +21,7 @@ mdbook = ["dep:mdbook"]   # mdBook-specific rules (MDBOOK001-007)
 
 [dependencies]
 # Local workspace crates
-mdbook-lint-core = { version = "0.11.2", path = "../mdbook-lint-core" }
+mdbook-lint-core = { version = "0.11.3", path = "../mdbook-lint-core" }
 
 # Core dependencies
 anyhow = { workspace = true }

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -38,6 +38,7 @@ mdbook = { workspace = true, optional = true }
 # Utilities
 walkdir = { workspace = true }
 regex = "1.10"
+toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mdbook-lint-rulesets/src/standard/md004.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md004.rs
@@ -78,7 +78,7 @@ impl MD004 {
                 "asterisk" => ListStyleConfig::Asterisk,
                 "plus" => ListStyleConfig::Plus,
                 "dash" => ListStyleConfig::Dash,
-                "consistent" | _ => ListStyleConfig::Consistent,
+                _ => ListStyleConfig::Consistent,
             };
         }
 

--- a/crates/mdbook-lint-rulesets/src/standard/md004.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md004.rs
@@ -68,6 +68,22 @@ impl MD004 {
     pub fn with_style(style: ListStyleConfig) -> Self {
         Self { style }
     }
+
+    /// Create MD004 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(style_str) = config.get("style").and_then(|v| v.as_str()) {
+            rule.style = match style_str {
+                "asterisk" => ListStyleConfig::Asterisk,
+                "plus" => ListStyleConfig::Plus,
+                "dash" => ListStyleConfig::Dash,
+                "consistent" | _ => ListStyleConfig::Consistent,
+            };
+        }
+
+        rule
+    }
 }
 
 impl Default for MD004 {

--- a/crates/mdbook-lint-rulesets/src/standard/md009.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md009.rs
@@ -89,6 +89,33 @@ impl MD009 {
             strict,
         }
     }
+
+    /// Create MD009 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(br_spaces) = config
+            .get("br-spaces")
+            .or_else(|| config.get("br_spaces"))
+            .and_then(|v| v.as_integer())
+        {
+            rule.br_spaces = br_spaces as usize;
+        }
+
+        if let Some(list_item) = config
+            .get("list-item-empty-lines")
+            .or_else(|| config.get("list_item_empty_lines"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.list_item_empty_lines = list_item;
+        }
+
+        if let Some(strict) = config.get("strict").and_then(|v| v.as_bool()) {
+            rule.strict = strict;
+        }
+
+        rule
+    }
 }
 
 impl Default for MD009 {

--- a/crates/mdbook-lint-rulesets/src/standard/md013.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md013.rs
@@ -42,6 +42,45 @@ impl MD013 {
         }
     }
 
+    /// Create MD013 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(line_length) = config
+            .get("line-length")
+            .or_else(|| config.get("line_length"))
+            .and_then(|v| v.as_integer())
+        {
+            rule.line_length = line_length as usize;
+        }
+
+        if let Some(ignore_code) = config
+            .get("ignore-code-blocks")
+            .or_else(|| config.get("ignore_code_blocks"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.ignore_code_blocks = ignore_code;
+        }
+
+        if let Some(ignore_tables) = config
+            .get("ignore-tables")
+            .or_else(|| config.get("ignore_tables"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.ignore_tables = ignore_tables;
+        }
+
+        if let Some(ignore_headings) = config
+            .get("ignore-headings")
+            .or_else(|| config.get("ignore_headings"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.ignore_headings = ignore_headings;
+        }
+
+        rule
+    }
+
     /// Check if a line should be ignored based on rule settings
     fn should_ignore_line(&self, line: &str, in_code_block: bool, in_table: bool) -> bool {
         let trimmed = line.trim_start();

--- a/crates/mdbook-lint-rulesets/src/standard/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/mod.rs
@@ -64,7 +64,7 @@ pub mod md057; // Placeholder: reserved for future use
 pub mod md058;
 pub mod md059;
 
-use mdbook_lint_core::{RuleProvider, RuleRegistry};
+use mdbook_lint_core::{Config, RuleProvider, RuleRegistry};
 
 /// Provider for standard markdown rules (MD001-MD059)
 pub struct StandardRuleProvider;
@@ -152,5 +152,90 @@ impl RuleProvider for StandardRuleProvider {
             "MD041", "MD042", "MD043", "MD044", "MD045", "MD046", "MD047", "MD048", "MD049",
             "MD050", "MD051", "MD052", "MD053", "MD054", "MD055", "MD056", "MD058", "MD059",
         ]
+    }
+
+    fn register_rules_with_config(&self, registry: &mut RuleRegistry, config: Option<&Config>) {
+        // Register all standard rules with configuration support
+        registry.register(Box::new(md001::MD001));
+        registry.register(Box::new(md002::MD002::default()));
+        registry.register(Box::new(md003::MD003::default()));
+
+        // MD004 - unordered list style
+        let md004 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD004")) {
+            md004::MD004::from_config(cfg)
+        } else {
+            md004::MD004::default()
+        };
+        registry.register(Box::new(md004));
+
+        registry.register(Box::new(md005::MD005));
+        registry.register(Box::new(md006::MD006));
+        registry.register(Box::new(md007::MD007::default()));
+        // MD008 is a placeholder
+
+        // MD009 - no trailing spaces
+        let md009 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD009")) {
+            md009::MD009::from_config(cfg)
+        } else {
+            md009::MD009::default()
+        };
+        registry.register(Box::new(md009));
+
+        registry.register(Box::new(md010::MD010::default()));
+        registry.register(Box::new(md011::MD011));
+        registry.register(Box::new(md012::MD012::default()));
+
+        // MD013 - line length
+        let md013 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD013")) {
+            md013::MD013::from_config(cfg)
+        } else {
+            md013::MD013::default()
+        };
+        registry.register(Box::new(md013));
+
+        registry.register(Box::new(md014::MD014));
+        // MD015-017 are placeholders
+        registry.register(Box::new(md018::MD018));
+        registry.register(Box::new(md019::MD019));
+        registry.register(Box::new(md020::MD020));
+        registry.register(Box::new(md021::MD021));
+        registry.register(Box::new(md022::MD022));
+        registry.register(Box::new(md023::MD023));
+        registry.register(Box::new(md024::MD024::default()));
+        registry.register(Box::new(md025::MD025::default()));
+        registry.register(Box::new(md026::MD026::default()));
+        registry.register(Box::new(md027::MD027));
+        registry.register(Box::new(md028::MD028));
+        registry.register(Box::new(md029::MD029::default()));
+        registry.register(Box::new(md030::MD030::default()));
+        registry.register(Box::new(md031::MD031));
+        registry.register(Box::new(md032::MD032));
+        registry.register(Box::new(md033::MD033));
+        registry.register(Box::new(md034::MD034));
+        registry.register(Box::new(md035::MD035::default()));
+        registry.register(Box::new(md036::MD036::default()));
+        registry.register(Box::new(md037::MD037));
+        registry.register(Box::new(md038::MD038));
+        registry.register(Box::new(md039::MD039));
+        registry.register(Box::new(md040::MD040));
+        registry.register(Box::new(md041::MD041));
+        registry.register(Box::new(md042::MD042));
+        registry.register(Box::new(md043::MD043::default()));
+        registry.register(Box::new(md044::MD044::default()));
+        registry.register(Box::new(md045::MD045));
+        registry.register(Box::new(md046::MD046::default()));
+        registry.register(Box::new(md047::MD047));
+        registry.register(Box::new(md048::MD048::default()));
+        registry.register(Box::new(md049::MD049::default()));
+        registry.register(Box::new(md050::MD050::default()));
+        registry.register(Box::new(md051::MD051::default()));
+        registry.register(Box::new(md052::MD052::default()));
+        registry.register(Box::new(md053::MD053::default()));
+        registry.register(Box::new(md054::MD054::default()));
+        registry.register(Box::new(md055::MD055::default()));
+        registry.register(Box::new(md056::MD056));
+        // MD057 is a placeholder
+        registry.register(Box::new(md058::MD058));
+        registry.register(Box::new(md059::MD059::default()));
     }
 }


### PR DESCRIPTION
## Summary
- Fixes rule configuration not being applied to rules (issue #161)
- Implements configuration support for MD013, MD009, and MD004 as proof of concept
- Adds backward-compatible architecture for rule configuration

## Changes
- Add `register_rules_with_config` to `RuleProvider` trait with default fallback
- Implement `from_config` methods for MD013 (line length), MD009 (trailing spaces), MD004 (list style)
- Update `PluginRegistry` to pass configuration during rule creation
- Modify CLI to use configured rules instead of defaults
- Add comprehensive test suite for rule configuration

## Test Plan
- ✅ Unit tests for all three rules with various configuration options
- ✅ End-to-end CLI tests confirming configuration is properly applied
- ✅ Backward compatibility tests ensuring existing behavior unchanged

## Breaking Changes
None - maintains full backward compatibility through default implementations.