### PR TITLE
docs: final documentation updates for v0.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mdbook-lint --version
 
 - ✅ **Native mdBook integration** - Seamless preprocessor integration
 - ✅ **67 linting rules** - 54 standard markdown + 13 mdBook-specific rules  
-- ✅ **Auto-fix support** - Automatically fix 13+ common issues
+- ✅ **Auto-fix support** - Automatically fix common issues with 12 rules
 - ✅ **Fast performance** - Lint entire books in seconds
 - ✅ **Configurable** - Disable rules, set custom parameters
 - ✅ **Cross-platform** - Prebuilt binaries for all major platforms
@@ -74,15 +74,23 @@ mdbook-lint rules
 
 ## Configuration
 
-Create a `.mdbook-lint.toml` file:
+Create a `.mdbook-lint.toml` file (also supports YAML/JSON):
 
 ```toml
+# Enable only specific rules
+[rules]
+default = false
+[rules.enabled]
+MD001 = true
+MD009 = true
+
+# Or use traditional configuration
 fail-on-warnings = true
-disabled-rules = ["MD013"]  # Disable line length rule
+disabled-rules = ["MD013"]
 
 # Configure specific rules
-[rules.MD007]
-indent = 4  # Use 4 spaces for list indentation
+[MD007]
+indent = 4
 
 [rules.MD009] 
 br_spaces = 2  # Allow 2 trailing spaces for line breaks

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -46,7 +46,7 @@ fail-on-warnings = true
 disabled-rules = ["MD013"]  # Allow long lines
 
 # Configure specific rules
-[rules.MD007]
+[MD007]
 indent = 4  # Use 4-space indentation for lists
 ```
 
@@ -81,9 +81,17 @@ mdbook-lint lint --fix --dry-run docs/
 mdbook-lint lint --fix-unsafe docs/
 ```
 
-Currently supported fixes:
-- **MD009**: Removes trailing whitespace
-- More fixes coming in future releases!
+Currently supported fixes include:
+- **MD009**: Trailing spaces
+- **MD010**: Hard tabs → spaces
+- **MD012**: Multiple blank lines
+- **MD018/MD019**: Heading spacing issues
+- **MD023**: Indented headings
+- **MD027**: Blockquote spacing
+- **MD030**: List marker spacing
+- **MD034**: Bare URLs
+- **MD047**: Missing trailing newline
+- And more!
 
 ## Common Workflow
 


### PR DESCRIPTION
## Summary
Final documentation updates that were missed in #187 merge.

## Changes
- ✅ Update README with latest features (12 rules with auto-fix)
- ✅ Update README configuration example to show `[rules]` section
- ✅ Update getting-started guide with accurate auto-fix list
- ✅ Fix configuration example format

These commits were pushed to the docs/configuration-update branch after #187 was merged, so they need to be added separately.