### PR TITLE
feat: add configuration support for batch 2 rules (MD024-MD030)

### DIFF
--- a/crates/mdbook-lint-cli/tests/batch2_rule_config_test.rs
+++ b/crates/mdbook-lint-cli/tests/batch2_rule_config_test.rs
@@ -1,0 +1,475 @@
+//! Tests for batch 2 rule configuration (MD024, MD025, MD026, MD029, MD030)
+
+mod common;
+
+use common::*;
+use predicates::str::contains;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_md024_siblings_only_configuration() {
+    // Test MD024 with siblings_only configuration
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# Main Title
+## Introduction
+### Introduction
+## Configuration  
+### Configuration
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    // Test with siblings_only = false (default) - should detect duplicates across levels
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD024 = true
+
+[MD024]
+siblings_only = false
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD024"))
+        .stdout(contains("Introduction"))
+        .stdout(contains("Configuration"));
+
+    // Test with siblings_only = true - should only detect duplicates at same level
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD024 = true
+
+[MD024]
+siblings_only = true
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    // Should succeed as there are no duplicates at same level
+    assert.success();
+}
+
+#[test]
+fn test_md025_level_configuration() {
+    // Test MD025 with level configuration
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# First H1
+## H2 heading
+# Second H1
+## Another H2
+## Third H2
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    // Test with level = 1 (default) - should detect multiple H1s
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD025 = true
+
+[MD025]
+level = 1
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD025"))
+        .stdout(contains("Multiple top-level headings"));
+
+    // Test with level = 2 - should detect multiple H2s
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD025 = true
+
+[MD025]
+level = 2
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD025"))
+        .stdout(contains("Multiple top-level headings"));
+}
+
+#[test]
+fn test_md026_punctuation_configuration() {
+    // Test MD026 with punctuation configuration
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# Heading with period.
+## Heading with exclamation!
+### Heading with custom @
+#### Heading without punctuation
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    // Test with default punctuation
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD026 = true
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD026"))
+        .stdout(contains("period"))
+        .stdout(contains("exclamation"));
+
+    // Test with custom punctuation
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD026 = true
+
+[MD026]
+punctuation = ".@"
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD026"))
+        .stdout(contains("period"))
+        .stdout(contains("@"));
+}
+
+#[test]
+fn test_md029_style_configuration() {
+    // Test MD029 with style configuration
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# Ordered Lists
+
+1. First item
+1. Second item
+3. Third item
+4. Fourth item
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    // Test with style = "sequential"
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD029 = true
+
+[MD029]
+style = "sequential"
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD029"))
+        .stdout(contains("expected '2'"));
+
+    // Test with style = "all_ones"
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD029 = true
+
+[MD029]
+style = "all_ones"
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD029"))
+        .stdout(contains("expected '1'"));
+}
+
+#[test]
+fn test_md030_spacing_configuration() {
+    // Test MD030 with spacing configuration
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# Lists
+
+- Single space
+-  Two spaces
+1. Single space
+1.  Two spaces
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    // Test with default (1 space)
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD030 = true
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD030"))
+        .stdout(contains("expected 1 space"));
+
+    // Test with custom spacing
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD030 = true
+
+[MD030]
+ul_single = 2
+ol_single = 2
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD030"))
+        .stdout(contains("expected 2 space"));
+}
+
+#[test]
+fn test_md030_hyphenated_config_keys() {
+    // Test MD030 with hyphenated configuration keys
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# Lists
+
+- Single space
+-  Two spaces
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD030 = true
+
+[MD030]
+ul-single = 2
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    assert
+        .failure()
+        .stdout(contains("MD030"))
+        .stdout(contains("expected 2 space"));
+}
+
+#[test]
+fn test_md024_hyphenated_config_key() {
+    // Test MD024 with hyphenated configuration key
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# Main Title
+## Introduction
+### Introduction
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD024 = true
+
+[MD024]
+siblings-only = true
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    // Should succeed as there are no duplicates at same level
+    assert.success();
+}
+
+#[test]
+fn test_batch2_all_rules_with_config() {
+    // Test all batch 2 rules together with configuration
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let config_file = temp_dir.path().join(".mdbook-lint.toml");
+
+    let content = r#"# Main Title!
+## Introduction
+### Introduction
+## Another Section.
+
+1. First item
+1. Second item
+
+- Item with one space
+-   Item with three spaces
+"#;
+    fs::write(&test_file, content).unwrap();
+
+    let config = r#"
+[rules]
+default = false
+
+[rules.enabled]
+MD024 = true
+MD025 = true
+MD026 = true
+MD029 = true
+MD030 = true
+
+[MD024]
+siblings_only = false
+
+[MD025]
+level = 1
+
+[MD026]
+punctuation = "!."
+
+[MD029]
+style = "sequential"
+
+[MD030]
+ul_single = 1
+ol_single = 1
+"#;
+    fs::write(&config_file, config).unwrap();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(&config_file)
+        .arg(&test_file)
+        .assert();
+
+    // Should have violations from multiple rules
+    assert
+        .failure()
+        .stdout(contains("MD024")) // "Introduction" duplicated
+        .stdout(contains("MD026")) // "!" and "." in headings
+        .stdout(contains("MD029")) // Second item should be "2"
+        .stdout(contains("MD030")); // Three spaces after "-"
+}

