### PR TITLE
feat: Phase 1 auto-fix batch - MD004 and MD011

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md004.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md004.rs
@@ -515,7 +515,7 @@ Regular list:
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2);
-        
+
         // Check first fix (+ to *)
         assert!(violations[0].fix.is_some());
         let fix1 = violations[0].fix.as_ref().unwrap();
@@ -523,7 +523,7 @@ Regular list:
         assert_eq!(fix1.replacement, Some("* Item 2".to_string()));
         assert_eq!(fix1.start.line, 4);
         assert_eq!(fix1.start.column, 1);
-        
+
         // Check second fix (- to *)
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
@@ -545,13 +545,13 @@ Regular list:
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2);
-        
+
         // Both should have fixes to change * to -
         assert!(violations[0].fix.is_some());
         let fix1 = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix1.description, "Replace '*' with '-'");
         assert_eq!(fix1.replacement, Some("- Item 1".to_string()));
-        
+
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
         assert_eq!(fix2.description, "Replace '*' with '-'");
@@ -571,12 +571,12 @@ Regular list:
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2);
-        
+
         // Check that indentation is preserved in the fix
         assert!(violations[0].fix.is_some());
         let fix1 = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix1.replacement, Some("  * Nested item".to_string()));
-        
+
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
         assert_eq!(fix2.replacement, Some("  * Another nested".to_string()));

--- a/crates/mdbook-lint-rulesets/src/standard/md011.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md011.rs
@@ -336,10 +336,16 @@ This is a (reversed link)[https://example.com] here.
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.description, "Fix reversed link: [reversed link](https://example.com)");
-        assert_eq!(fix.replacement, Some("[reversed link](https://example.com)".to_string()));
+        assert_eq!(
+            fix.description,
+            "Fix reversed link: [reversed link](https://example.com)"
+        );
+        assert_eq!(
+            fix.replacement,
+            Some("[reversed link](https://example.com)".to_string())
+        );
         assert_eq!(fix.start.line, 3);
         assert_eq!(fix.start.column, 11); // Position of opening paren
     }
@@ -355,12 +361,12 @@ First (link one)[url1] and then (link two)[url2] here.
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2);
-        
+
         // First link fix
         assert!(violations[0].fix.is_some());
         let fix1 = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix1.replacement, Some("[link one](url1)".to_string()));
-        
+
         // Second link fix
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
@@ -379,7 +385,7 @@ This ()[https://example.com] has empty text.
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.replacement, Some("[](https://example.com)".to_string()));
     }
@@ -396,11 +402,14 @@ Check this (documentation)[https://example.com/path?param=value&other=test#ancho
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(
-            fix.replacement, 
-            Some("[documentation](https://example.com/path?param=value&other=test#anchor)".to_string())
+            fix.replacement,
+            Some(
+                "[documentation](https://example.com/path?param=value&other=test#anchor)"
+                    .to_string()
+            )
         );
     }
 
@@ -416,7 +425,7 @@ Some text before (reversed)[url] and text after.
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.start.line, 3);
         assert_eq!(fix.start.column, 18); // Position of opening paren


### PR DESCRIPTION
## Summary
- Implements auto-fix support for MD004 (unordered list style) and MD011 (reversed link syntax)
- Part of Phase 1 auto-fix implementation for feature parity with markdownlint
- Addresses #19

## Changes

### MD004: Unordered list style consistency
- Detects current list marker style (*, +, or -)
- Replaces inconsistent markers with expected style  
- Supports both configured style enforcement and consistent mode
- Preserves line content and only changes the marker character

### MD011: Reversed link syntax
- Detects incorrect `(text)[url]` pattern
- Converts to correct `[text](url)` format
- Handles edge cases including empty text and complex URLs
- Skips code blocks and inline code spans

## Test plan
- [x] All existing tests pass
- [x] Manual testing with test files confirms fixes work correctly
- [x] `cargo fmt` and `cargo clippy` pass without warnings

### Test MD004:
```bash
echo "* Item 1
+ Item 2  
- Item 3" | mdbook-lint lint --enable MD004 --fix -
```
Results in all items using `*` marker

### Test MD011:
```bash
echo "This is a (reversed link)[https://example.com]" | mdbook-lint lint --enable MD011 --fix -
```
Results in `[reversed link](https://example.com)`

## Related Issues
- Addresses #19 (Auto-fix tracking issue)
- Part of Phase 1 "easy wins" implementation