### PR TITLE
feat: implement auto-fix for heading rules (MD001, MD002, MD024, MD025, MD026)

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md001.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md001.rs
@@ -116,33 +116,50 @@ impl AstRule for MD001 {
                     // Create fix by adjusting the heading level
                     let expected_level = previous_level + 1;
                     let line_content = &document.lines[line - 1];
-                    
+
                     // Determine if it's an ATX heading or Setext
                     let fixed_line = if line_content.trim_start().starts_with('#') {
                         // ATX heading - adjust the number of hashes
                         let trimmed = line_content.trim_start();
-                        let content_start = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
+                        let content_start =
+                            trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
                         let heading_content = if content_start < trimmed.len() {
                             &trimmed[content_start..]
                         } else {
                             ""
                         };
-                        format!("{}{}\n", "#".repeat(expected_level as usize), heading_content)
+                        format!(
+                            "{}{}\n",
+                            "#".repeat(expected_level as usize),
+                            heading_content
+                        )
                     } else {
                         // For simplicity, convert Setext to ATX with correct level
                         let heading_text = document.node_text(heading);
                         let heading_text = heading_text.trim();
                         format!("{} {}\n", "#".repeat(expected_level as usize), heading_text)
                     };
-                    
+
                     let fix = Fix {
-                        description: format!("Change heading level from {} to {}", level, expected_level),
+                        description: format!(
+                            "Change heading level from {} to {}",
+                            level, expected_level
+                        ),
                         replacement: Some(fixed_line),
                         start: Position { line, column: 1 },
-                        end: Position { line, column: line_content.len() + 1 },
+                        end: Position {
+                            line,
+                            column: line_content.len() + 1,
+                        },
                     };
-                    
-                    violations.push(self.create_violation_with_fix(message, line, column, Severity::Error, fix));
+
+                    violations.push(self.create_violation_with_fix(
+                        message,
+                        line,
+                        column,
+                        Severity::Error,
+                        fix,
+                    ));
                 }
 
                 previous_level = level;
@@ -260,10 +277,13 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Change heading level from 3 to 2");
-        assert_eq!(fix.replacement, Some("## Level 3 - skipped level 2\n".to_string()));
+        assert_eq!(
+            fix.replacement,
+            Some("## Level 3 - skipped level 2\n".to_string())
+        );
     }
 
     #[test]
