### PR TITLE
feat: enable can_fix() for 8 rules with existing fix implementations

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md003.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md003.rs
@@ -84,6 +84,10 @@ impl mdbook_lint_core::rule::AstRule for MD003 {
         RuleMetadata::stable(RuleCategory::Structure).introduced_in("markdownlint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let mut headings = Vec::new();

--- a/crates/mdbook-lint-rulesets/src/standard/md004.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md004.rs
@@ -109,6 +109,10 @@ impl AstRule for MD004 {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let mut expected_style: Option<ListStyle> = None;

--- a/crates/mdbook-lint-rulesets/src/standard/md011.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md011.rs
@@ -30,6 +30,10 @@ impl AstRule for MD011 {
         RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, _ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let mut in_code_block = false;

--- a/crates/mdbook-lint-rulesets/src/standard/md021.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md021.rs
@@ -30,6 +30,10 @@ impl Rule for MD021 {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_with_ast<'a>(
         &self,
         document: &Document,

--- a/crates/mdbook-lint-rulesets/src/standard/md022.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md022.rs
@@ -33,6 +33,10 @@ impl AstRule for MD022 {
         RuleMetadata::stable(RuleCategory::Structure).introduced_in("markdownlint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
 

--- a/crates/mdbook-lint-rulesets/src/standard/md023.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md023.rs
@@ -29,6 +29,10 @@ impl Rule for MD023 {
         RuleMetadata::stable(RuleCategory::Structure).introduced_in("markdownlint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_with_ast<'a>(
         &self,
         document: &Document,

--- a/crates/mdbook-lint-rulesets/src/standard/md030.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md030.rs
@@ -108,6 +108,10 @@ impl Rule for MD030 {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_with_ast<'a>(
         &self,
         document: &Document,

--- a/crates/mdbook-lint-rulesets/src/standard/md034.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md034.rs
@@ -30,6 +30,10 @@ impl AstRule for MD034 {
         RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, _ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let mut in_code_block = false;


### PR DESCRIPTION
## Summary
- Adds `can_fix()` method to 8 rules that already had complete fix implementations
- Rules affected: MD003, MD004, MD011, MD021, MD022, MD023, MD030, MD034
- Increases auto-fix coverage from ~42% to 50.8% (30/59 rules)

## Details
These rules already had working fix implementations using `create_violation_with_fix` but were missing the `can_fix()` method that tells the linter the rule is fixable. Adding this method enables their auto-fix functionality.

### Rules enabled:
- **MD003**: Heading style consistency
- **MD004**: Unordered list style consistency  
- **MD011**: Reversed link syntax
- **MD021**: Multiple spaces inside hashes on closed atx style heading
- **MD022**: Headings should be surrounded by blank lines
- **MD023**: Headings must start at the beginning of the line
- **MD030**: Spaces after list markers
- **MD034**: Bare URL used

## Test plan
- [x] All rule tests pass
- [x] No functionality changes, just enabling existing fixes
- [x] Verified each rule already had complete fix implementation

Part of #19