### PR TITLE
fix: resolve release-plz workspace dependency issues

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release
 permissions:
   pull-requests: write
   contents: write
+  packages: write  # Required for crates.io publishing
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ mdbook = { version = "0.4", default-features = false }
 # Utilities
 walkdir = "2.3"
 
+# Internal workspace crates
+mdbook-lint-core = { version = "0.11.4", path = "crates/mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.11.4", path = "crates/mdbook-lint-rulesets" }
 
 # Dev dependencies
 tempfile = "3.0"

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -41,8 +41,8 @@ tower-lsp = { version = "0.20", optional = true }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "io-util", "io-std", "net", "time"], optional = true }
 
 # Local workspace crates  
-mdbook-lint-core = { version = "0.11.4", path = "../mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.11.4", path = "../mdbook-lint-rulesets" }
+mdbook-lint-core = { workspace = true }
+mdbook-lint-rulesets = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -21,7 +21,7 @@ mdbook = ["dep:mdbook"]   # mdBook-specific rules (MDBOOK001-007)
 
 [dependencies]
 # Local workspace crates
-mdbook-lint-core = { version = "0.11.4", path = "../mdbook-lint-core" }
+mdbook-lint-core = { workspace = true }
 
 # Core dependencies
 anyhow = { workspace = true }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,13 +8,19 @@ dependencies_update = false
 # Publishing to crates.io
 publish = true
 
-# Ensure all packages are published before creating the tag
-publish_timeout = "10m"
+# Increased timeout for publishing multiple crates
+publish_timeout = "15m"
 
 # Only create a single tag/release for the workspace after all crates are published
 git_release_enable = true
 git_tag_enable = true
 git_tag_name = "v{{ version }}"
+
+# Safer for workspace projects - don't always release
+release_always = false
+
+# Explicit changelog setting (we don't use CHANGELOG.md)
+changelog_update = false
 
 # Disable individual package releases to avoid tag conflicts
 [[package]]


### PR DESCRIPTION
Fixes #191 

## Problem
Release automation using release-plz has been unreliable, with crates publishing to crates.io but GitHub releases/tags not being created, requiring manual intervention.

## Root Cause
The workspace crates had hardcoded version dependencies instead of using workspace references. This prevented release-plz from properly managing version updates during the release process.

## Solution

### 1. Fixed Workspace Dependencies (CRITICAL)
- Added internal crates to `[workspace.dependencies]` in root Cargo.toml
- Updated crates to use `workspace = true` for internal dependencies
- This allows release-plz to manage versions properly

### 2. Improved release-plz.toml Configuration
- Increased `publish_timeout` from 10m to 15m for reliability
- Added `release_always = false` for safer workspace releases  
- Added explicit `changelog_update = false` (we don't use CHANGELOG.md)

### 3. Fixed GitHub Actions Permissions
- Added `packages: write` permission for crates.io publishing

## Testing
- ✅ `cargo check --all-targets` passes
- ✅ `cargo test --lib --all-features` passes
- ✅ Workspace builds correctly with new dependency structure

## Expected Outcome
After this fix, the release process should:
1. Automatically bump versions across all workspace crates
2. Publish all crates to crates.io in correct order
3. Create git tag and GitHub release
4. Trigger binary builds automatically

No more manual intervention should be required for releases.

## References
- Detailed analysis: https://github.com/joshrotenberg/mdbook-lint/issues/191#issuecomment-3235678017
- release-plz workspace docs: https://release-plz.dev/docs/workspace