### PR TITLE
feat: enable auto-fix for MD009, MD012, MD027 whitespace rules

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md009.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md009.rs
@@ -141,6 +141,10 @@ impl AstRule for MD009 {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("markdownlint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(
         &self,
         document: &Document,

--- a/crates/mdbook-lint-rulesets/src/standard/md012.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md012.rs
@@ -62,6 +62,10 @@ impl Rule for MD012 {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("markdownlint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_with_ast<'a>(
         &self,
         document: &Document,

--- a/crates/mdbook-lint-rulesets/src/standard/md027.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md027.rs
@@ -30,6 +30,10 @@ impl Rule for MD027 {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_with_ast<'a>(
         &self,
         document: &Document,


### PR DESCRIPTION
## Summary
- Enables auto-fix functionality for MD009, MD012, and MD027
- MD009: Removes trailing spaces from lines (preserves configured line break spaces)
- MD012: Reduces multiple consecutive blank lines to configured maximum
- MD027: Replaces multiple spaces after blockquote symbol with single space

## Implementation Details
All three rules already had comprehensive fix implementations with full test coverage:
- MD009: 16 tests including fix validation, supports configurable line break spaces
- MD012: 17 tests including fix validation, supports configurable maximum blank lines
- MD027: 18 tests including fix validation

The only change needed was adding the `can_fix()` method returning `true` to enable the auto-fix functionality.

## Testing
- 51 total tests pass across the three rules
- All tests verify fix replacements are correct
- Zero clippy warnings
- Proper handling of edge cases:
  - MD009: Preserves configured line break spaces (e.g., 2 spaces for markdown line breaks)
  - MD012: Handles blank lines at start/end of file and between content
  - MD027: Handles nested blockquotes and mixed whitespace

## Configuration Support
All three rules support configuration:
- MD009: `br_spaces` (line break spaces), `strict` mode
- MD012: `maximum` (max consecutive blank lines)
- MD027: Works with all blockquote patterns

This brings the total auto-fix coverage to 30/59 rules (50.8%).

Closes #19 (partially)