### PR TITLE
feat: add auto-fix support for MD005, MD006, and MD007

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md005.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md005.rs
@@ -76,11 +76,7 @@ impl MD005 {
                 {
                     // Check if this item's indentation matches
                     // Create fix by adjusting indentation to match expected
-                    let spaces_to_adjust = if actual_indent > expected {
-                        actual_indent - expected
-                    } else {
-                        expected - actual_indent
-                    };
+                    let spaces_to_adjust = actual_indent.abs_diff(expected);
 
                     let fixed_line = if actual_indent > expected {
                         // Remove extra spaces

--- a/crates/mdbook-lint-rulesets/src/standard/md006.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md006.rs
@@ -130,7 +130,7 @@ impl MD006 {
                         && trimmed_after_indent
                             .chars()
                             .nth(1)
-                            .map_or(false, |c| c.is_whitespace())
+                            .is_some_and(|c| c.is_whitespace())
                 } else {
                     false
                 };


### PR DESCRIPTION
## Summary
- Implements auto-fix functionality for three list indentation rules
- Brings mdbook-lint to 19/21 auto-fixable rules (90.5% parity with markdownlint)
- Closes #184 (partially) and advances #19

## Changes

### MD005 - List item indentation consistency
- Fixes inconsistent indentation within the same list level
- Adjusts indentation to match the first item in the list
- Handles both adding and removing spaces

### MD006 - Bulleted lists at beginning of line  
- Removes indentation from top-level unordered list items
- Preserves list content and formatting
- Distinguishes between indented lists and indented code blocks

### MD007 - Unordered list indentation
- Fixes incorrect indentation depth for nested lists
- Supports configurable indent size (default 2 spaces)
- Handles start_indented configuration option

## Test Coverage
Each rule includes comprehensive tests for:
- Basic fix functionality
- Edge cases (tabs, mixed indentation)
- Content preservation
- Multiple violations
- Configuration options

## Test Plan
- [x] All unit tests pass
- [x] cargo fmt applied
- [x] cargo clippy shows no warnings
- [x] Manual testing with sample markdown files