### PR TITLE
feat: implement configuration support for batch 3 rules (MD035, MD036, MD043, MD044, MD046)

### DIFF
--- a/crates/mdbook-lint-cli/tests/batch3_rule_config_test.rs
+++ b/crates/mdbook-lint-cli/tests/batch3_rule_config_test.rs
@@ -1,0 +1,449 @@
+//! Integration tests for batch 3 rule configuration (MD035, MD036, MD043, MD044, MD046)
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_md035_horizontal_rule_style_configuration() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".mdbook-lint.toml");
+    let md_path = dir.path().join("test.md");
+
+    // Write markdown with various horizontal rule styles
+    let markdown_content = r#"# Document
+
+---
+
+Some content
+
+***
+
+More content
+
+___
+
+Final content
+"#;
+    fs::write(&md_path, markdown_content).unwrap();
+
+    // Test with "---" style configuration
+    let config_content = r#"[rules]
+default = false
+
+[rules.enabled]
+MD035 = true
+
+[MD035]
+style = "---"
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("mdbook-lint").unwrap();
+    let output = cmd
+        .arg("lint")
+        .arg("-c")
+        .arg(&config_path)
+        .arg(&md_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output_text = format!("{}{}", stdout, stderr);
+
+    // Should find violations for *** and ___ but not ---
+    assert!(
+        output_text.contains("MD035"),
+        "Expected MD035 in output: {}",
+        output_text
+    );
+    assert!(output_text.contains(":7:") || output_text.contains("line 7")); // *** line
+    assert!(output_text.contains(":11:") || output_text.contains("line 11")); // ___ line
+    assert!(!output_text.contains(":3:") && !output_text.contains("line 3")); // --- line should be OK
+}
+
+#[test]
+fn test_md036_emphasis_punctuation_configuration() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".mdbook-lint.toml");
+    let md_path = dir.path().join("test.md");
+
+    // Write markdown with emphasis that could be headings
+    let markdown_content = r#"Some intro text
+
+**Important Section**
+
+Some content
+
+**Note:**
+
+More content
+
+*Another Section*
+
+Final content
+"#;
+    fs::write(&md_path, markdown_content).unwrap();
+
+    // Test with custom punctuation configuration (only : and !)
+    let config_content = r#"[rules]
+default = false
+
+[rules.enabled]
+MD036 = true
+
+[MD036]
+punctuation = ":!"
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("mdbook-lint").unwrap();
+    let output = cmd
+        .arg("lint")
+        .arg("-c")
+        .arg(&config_path)
+        .arg(&md_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output_text = format!("{}{}", stdout, stderr);
+
+    // Should find violations for lines without punctuation at the end
+    assert!(
+        output_text.contains("MD036"),
+        "Expected MD036 in output: {}",
+        output_text
+    );
+    assert!(output_text.contains(":3:") || output_text.contains("line 3")); // **Important Section**
+    assert!(output_text.contains(":11:") || output_text.contains("line 11")); // *Another Section*
+    assert!(!output_text.contains(":7:") && !output_text.contains("line 7")); // **Note:** ends with allowed punctuation
+}
+
+#[test]
+fn test_md043_required_headings_configuration() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".mdbook-lint.toml");
+    let md_path = dir.path().join("test.md");
+
+    // Write markdown with specific headings
+    let markdown_content = r#"# Overview
+
+## Getting Started
+
+## Configuration
+
+## Advanced Topics
+"#;
+    fs::write(&md_path, markdown_content).unwrap();
+
+    // Test with required heading structure
+    let config_content = r#"[rules]
+default = false
+
+[rules.enabled]
+MD043 = true
+
+[MD043]
+headings = ["Introduction", "Getting Started", "Configuration"]
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("mdbook-lint").unwrap();
+    let output = cmd
+        .arg("lint")
+        .arg("-c")
+        .arg(&config_path)
+        .arg(&md_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output_text = format!("{}{}", stdout, stderr);
+
+    // Should find violation for wrong first heading
+    assert!(
+        output_text.contains("MD043"),
+        "Expected MD043 in output: {}",
+        output_text
+    );
+    assert!(output_text.contains("Expected heading 'Introduction' but found 'Overview'"));
+}
+
+#[test]
+fn test_md044_proper_names_configuration() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".mdbook-lint.toml");
+    let md_path = dir.path().join("test.md");
+
+    // Write markdown with various capitalizations
+    let markdown_content = r#"# Working with github
+
+Use Javascript and typescript in your projects.
+
+GitHub Actions and JavaScript are powerful tools.
+
+Don't forget about rust and python.
+"#;
+    fs::write(&md_path, markdown_content).unwrap();
+
+    // Test with proper names configuration
+    let config_content = r#"[rules]
+default = false
+
+[rules.enabled]
+MD044 = true
+
+[MD044.names]
+GitHub = "GitHub"
+JavaScript = "JavaScript"
+TypeScript = "TypeScript"
+Rust = "Rust"
+Python = "Python"
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("mdbook-lint").unwrap();
+    let output = cmd
+        .arg("lint")
+        .arg("-c")
+        .arg(&config_path)
+        .arg(&md_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output_text = format!("{}{}", stdout, stderr);
+
+    // Should find violations for incorrect capitalizations
+    assert!(
+        output_text.contains("MD044"),
+        "Expected MD044 in output: {}",
+        output_text
+    );
+    assert!(output_text.contains("github")); // Line 1
+    assert!(output_text.contains("Javascript")); // Line 3
+    assert!(output_text.contains("typescript")); // Line 3
+    assert!(output_text.contains("rust")); // Line 7
+    assert!(output_text.contains("python")); // Line 7
+}
+
+#[test]
+fn test_md046_code_block_style_configuration() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".mdbook-lint.toml");
+    let md_path = dir.path().join("test.md");
+
+    // Write markdown with mixed code block styles
+    let markdown_content = r#"# Document
+
+Here's some fenced code:
+
+```rust
+fn main() {
+    println!("Hello");
+}
+```
+
+And here's indented code:
+
+    def hello():
+        print("Hello")
+
+More fenced code:
+
+```python
+print("World")
+```
+"#;
+    fs::write(&md_path, markdown_content).unwrap();
+
+    // Test with fenced style requirement
+    let config_content = r#"[rules]
+default = false
+
+[rules.enabled]
+MD046 = true
+
+[MD046]
+style = "fenced"
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("mdbook-lint").unwrap();
+    let output = cmd
+        .arg("lint")
+        .arg("-c")
+        .arg(&config_path)
+        .arg(&md_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output_text = format!("{}{}", stdout, stderr);
+
+    // Should find violation for indented code block
+    assert!(
+        output_text.contains("MD046"),
+        "Expected MD046 in output: {}",
+        output_text
+    );
+    assert!(output_text.contains("expected fenced but found indented"));
+}
+
+#[test]
+fn test_md046_consistent_style_detection() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".mdbook-lint.toml");
+    let md_path = dir.path().join("test.md");
+
+    // Write markdown starting with indented style
+    let markdown_content = r#"# Document
+
+First code block is indented:
+
+    fn main() {
+        println!("Hello");
+    }
+
+Then a fenced block:
+
+```python
+print("World")
+```
+"#;
+    fs::write(&md_path, markdown_content).unwrap();
+
+    // Test with consistent style (detects from first usage)
+    let config_content = r#"[rules]
+default = false
+
+[rules.enabled]
+MD046 = true
+
+[MD046]
+style = "consistent"
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("mdbook-lint").unwrap();
+    let output = cmd
+        .arg("lint")
+        .arg("-c")
+        .arg(&config_path)
+        .arg(&md_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output_text = format!("{}{}", stdout, stderr);
+
+    // Should find violation for fenced block (first was indented)
+    assert!(
+        output_text.contains("MD046"),
+        "Expected MD046 in output: {}",
+        output_text
+    );
+    assert!(output_text.contains("expected indented but found fenced"));
+}
+
+#[test]
+fn test_batch3_all_rules_together() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join(".mdbook-lint.toml");
+    let md_path = dir.path().join("test.md");
+
+    // Write markdown that triggers all batch 3 rules
+    let markdown_content = r#"# Wrong Title
+
+**Section One**
+
+---
+
+Use github and javascript here.
+
+```rust
+fn main() {}
+```
+
+***
+
+    print("indented")
+"#;
+    fs::write(&md_path, markdown_content).unwrap();
+
+    // Configure all batch 3 rules
+    let config_content = r#"[rules]
+default = false
+
+[rules.enabled]
+MD035 = true
+MD036 = true
+MD043 = true
+MD044 = true
+MD046 = true
+
+[MD035]
+style = "---"
+
+[MD036]
+punctuation = ".,;:!?"
+
+[MD043]
+headings = ["Introduction", "Getting Started"]
+
+[MD044.names]
+GitHub = "GitHub"
+JavaScript = "JavaScript"
+
+[MD046]
+style = "fenced"
+"#;
+    fs::write(&config_path, config_content).unwrap();
+
+    let mut cmd = Command::cargo_bin("mdbook-lint").unwrap();
+    let output = cmd
+        .arg("lint")
+        .arg("-c")
+        .arg(&config_path)
+        .arg(&md_path)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output_text = format!("{}{}", stdout, stderr);
+
+    // Should find violations from multiple rules
+    assert!(
+        output_text.contains("MD035"),
+        "Expected MD035 in output: {}",
+        output_text
+    ); // *** on line 13
+    assert!(
+        output_text.contains("MD036"),
+        "Expected MD036 in output: {}",
+        output_text
+    ); // **Section One** on line 3
+    assert!(
+        output_text.contains("MD043"),
+        "Expected MD043 in output: {}",
+        output_text
+    ); // Wrong title structure
+    assert!(
+        output_text.contains("MD044"),
+        "Expected MD044 in output: {}",
+        output_text
+    ); // github and javascript
+    assert!(
+        output_text.contains("MD046"),
+        "Expected MD046 in output: {}",
+        output_text
+    ); // indented code block
+}