--- a/crates/mdbook-lint-rulesets/src/standard/md024.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md024.rs
@@ -30,6 +30,19 @@ impl MD024 {
     pub fn with_siblings_only(siblings_only: bool) -> Self {
         Self { siblings_only }
     }
+
+    /// Create MD024 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(siblings_only) = config.get("siblings_only").and_then(|v| v.as_bool()) {
+            rule.siblings_only = siblings_only;
+        } else if let Some(siblings_only) = config.get("siblings-only").and_then(|v| v.as_bool()) {
+            rule.siblings_only = siblings_only;
+        }
+
+        rule
+    }
 }
 
 impl Default for MD024 {

--- a/crates/mdbook-lint-rulesets/src/standard/md025.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md025.rs
@@ -27,6 +27,17 @@ impl MD025 {
     pub fn with_level(level: u8) -> Self {
         Self { level }
     }
+
+    /// Create MD025 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(level) = config.get("level").and_then(|v| v.as_integer()) {
+            rule.level = level as u8;
+        }
+
+        rule
+    }
 }
 
 impl Default for MD025 {

--- a/crates/mdbook-lint-rulesets/src/standard/md026.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md026.rs
@@ -30,6 +30,17 @@ impl MD026 {
         Self { punctuation }
     }
 
+    /// Create MD026 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(punctuation) = config.get("punctuation").and_then(|v| v.as_str()) {
+            rule.punctuation = punctuation.to_string();
+        }
+
+        rule
+    }
+
     /// Check if a character is considered punctuation for this rule
     fn is_punctuation(&self, ch: char) -> bool {
         self.punctuation.contains(ch)

--- a/crates/mdbook-lint-rulesets/src/standard/md029.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md029.rs
@@ -40,6 +40,22 @@ impl MD029 {
     pub fn with_style(style: OrderedListStyle) -> Self {
         Self { style }
     }
+
+    /// Create MD029 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(style_str) = config.get("style").and_then(|v| v.as_str()) {
+            rule.style = match style_str.to_lowercase().as_str() {
+                "sequential" => OrderedListStyle::Sequential,
+                "all_ones" | "all-ones" => OrderedListStyle::AllOnes,
+                "consistent" => OrderedListStyle::Consistent,
+                _ => OrderedListStyle::Consistent, // Default fallback
+            };
+        }
+
+        rule
+    }
 }
 
 impl Default for MD029 {

--- a/crates/mdbook-lint-rulesets/src/standard/md030.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md030.rs
@@ -52,6 +52,37 @@ impl MD030 {
     pub fn with_config(config: MD030Config) -> Self {
         Self { config }
     }
+
+    /// Create MD030 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(ul_single) = config.get("ul_single").and_then(|v| v.as_integer()) {
+            rule.config.ul_single = ul_single as usize;
+        } else if let Some(ul_single) = config.get("ul-single").and_then(|v| v.as_integer()) {
+            rule.config.ul_single = ul_single as usize;
+        }
+
+        if let Some(ol_single) = config.get("ol_single").and_then(|v| v.as_integer()) {
+            rule.config.ol_single = ol_single as usize;
+        } else if let Some(ol_single) = config.get("ol-single").and_then(|v| v.as_integer()) {
+            rule.config.ol_single = ol_single as usize;
+        }
+
+        if let Some(ul_multi) = config.get("ul_multi").and_then(|v| v.as_integer()) {
+            rule.config.ul_multi = ul_multi as usize;
+        } else if let Some(ul_multi) = config.get("ul-multi").and_then(|v| v.as_integer()) {
+            rule.config.ul_multi = ul_multi as usize;
+        }
+
+        if let Some(ol_multi) = config.get("ol_multi").and_then(|v| v.as_integer()) {
+            rule.config.ol_multi = ol_multi as usize;
+        } else if let Some(ol_multi) = config.get("ol-multi").and_then(|v| v.as_integer()) {
+            rule.config.ol_multi = ol_multi as usize;
+        }
+
+        rule
+    }
 }
 
 impl Default for MD030 {

--- a/crates/mdbook-lint-rulesets/src/standard/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/mod.rs
@@ -236,13 +236,50 @@ impl RuleProvider for StandardRuleProvider {
         registry.register(Box::new(md021::MD021));
         registry.register(Box::new(md022::MD022));
         registry.register(Box::new(md023::MD023));
-        registry.register(Box::new(md024::MD024::default()));
-        registry.register(Box::new(md025::MD025::default()));
-        registry.register(Box::new(md026::MD026::default()));
+
+        // MD024 - duplicate headings
+        let md024 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD024")) {
+            md024::MD024::from_config(cfg)
+        } else {
+            md024::MD024::default()
+        };
+        registry.register(Box::new(md024));
+
+        // MD025 - single H1 per document
+        let md025 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD025")) {
+            md025::MD025::from_config(cfg)
+        } else {
+            md025::MD025::default()
+        };
+        registry.register(Box::new(md025));
+
+        // MD026 - trailing punctuation in headings
+        let md026 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD026")) {
+            md026::MD026::from_config(cfg)
+        } else {
+            md026::MD026::default()
+        };
+        registry.register(Box::new(md026));
+
         registry.register(Box::new(md027::MD027));
         registry.register(Box::new(md028::MD028));
