### PR TITLE
feat: implement auto-fix support for all rules with fixes

### DIFF
--- a/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
+++ b/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
@@ -335,8 +335,8 @@ fn test_fix_no_fixable_violations() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = temp_dir.path().join("test.md");
 
-    // Create content that has violations but no fixable ones (multiple blank lines)
-    fs::write(&test_file, "# Test Document\n\n\n\nContent here.\n\n\n").unwrap();
+    // Create content that has violations but no fixable ones (MD033 - inline HTML has no fix)
+    fs::write(&test_file, "# Test Document\n\nThis has <b>inline HTML</b> which violates MD033.\n").unwrap();
 
     let assert = cli_command()
         .arg("lint")
@@ -366,7 +366,7 @@ fn test_fix_no_fixable_violations() {
     // Verify file content is unchanged
     let content = fs::read_to_string(&test_file).unwrap();
     assert!(
-        content.contains("\n\n\n"),
+        content.contains("<b>inline HTML</b>"),
         "Content should be unchanged when no fixes applied"
     );
 

--- a/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
+++ b/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
@@ -336,7 +336,11 @@ fn test_fix_no_fixable_violations() {
     let test_file = temp_dir.path().join("test.md");
 
     // Create content that has violations but no fixable ones (MD033 - inline HTML has no fix)
-    fs::write(&test_file, "# Test Document\n\nThis has <b>inline HTML</b> which violates MD033.\n").unwrap();
+    fs::write(
+        &test_file,
+        "# Test Document\n\nThis has <b>inline HTML</b> which violates MD033.\n",
+    )
+    .unwrap();
 
     let assert = cli_command()
         .arg("lint")


### PR DESCRIPTION
## Summary
- Rewrote fix implementation to use actual Fix objects from violations
- Now applies fixes from all 12 rules that have fix implementations
- Properly handles replace, insert, and delete operations

## Problem
The --fix option was only applying fixes for MD009 (trailing spaces) even though 12 rules have fix implementations. The code was using a simplified approach with SimpleFix struct that filtered out all other fixes.

## Solution
- Removed SimpleFix struct and get_simple_fix filtering function
- Rewritten apply_fixes_to_content to use the actual Fix objects from violations
- Implemented proper line/column to byte offset conversion
- Sorts fixes by position (descending) to avoid offset issues

## Fixes Now Work For
- MD009: Trailing spaces
- MD010: Hard tabs (converts to spaces)
- MD012: Multiple blank lines
- MD018: No space after hash in heading
- MD019: Multiple spaces after hash in heading
- MD020: No spaces inside hashes in closed ATX heading
- MD021: Multiple spaces inside hashes in closed ATX heading
- MD023: Headings not starting at beginning of line
- MD027: Multiple spaces after blockquote symbol
- MD030: Spaces after list markers
- MD034: Bare URLs (wraps in angle brackets)
- MD047: Missing trailing newline

## Testing
Tested with a comprehensive markdown file containing violations for all fixable rules. 15 out of 19 violations were successfully fixed (the remaining ones don't have fix implementations yet).

## Example
Before: 15 fixes applied across 1 file
After: All 12 rules with fix implementations now work

Fixes #183
Addresses user feedback from #175