--- a/crates/mdbook-lint-rulesets/src/standard/md035.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md035.rs
@@ -22,6 +22,17 @@ impl MD035 {
         self
     }
 
+    /// Create MD035 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(style) = config.get("style").and_then(|v| v.as_str()) {
+            rule.style = style.to_string();
+        }
+
+        rule
+    }
+
     fn is_horizontal_rule(&self, line: &str) -> Option<String> {
         let trimmed = line.trim();
 

--- a/crates/mdbook-lint-rulesets/src/standard/md036.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md036.rs
@@ -22,6 +22,17 @@ impl MD036 {
         self
     }
 
+    /// Create MD036 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(punctuation) = config.get("punctuation").and_then(|v| v.as_str()) {
+            rule.punctuation = punctuation.to_string();
+        }
+
+        rule
+    }
+
     fn is_emphasis_as_heading(&self, line: &str) -> bool {
         let trimmed = line.trim();
 

--- a/crates/mdbook-lint-rulesets/src/standard/md043.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md043.rs
@@ -30,6 +30,23 @@ impl MD043 {
         Self { headings }
     }
 
+    /// Create MD043 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(headings_value) = config.get("headings")
+            && let Some(headings_array) = headings_value.as_array()
+        {
+            rule.headings = headings_array
+                .iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.to_string())
+                .collect();
+        }
+
+        rule
+    }
+
     /// Get line and column position for a node
     fn get_position<'a>(&self, node: &'a AstNode<'a>) -> (usize, usize) {
         let data = node.data.borrow();