-        registry.register(Box::new(md029::MD029::default()));
-        registry.register(Box::new(md030::MD030::default()));
+
+        // MD029 - ordered list item prefix consistency
+        let md029 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD029")) {
+            md029::MD029::from_config(cfg)
+        } else {
+            md029::MD029::default()
+        };
+        registry.register(Box::new(md029));
+
+        // MD030 - spaces after list markers
+        let md030 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD030")) {
+            md030::MD030::from_config(cfg)
+        } else {
+            md030::MD030::default()
+        };
+        registry.register(Box::new(md030));
+
         registry.register(Box::new(md031::MD031));
         registry.register(Box::new(md032::MD032));
         registry.register(Box::new(md033::MD033));


### PR DESCRIPTION
## Summary
- Implements configuration support for batch 2 rules as part of issue #172
- Adds `from_config` methods for MD024, MD025, MD026, MD029, and MD030
- Supports both underscore and hyphenated configuration key names

## Configuration Options Added

### MD024 - Duplicate headings
- `siblings_only`: Only check for duplicates at the same heading level

### MD025 - Single H1 per document  
- `level`: Specify which heading level to check for uniqueness (default: 1)

### MD026 - Trailing punctuation in headings
- `punctuation`: Customize which characters are considered punctuation (default: ".,;:!?")

### MD029 - Ordered list item prefix consistency
- `style`: Choose numbering style ("sequential", "all_ones", or "consistent")

### MD030 - Spaces after list markers
- `ul_single`: Spaces after unordered list markers
- `ol_single`: Spaces after ordered list markers  
- `ul_multi`: Spaces after unordered list markers in multi-item lists
- `ol_multi`: Spaces after ordered list markers in multi-item lists

## Test Plan
- [x] Unit tests pass for all rule implementations
- [x] Integration tests verify configuration parsing and application
- [x] Both underscore and hyphenated key names work correctly
- [x] Backward compatibility maintained with default values
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` applied to all code

Closes #172