@@ -276,10 +296,13 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Change heading level from 5 to 2");
-        assert_eq!(fix.replacement, Some("## Level 5 - skipped levels\n".to_string()));
+        assert_eq!(
+            fix.replacement,
+            Some("## Level 5 - skipped levels\n".to_string())
+        );
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md001.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md001.rs
@@ -3,7 +3,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::{
     Document,
     rule::{AstRule, RuleCategory, RuleMetadata},
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// MD001: Heading levels should only increment by one level at a time
@@ -74,6 +74,10 @@ impl AstRule for MD001 {
         RuleMetadata::stable(RuleCategory::Structure).introduced_in("markdownlint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let headings = document.headings(ast);
@@ -109,7 +113,36 @@ impl AstRule for MD001 {
                         }
                     );
 
-                    violations.push(self.create_violation(message, line, column, Severity::Error));
+                    // Create fix by adjusting the heading level
+                    let expected_level = previous_level + 1;
+                    let line_content = &document.lines[line - 1];
+                    
+                    // Determine if it's an ATX heading or Setext
+                    let fixed_line = if line_content.trim_start().starts_with('#') {
+                        // ATX heading - adjust the number of hashes
+                        let trimmed = line_content.trim_start();
+                        let content_start = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
+                        let heading_content = if content_start < trimmed.len() {
+                            &trimmed[content_start..]
+                        } else {
+                            ""
+                        };
+                        format!("{}{}\n", "#".repeat(expected_level as usize), heading_content)
+                    } else {
+                        // For simplicity, convert Setext to ATX with correct level
+                        let heading_text = document.node_text(heading);
+                        let heading_text = heading_text.trim();
+                        format!("{} {}\n", "#".repeat(expected_level as usize), heading_text)
+                    };
+                    
+                    let fix = Fix {
+                        description: format!("Change heading level from {} to {}", level, expected_level),
+                        replacement: Some(fixed_line),
+                        start: Position { line, column: 1 },
+                        end: Position { line, column: line_content.len() + 1 },
+                    };
+                    
+                    violations.push(self.create_violation_with_fix(message, line, column, Severity::Error, fix));
                 }
 
                 previous_level = level;
@@ -214,5 +247,44 @@ mod tests {
 
         // Single heading is always OK, regardless of level
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md001_fix_skip_level() {
+        let content = r#"# Level 1
+### Level 3 - skipped level 2
+"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD001;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.description, "Change heading level from 3 to 2");
+        assert_eq!(fix.replacement, Some("## Level 3 - skipped level 2\n".to_string()));
+    }
+
+    #[test]
+    fn test_md001_fix_multiple_skips() {
+        let content = r#"# Level 1
+##### Level 5 - skipped levels"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD001;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.description, "Change heading level from 5 to 2");
+        assert_eq!(fix.replacement, Some("## Level 5 - skipped levels\n".to_string()));
+    }
+
+    #[test]
+    fn test_md001_can_fix() {
+        let rule = MD001;
+        assert!(mdbook_lint_core::AstRule::can_fix(&rule));
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md002.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md002.rs
@@ -8,7 +8,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// Rule to check that the first heading is a top-level heading
@@ -69,6 +69,10 @@ impl AstRule for MD002 {
         .introduced_in("markdownlint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let headings = document.headings(ast);
@@ -91,7 +95,32 @@ impl AstRule for MD002 {
                 }
             );
 
-            violations.push(self.create_violation(message, line, column, Severity::Warning));
+            // Create fix by changing the heading level
+            let line_content = &document.lines[line - 1];
+            
+            let fixed_line = if line_content.trim_start().starts_with('#') {
+                // ATX heading - adjust the number of hashes
+                let trimmed = line_content.trim_start();
+                let content_start = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
+                let heading_content = if content_start < trimmed.len() {
+                    &trimmed[content_start..]
+                } else {
+                    ""
+                };
+                format!("{}{}\n", "#".repeat(self.level as usize), heading_content)
+            } else {
+                // For Setext headings, convert to ATX with correct level
+                format!("{} {}\n", "#".repeat(self.level as usize), heading_text.trim())
+            };
+            
+            let fix = Fix {
+                description: format!("Change first heading level from {} to {}", heading_level, self.level),
+                replacement: Some(fixed_line),
+                start: Position { line, column: 1 },
+                end: Position { line, column: line_content.len() + 1 },
+            };
+            
+            violations.push(self.create_violation_with_fix(message, line, column, Severity::Warning, fix));
         }
 
         Ok(violations)
@@ -212,5 +241,41 @@ mod tests {
         assert_eq!(violations.len(), 1);
         assert!(violations[0].message.contains("should be level 1"));
         assert!(violations[0].message.contains("got level 2"));
+    }
+
+    #[test]
+    fn test_md002_fix_atx_heading() {
+        let content = "## This should be h1\n### This is h3";
+        let document = create_test_document(content);
+        let rule = MD002::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.description, "Change first heading level from 2 to 1");
+        assert_eq!(fix.replacement, Some("# This should be h1\n".to_string()));
+    }
+
+    #[test]
+    fn test_md002_fix_setext_heading() {
+        let content = "First Heading\n--------------\n\nSome text";
+        let document = create_test_document(content);
+        let rule = MD002::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.description, "Change first heading level from 2 to 1");
+        assert_eq!(fix.replacement, Some("# First Heading\n".to_string()));
+    }
+
+    #[test]
+    fn test_md002_can_fix() {
+        let rule = MD002::new();
+        assert!(mdbook_lint_core::AstRule::can_fix(&rule));
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md002.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md002.rs
@@ -97,7 +97,7 @@ impl AstRule for MD002 {
 
             // Create fix by changing the heading level
             let line_content = &document.lines[line - 1];
-            
+
             let fixed_line = if line_content.trim_start().starts_with('#') {
                 // ATX heading - adjust the number of hashes
                 let trimmed = line_content.trim_start();
@@ -110,17 +110,33 @@ impl AstRule for MD002 {
                 format!("{}{}\n", "#".repeat(self.level as usize), heading_content)
             } else {
                 // For Setext headings, convert to ATX with correct level
-                format!("{} {}\n", "#".repeat(self.level as usize), heading_text.trim())
+                format!(
+                    "{} {}\n",
+                    "#".repeat(self.level as usize),
+                    heading_text.trim()
+                )
             };
-            
+
             let fix = Fix {
-                description: format!("Change first heading level from {} to {}", heading_level, self.level),
+                description: format!(
+                    "Change first heading level from {} to {}",
+                    heading_level, self.level
+                ),
                 replacement: Some(fixed_line),
                 start: Position { line, column: 1 },
-                end: Position { line, column: line_content.len() + 1 },
+                end: Position {
+                    line,
+                    column: line_content.len() + 1,
+                },
             };
-            
-            violations.push(self.create_violation_with_fix(message, line, column, Severity::Warning, fix));
+
+            violations.push(self.create_violation_with_fix(
+                message,
+                line,
+                column,
+                Severity::Warning,
+                fix,
+            ));
         }
 
         Ok(violations)
@@ -252,7 +268,7 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Change first heading level from 2 to 1");
         assert_eq!(fix.replacement, Some("# This should be h1\n".to_string()));
@@ -267,7 +283,7 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Change first heading level from 2 to 1");
         assert_eq!(fix.replacement, Some("# First Heading\n".to_string()));

--- a/crates/mdbook-lint-rulesets/src/standard/md024.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md024.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 use std::collections::HashMap;
 
@@ -68,6 +68,10 @@ impl AstRule for MD024 {
         RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
 
@@ -109,14 +113,50 @@ impl MD024 {
                 let normalized_text = self.normalize_heading_text(heading_text);
 
                 if let Some((first_line, _first_column)) = seen_headings.get(&normalized_text) {
-                    violations.push(self.create_violation(
+                    // Create fix by appending a number to make it unique
+                    let line_content = &document.lines[line - 1];
+                    let mut counter = 2;
+                    let mut unique_text = format!("{} {}", heading_text, counter);
+                    let mut normalized_unique = self.normalize_heading_text(&unique_text);
+                    
+                    // Find a unique number to append
+                    while seen_headings.contains_key(&normalized_unique) {
+                        counter += 1;
+                        unique_text = format!("{} {}", heading_text, counter);
+                        normalized_unique = self.normalize_heading_text(&unique_text);
+                    }
+                    
+                    // Build the fixed line
+                    let fixed_line = if line_content.trim_start().starts_with('#') {
+                        // ATX heading
+                        let trimmed = line_content.trim_start();
+                        let hashes_end = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
+                        let hashes = &trimmed[..hashes_end];
+                        format!("{} {}\n", hashes, unique_text)
+                    } else {
+                        // Setext heading - keep original format but change text
+                        format!("{}\n", unique_text)
+                    };
+                    
+                    let fix = Fix {
+                        description: format!("Make heading unique by appending ' {}'", counter),
+                        replacement: Some(fixed_line),
+                        start: Position { line, column: 1 },
+                        end: Position { line, column: line_content.len() + 1 },
+                    };
+                    
+                    violations.push(self.create_violation_with_fix(
                         format!(
                             "Duplicate heading content: '{heading_text}' (first occurrence at line {first_line})"
                         ),
                         line,
                         column,
                         Severity::Warning,
+                        fix,
                     ));
+                    
+                    // Add the unique heading to seen_headings so subsequent duplicates know about it
+                    seen_headings.insert(normalized_unique, (line, column));
                 } else {
                     seen_headings.insert(normalized_text, (line, column));
                 }
@@ -154,14 +194,50 @@ impl MD024 {
                 let level_map = headings_by_level.entry(level).or_default();
 
                 if let Some((first_line, _first_column)) = level_map.get(&normalized_text) {
-                    violations.push(self.create_violation(
+                    // Create fix by appending a number to make it unique
+                    let line_content = &document.lines[line - 1];
+                    let mut counter = 2;
+                    let mut unique_text = format!("{} {}", heading_text, counter);
+                    let mut normalized_unique = self.normalize_heading_text(&unique_text);
+                    
+                    // Find a unique number to append
+                    while level_map.contains_key(&normalized_unique) {
+                        counter += 1;
+                        unique_text = format!("{} {}", heading_text, counter);
+                        normalized_unique = self.normalize_heading_text(&unique_text);
+                    }
+                    
+                    // Build the fixed line
+                    let fixed_line = if line_content.trim_start().starts_with('#') {
+                        // ATX heading
+                        let trimmed = line_content.trim_start();
+                        let hashes_end = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
+                        let hashes = &trimmed[..hashes_end];
+                        format!("{} {}\n", hashes, unique_text)
+                    } else {
+                        // Setext heading - keep original format but change text
+                        format!("{}\n", unique_text)
+                    };
+                    
+                    let fix = Fix {
+                        description: format!("Make heading unique by appending ' {}'", counter),
+                        replacement: Some(fixed_line),
+                        start: Position { line, column: 1 },
+                        end: Position { line, column: line_content.len() + 1 },
+                    };
+                    
+                    violations.push(self.create_violation_with_fix(
                         format!(
                             "Duplicate heading content at level {level}: '{heading_text}' (first occurrence at line {first_line})"
                         ),
                         line,
                         column,
                         Severity::Warning,
+                        fix,
                     ));
+                    
+                    // Add the unique heading to level_map so subsequent duplicates know about it
+                    level_map.insert(normalized_unique, (line, column));
                 } else {
                     level_map.insert(normalized_text, (line, column));
                 }
@@ -429,5 +505,54 @@ ATX Heading
                 .any(|m| m.contains("Getting Started"))
         );
         assert!(violation_texts.iter().any(|m| m.contains("Configuration")));
+    }
+
+    #[test]
+    fn test_md024_fix_duplicate_headings() {
+        let content = r#"# Introduction
+## Setup
+## Setup
+### Details"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD024::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.description, "Make heading unique by appending ' 2'");
+        assert_eq!(fix.replacement, Some("## Setup 2\n".to_string()));
+    }
+
+    #[test]
+    fn test_md024_fix_multiple_duplicates() {
+        let content = r#"# Title
+## Config
+## Config
+## Config"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD024::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        
+        // First duplicate gets 2
+        assert!(violations[0].fix.is_some());
+        let fix1 = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix1.description, "Make heading unique by appending ' 2'");
+        assert_eq!(fix1.replacement, Some("## Config 2\n".to_string()));
+        
+        // Second duplicate gets 3
+        assert!(violations[1].fix.is_some());
+        let fix2 = violations[1].fix.as_ref().unwrap();
+        assert_eq!(fix2.description, "Make heading unique by appending ' 3'");
+        assert_eq!(fix2.replacement, Some("## Config 3\n".to_string()));
+    }
+
+    #[test]
+    fn test_md024_can_fix() {
+        let rule = MD024::new();
+        assert!(mdbook_lint_core::AstRule::can_fix(&rule));
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md024.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md024.rs
@@ -118,14 +118,14 @@ impl MD024 {
                     let mut counter = 2;
                     let mut unique_text = format!("{} {}", heading_text, counter);
                     let mut normalized_unique = self.normalize_heading_text(&unique_text);
-                    
+
                     // Find a unique number to append
                     while seen_headings.contains_key(&normalized_unique) {
                         counter += 1;
                         unique_text = format!("{} {}", heading_text, counter);
                         normalized_unique = self.normalize_heading_text(&unique_text);
                     }
-                    
+
                     // Build the fixed line
                     let fixed_line = if line_content.trim_start().starts_with('#') {
                         // ATX heading
@@ -137,14 +137,17 @@ impl MD024 {
                         // Setext heading - keep original format but change text
                         format!("{}\n", unique_text)
                     };
-                    
+
                     let fix = Fix {
                         description: format!("Make heading unique by appending ' {}'", counter),
                         replacement: Some(fixed_line),
                         start: Position { line, column: 1 },
-                        end: Position { line, column: line_content.len() + 1 },
+                        end: Position {
+                            line,
+                            column: line_content.len() + 1,
+                        },
                     };
-                    
+
                     violations.push(self.create_violation_with_fix(
                         format!(
                             "Duplicate heading content: '{heading_text}' (first occurrence at line {first_line})"
@@ -154,7 +157,7 @@ impl MD024 {
                         Severity::Warning,
                         fix,
                     ));
-                    
+
                     // Add the unique heading to seen_headings so subsequent duplicates know about it
                     seen_headings.insert(normalized_unique, (line, column));
                 } else {
@@ -199,14 +202,14 @@ impl MD024 {
                     let mut counter = 2;
                     let mut unique_text = format!("{} {}", heading_text, counter);
                     let mut normalized_unique = self.normalize_heading_text(&unique_text);
-                    
+
                     // Find a unique number to append
                     while level_map.contains_key(&normalized_unique) {
                         counter += 1;
                         unique_text = format!("{} {}", heading_text, counter);
                         normalized_unique = self.normalize_heading_text(&unique_text);
                     }
-                    
+
                     // Build the fixed line
                     let fixed_line = if line_content.trim_start().starts_with('#') {
                         // ATX heading
@@ -218,14 +221,17 @@ impl MD024 {
                         // Setext heading - keep original format but change text
                         format!("{}\n", unique_text)
                     };
-                    
+
                     let fix = Fix {
                         description: format!("Make heading unique by appending ' {}'", counter),
                         replacement: Some(fixed_line),
                         start: Position { line, column: 1 },
-                        end: Position { line, column: line_content.len() + 1 },
+                        end: Position {
+                            line,
+                            column: line_content.len() + 1,
+                        },
                     };
-                    
+
                     violations.push(self.create_violation_with_fix(
                         format!(
                             "Duplicate heading content at level {level}: '{heading_text}' (first occurrence at line {first_line})"
@@ -235,7 +241,7 @@ impl MD024 {
                         Severity::Warning,
                         fix,
                     ));
-                    
+
                     // Add the unique heading to level_map so subsequent duplicates know about it
                     level_map.insert(normalized_unique, (line, column));
                 } else {
@@ -519,7 +525,7 @@ ATX Heading
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Make heading unique by appending ' 2'");
         assert_eq!(fix.replacement, Some("## Setup 2\n".to_string()));
@@ -536,13 +542,13 @@ ATX Heading
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2);
-        
+
         // First duplicate gets 2
         assert!(violations[0].fix.is_some());
         let fix1 = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix1.description, "Make heading unique by appending ' 2'");
         assert_eq!(fix1.replacement, Some("## Config 2\n".to_string()));
-        
+
         // Second duplicate gets 3
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();

--- a/crates/mdbook-lint-rulesets/src/standard/md025.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md025.rs
@@ -89,7 +89,7 @@ impl AstRule for MD025 {
                 // Create fix by demoting to level 2
                 let line_content = &document.lines[*line - 1];
                 let new_level = self.level + 1;
-                
+
                 let fixed_line = if line_content.trim_start().starts_with('#') {
                     // ATX heading - add one more hash
                     let trimmed = line_content.trim_start();
@@ -104,14 +104,20 @@ impl AstRule for MD025 {
                     // Setext heading - convert to ATX at level 2
                     format!("{} {}\n", "#".repeat(new_level as usize), heading_text)
                 };
-                
+
                 let fix = Fix {
                     description: format!("Demote heading to level {}", new_level),
                     replacement: Some(fixed_line),
-                    start: Position { line: *line, column: 1 },
-                    end: Position { line: *line, column: line_content.len() + 1 },
+                    start: Position {
+                        line: *line,
+                        column: 1,
+                    },
+                    end: Position {
+                        line: *line,
+                        column: line_content.len() + 1,
+                    },
                 };
-                
+
                 violations.push(self.create_violation_with_fix(
                     format!(
                         "Multiple top-level headings in the same document (first at line {}): {}",
@@ -345,13 +351,13 @@ More content.
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2); // Second and third H1s
-        
+
         // First extra H1 gets demoted to H2
         assert!(violations[0].fix.is_some());
         let fix1 = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix1.description, "Demote heading to level 2");
         assert_eq!(fix1.replacement, Some("## Second Title\n".to_string()));
-        
+
         // Second extra H1 also gets demoted to H2
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();

--- a/crates/mdbook-lint-rulesets/src/standard/md026.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md026.rs
@@ -96,8 +96,9 @@ impl AstRule for MD026 {
                 {
                     // Create fix by removing trailing punctuation
                     let line_content = &document.lines[line - 1];
-                    let heading_without_punct = heading_text.trim_end_matches(|c| self.is_punctuation(c));
-                    
+                    let heading_without_punct =
+                        heading_text.trim_end_matches(|c| self.is_punctuation(c));
+
                     let fixed_line = if line_content.trim_start().starts_with('#') {
                         // ATX heading
                         let trimmed = line_content.trim_start();
@@ -107,8 +108,16 @@ impl AstRule for MD026 {
                         let content_after_hashes = &trimmed[hashes_end..];
                         if content_after_hashes.trim_end().ends_with('#') {
                             // Closed ATX - preserve closing hashes
-                            let closing_hashes_start = content_after_hashes.rfind(|c: char| c != '#' && !c.is_whitespace()).map(|i| i + 1).unwrap_or(0);
-                            format!("{} {} {}\n", hashes, heading_without_punct, content_after_hashes[closing_hashes_start..].trim())
+                            let closing_hashes_start = content_after_hashes
+                                .rfind(|c: char| c != '#' && !c.is_whitespace())
+                                .map(|i| i + 1)
+                                .unwrap_or(0);
+                            format!(
+                                "{} {} {}\n",
+                                hashes,
+                                heading_without_punct,
+                                content_after_hashes[closing_hashes_start..].trim()
+                            )
                         } else {
                             format!("{} {}\n", hashes, heading_without_punct)
                         }
@@ -116,14 +125,17 @@ impl AstRule for MD026 {
                         // Setext heading - just replace the text
                         format!("{}\n", heading_without_punct)
                     };
-                    
+
                     let fix = Fix {
                         description: format!("Remove trailing punctuation '{}'", last_char),
                         replacement: Some(fixed_line),
                         start: Position { line, column: 1 },
-                        end: Position { line, column: line_content.len() + 1 },
+                        end: Position {
+                            line,
+                            column: line_content.len() + 1,
+                        },
                     };
-                    
+
                     violations.push(self.create_violation_with_fix(
                         format!(
                             "Heading should not end with punctuation '{last_char}': {heading_text}"
@@ -389,18 +401,24 @@ Another setext with question?
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2);
-        
+
         // First heading - remove !
         assert!(violations[0].fix.is_some());
         let fix1 = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix1.description, "Remove trailing punctuation '!'");
-        assert_eq!(fix1.replacement, Some("# Heading with exclamation\n".to_string()));
-        
+        assert_eq!(
+            fix1.replacement,
+            Some("# Heading with exclamation\n".to_string())
+        );
+
         // Second heading - remove .
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
         assert_eq!(fix2.description, "Remove trailing punctuation '.'");
-        assert_eq!(fix2.replacement, Some("## Another with period\n".to_string()));
+        assert_eq!(
+            fix2.replacement,
+            Some("## Another with period\n".to_string())
+        );
     }
 
     #[test]
@@ -412,10 +430,13 @@ Another setext with question?
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         // Should remove all trailing punctuation
-        assert_eq!(fix.replacement, Some("# Heading with multiple\n".to_string()));
+        assert_eq!(
+            fix.replacement,
+            Some("# Heading with multiple\n".to_string())
+        );
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md026.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md026.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// Rule to check that headings do not end with punctuation
@@ -70,6 +70,10 @@ impl AstRule for MD026 {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("mdbook-lint v0.1.0")
     }
 
+    fn can_fix(&self) -> bool {
+        true
+    }
+
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
 
@@ -90,13 +94,44 @@ impl AstRule for MD026 {
                 if let Some(last_char) = heading_text.chars().last()
                     && self.is_punctuation(last_char)
                 {
-                    violations.push(self.create_violation(
+                    // Create fix by removing trailing punctuation
+                    let line_content = &document.lines[line - 1];
+                    let heading_without_punct = heading_text.trim_end_matches(|c| self.is_punctuation(c));
+                    
+                    let fixed_line = if line_content.trim_start().starts_with('#') {
+                        // ATX heading
+                        let trimmed = line_content.trim_start();
+                        let hashes_end = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
+                        let hashes = &trimmed[..hashes_end];
+                        // Check if it's a closed ATX heading (ends with hashes)
+                        let content_after_hashes = &trimmed[hashes_end..];
+                        if content_after_hashes.trim_end().ends_with('#') {
+                            // Closed ATX - preserve closing hashes
+                            let closing_hashes_start = content_after_hashes.rfind(|c: char| c != '#' && !c.is_whitespace()).map(|i| i + 1).unwrap_or(0);
+                            format!("{} {} {}\n", hashes, heading_without_punct, content_after_hashes[closing_hashes_start..].trim())
+                        } else {
+                            format!("{} {}\n", hashes, heading_without_punct)
+                        }
+                    } else {
+                        // Setext heading - just replace the text
+                        format!("{}\n", heading_without_punct)
+                    };
+                    
+                    let fix = Fix {
+                        description: format!("Remove trailing punctuation '{}'", last_char),
+                        replacement: Some(fixed_line),
+                        start: Position { line, column: 1 },
+                        end: Position { line, column: line_content.len() + 1 },
+                    };
+                    
+                    violations.push(self.create_violation_with_fix(
                         format!(
                             "Heading should not end with punctuation '{last_char}': {heading_text}"
                         ),
                         line,
                         column,
                         Severity::Warning,
+                        fix,
                     ));
                 }
             }
@@ -344,5 +379,48 @@ Another setext with question?
                 .contains("should not end with punctuation '.'")
         );
         assert_eq!(violations[0].line, 8);
+    }
+
+    #[test]
+    fn test_md026_fix_trailing_punctuation() {
+        let content = "# Heading with exclamation!\n## Another with period.";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD026::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 2);
+        
+        // First heading - remove !
+        assert!(violations[0].fix.is_some());
+        let fix1 = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix1.description, "Remove trailing punctuation '!'");
+        assert_eq!(fix1.replacement, Some("# Heading with exclamation\n".to_string()));
+        
+        // Second heading - remove .
+        assert!(violations[1].fix.is_some());
+        let fix2 = violations[1].fix.as_ref().unwrap();
+        assert_eq!(fix2.description, "Remove trailing punctuation '.'");
+        assert_eq!(fix2.replacement, Some("## Another with period\n".to_string()));
+    }
+
+    #[test]
+    fn test_md026_fix_multiple_punctuation() {
+        let content = "# Heading with multiple...";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD026::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        
+        let fix = violations[0].fix.as_ref().unwrap();
+        // Should remove all trailing punctuation
+        assert_eq!(fix.replacement, Some("# Heading with multiple\n".to_string()));
+    }
+
+    #[test]
+    fn test_md026_can_fix() {
+        let rule = MD026::new();
+        assert!(mdbook_lint_core::AstRule::can_fix(&rule));
     }
 }


### PR DESCRIPTION
## Summary
Implements auto-fix functionality for 5 heading-related rules, bringing us to 29/59 rules (49.2%) with auto-fix support.

## Rules Implemented
- **MD001**: Heading levels should only increment by one level at a time
  - Fix: Adjusts heading level to the expected increment
- **MD002**: First heading should be a top-level heading  
  - Fix: Changes first heading to configured level (default h1)
- **MD024**: Multiple headings with the same content
  - Fix: Appends numbers (2, 3, etc.) to make headings unique
- **MD025**: Multiple top-level headings in the same document
  - Fix: Demotes extra h1 headings to h2
- **MD026**: Trailing punctuation in heading
  - Fix: Removes trailing punctuation from heading text

## Implementation Details
- All fixes handle both ATX (`#`) and Setext (`===`/`---`) heading styles
- MD024 correctly handles multiple duplicates by tracking generated unique names
- Comprehensive tests added for each rule's fix functionality
- All existing tests continue to pass

## Test Plan
- [x] All rule tests pass (`cargo test --lib md001 md002 md024 md025 md026`)
- [x] Fix tests verify correct replacements
- [x] Edge cases tested (multiple duplicates, setext headings, etc.)

Part of #19 - Auto-fix implementation tracking