--- a/crates/mdbook-lint-rulesets/src/standard/md044.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md044.rs
@@ -77,6 +77,26 @@ impl MD044 {
         Self { proper_names }
     }
 
+    /// Create MD044 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(names_value) = config.get("names")
+            && let Some(names_table) = names_value.as_table()
+        {
+            // Clear default names and use only configured ones
+            rule.proper_names.clear();
+            for (key, value) in names_table {
+                if let Some(correct_name) = value.as_str() {
+                    rule.proper_names
+                        .insert(key.to_lowercase(), correct_name.to_string());
+                }
+            }
+        }
+
+        rule
+    }
+
     /// Add a proper name to the list
     #[allow(dead_code)]
     pub fn add_name(&mut self, incorrect: String, correct: String) {

--- a/crates/mdbook-lint-rulesets/src/standard/md046.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md046.rs
@@ -40,6 +40,22 @@ impl MD046 {
         Self { style }
     }
 
+    /// Create MD046 from configuration
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::new();
+
+        if let Some(style_str) = config.get("style").and_then(|v| v.as_str()) {
+            rule.style = match style_str.to_lowercase().as_str() {
+                "fenced" => CodeBlockStyle::Fenced,
+                "indented" => CodeBlockStyle::Indented,
+                "consistent" => CodeBlockStyle::Consistent,
+                _ => CodeBlockStyle::Consistent, // Default fallback
+            };
+        }
+
+        rule
+    }
+
     /// Determine if a code block is fenced or indented
     fn get_code_block_style(&self, node: &AstNode) -> Option<CodeBlockStyle> {
         if let NodeValue::CodeBlock(code_block) = &node.data.borrow().value {

--- a/crates/mdbook-lint-rulesets/src/standard/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/mod.rs
@@ -284,18 +284,55 @@ impl RuleProvider for StandardRuleProvider {
         registry.register(Box::new(md032::MD032));
         registry.register(Box::new(md033::MD033));
         registry.register(Box::new(md034::MD034));
-        registry.register(Box::new(md035::MD035::default()));
-        registry.register(Box::new(md036::MD036::default()));
+
+        // MD035 - horizontal rule style
+        let md035 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD035")) {
+            md035::MD035::from_config(cfg)
+        } else {
+            md035::MD035::default()
+        };
+        registry.register(Box::new(md035));
+
+        // MD036 - emphasis used instead of a heading
+        let md036 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD036")) {
+            md036::MD036::from_config(cfg)
+        } else {
+            md036::MD036::default()
+        };
+        registry.register(Box::new(md036));
+
         registry.register(Box::new(md037::MD037));
         registry.register(Box::new(md038::MD038));
         registry.register(Box::new(md039::MD039));
         registry.register(Box::new(md040::MD040));
         registry.register(Box::new(md041::MD041));
         registry.register(Box::new(md042::MD042));
-        registry.register(Box::new(md043::MD043::default()));
-        registry.register(Box::new(md044::MD044::default()));
+
+        // MD043 - required heading structure
+        let md043 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD043")) {
+            md043::MD043::from_config(cfg)
+        } else {
+            md043::MD043::default()
+        };
+        registry.register(Box::new(md043));
+
+        // MD044 - proper names should have correct capitalization
+        let md044 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD044")) {
+            md044::MD044::from_config(cfg)
+        } else {
+            md044::MD044::default()
+        };
+        registry.register(Box::new(md044));
+
         registry.register(Box::new(md045::MD045));
