### PR TITLE
fix: preprocessor now properly uses discovered configuration

### DIFF
--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -75,6 +75,19 @@ impl MdBookLint {
                 self.config = Config::from_file(&discovered_path)?;
             }
         }
+        
+        // Recreate the engine with the loaded configuration
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(StandardRuleProvider))
+            .expect("Failed to register standard rules");
+        registry
+            .register_provider(Box::new(MdBookRuleProvider))
+            .expect("Failed to register mdbook rules");
+        self.engine = registry
+            .create_engine_with_config(Some(&self.config.core))
+            .expect("Failed to create configured engine");
+        
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Fixed preprocessor to properly apply discovered configuration files
- Engine is now recreated with loaded configuration instead of using defaults
- Custom settings like line-length are now respected in preprocessor mode

## Problem
The preprocessor was discovering config files but not applying the configuration to the linting engine. The engine was created once with default rules and never updated after configuration was loaded.

## Solution
After loading configuration, the engine is now recreated using create_engine_with_config with the discovered configuration. This ensures all custom settings are properly applied.

## Testing
- All existing preprocessor tests pass
- Manual testing confirms custom line-length settings now work in preprocessor mode
- Config discovery message is still shown when a config file is found

Fixes #160