-        registry.register(Box::new(md046::MD046::default()));
+
+        // MD046 - code block style consistency
+        let md046 = if let Some(cfg) = config.and_then(|c| c.rule_configs.get("MD046")) {
+            md046::MD046::from_config(cfg)
+        } else {
+            md046::MD046::default()
+        };
+        registry.register(Box::new(md046));
         registry.register(Box::new(md047::MD047));
         registry.register(Box::new(md048::MD048::default()));
         registry.register(Box::new(md049::MD049::default()));


### PR DESCRIPTION
## Summary

This PR implements configuration support for batch 3 rules as defined in issue #173.

## Changes

### Rules Updated

- **MD035**: Horizontal rule style configuration (`style` parameter)
- **MD036**: Emphasis used instead of heading configuration (`punctuation` parameter)
- **MD043**: Required heading structure configuration (`headings` array parameter)
- **MD044**: Proper names capitalization configuration (`names` map parameter)
- **MD046**: Code block style consistency configuration (`style` parameter)

### Implementation Details

1. Added `from_config` methods to all batch 3 rules that parse TOML configuration
2. Updated `StandardRuleProvider::register_rules_with_config` to apply batch 3 configurations
3. Added comprehensive integration tests for all batch 3 rules

## Testing

- All unit tests pass
- New integration tests verify configuration parsing and application
- Tested various configuration scenarios for each rule

## Related Issues

Resolves #173

## Test Plan

- [x] Unit tests pass
- [x] Integration tests for all batch 3 rules
- [x] cargo fmt and clippy pass