### PR TITLE
feat: add auto-fix for formatting rules (MD014, MD028, MD035, MD045)

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md014.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md014.rs
@@ -8,7 +8,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// Rule to check that shell commands don't include dollar signs
@@ -29,6 +29,10 @@ impl AstRule for MD014 {
 
     fn metadata(&self) -> RuleMetadata {
         RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.1.0")
+    }
+
+    fn can_fix(&self) -> bool {
+        true
     }
 
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
@@ -59,11 +63,43 @@ impl AstRule for MD014 {
                                 && let Some((base_line, _)) = document.node_position(node)
                             {
                                 let actual_line = base_line + line_idx + 1; // +1 because code block content starts on next line
-                                violations.push(self.create_violation(
+                                
+                                // Create fix by removing the $ prompt
+                                let fixed_line = if trimmed.starts_with("$ ") {
+                                    trimmed[2..].to_string()
+                                } else if trimmed == "$" {
+                                    String::new()
+                                } else {
+                                    // Remove $ and any following space
+                                    trimmed[1..].trim_start().to_string()
+                                };
+                                
+                                // Create a fixed version of the entire code block
+                                let fixed_content = lines.iter().enumerate().map(|(idx, l)| {
+                                    if idx == line_idx {
+                                        fixed_line.as_str()
+                                    } else {
+                                        *l
+                                    }
+                                }).collect::<Vec<_>>().join("\n");
+                                
+                                // The fix needs to replace the entire code block content
+                                let fix = Fix {
+                                    description: "Remove dollar sign prompt from command".to_string(),
+                                    replacement: Some(format!("{}\n", fixed_content)),
+                                    start: Position { line: base_line + 1, column: 1 },
+                                    end: Position { 
+                                        line: base_line + lines.len(), 
+                                        column: lines.last().map(|l| l.len() + 1).unwrap_or(1) 
+                                    },
+                                };
+                                
+                                violations.push(self.create_violation_with_fix(
                                     format!("Shell command should not include dollar sign prompt: '{trimmed}'"),
                                     actual_line,
                                     1,
                                     Severity::Warning,
+                                    fix,
                                 ));
                             }
                         }
@@ -430,5 +466,35 @@ $$$multiple
         assert!(!is_command_prompt_dollar("${var}"));
         assert!(!is_command_prompt_dollar("$((math))"));
         assert!(!is_command_prompt_dollar("$_PRIVATE"));
+    }
+
+    #[test]
+    fn test_md014_fix_dollar_prompt() {
+        let content = r#"# Commands with dollar prompts
+
+```bash
+$ echo "hello"
+$ ls -la
+$ cd /home
+```
+"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD014;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 3);
+        
+        // Check fixes
+        for violation in &violations {
+            assert!(violation.fix.is_some());
+            let fix = violation.fix.as_ref().unwrap();
+            assert_eq!(fix.description, "Remove dollar sign prompt from command");
+        }
+    }
+
+    #[test]
+    fn test_md014_can_fix() {
+        let rule = MD014;
+        assert!(mdbook_lint_core::AstRule::can_fix(&rule));
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md014.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md014.rs
@@ -65,7 +65,8 @@ impl AstRule for MD014 {
                                 let actual_line = base_line + line_idx + 1; // +1 because code block content starts on next line
 
                                 // Create fix by removing the $ prompt
-                                let fixed_line = if let Some(stripped) = trimmed.strip_prefix("$ ") {
+                                let fixed_line = if let Some(stripped) = trimmed.strip_prefix("$ ")
+                                {
                                     stripped.to_string()
                                 } else if trimmed == "$" {
                                     String::new()

--- a/crates/mdbook-lint-rulesets/src/standard/md014.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md014.rs
@@ -63,7 +63,7 @@ impl AstRule for MD014 {
                                 && let Some((base_line, _)) = document.node_position(node)
                             {
                                 let actual_line = base_line + line_idx + 1; // +1 because code block content starts on next line
-                                
+
                                 // Create fix by removing the $ prompt
                                 let fixed_line = if trimmed.starts_with("$ ") {
                                     trimmed[2..].to_string()
@@ -73,27 +73,36 @@ impl AstRule for MD014 {
                                     // Remove $ and any following space
                                     trimmed[1..].trim_start().to_string()
                                 };
-                                
+
                                 // Create a fixed version of the entire code block
-                                let fixed_content = lines.iter().enumerate().map(|(idx, l)| {
-                                    if idx == line_idx {
-                                        fixed_line.as_str()
-                                    } else {
-                                        *l
-                                    }
-                                }).collect::<Vec<_>>().join("\n");
-                                
+                                let fixed_content = lines
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(idx, l)| {
+                                        if idx == line_idx {
+                                            fixed_line.as_str()
+                                        } else {
+                                            *l
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n");
+
                                 // The fix needs to replace the entire code block content
                                 let fix = Fix {
-                                    description: "Remove dollar sign prompt from command".to_string(),
+                                    description: "Remove dollar sign prompt from command"
+                                        .to_string(),
                                     replacement: Some(format!("{}\n", fixed_content)),
-                                    start: Position { line: base_line + 1, column: 1 },
-                                    end: Position { 
-                                        line: base_line + lines.len(), 
-                                        column: lines.last().map(|l| l.len() + 1).unwrap_or(1) 
+                                    start: Position {
+                                        line: base_line + 1,
+                                        column: 1,
+                                    },
+                                    end: Position {
+                                        line: base_line + lines.len(),
+                                        column: lines.last().map(|l| l.len() + 1).unwrap_or(1),
                                     },
                                 };
-                                
+
                                 violations.push(self.create_violation_with_fix(
                                     format!("Shell command should not include dollar sign prompt: '{trimmed}'"),
                                     actual_line,
@@ -483,7 +492,7 @@ $ cd /home
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 3);
-        
+
         // Check fixes
         for violation in &violations {
             assert!(violation.fix.is_some());

--- a/crates/mdbook-lint-rulesets/src/standard/md014.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md014.rs
@@ -65,13 +65,16 @@ impl AstRule for MD014 {
                                 let actual_line = base_line + line_idx + 1; // +1 because code block content starts on next line
 
                                 // Create fix by removing the $ prompt
-                                let fixed_line = if trimmed.starts_with("$ ") {
-                                    trimmed[2..].to_string()
+                                let fixed_line = if let Some(stripped) = trimmed.strip_prefix("$ ") {
+                                    stripped.to_string()
                                 } else if trimmed == "$" {
                                     String::new()
-                                } else {
+                                } else if let Some(stripped) = trimmed.strip_prefix('$') {
                                     // Remove $ and any following space
-                                    trimmed[1..].trim_start().to_string()
+                                    stripped.trim_start().to_string()
+                                } else {
+                                    // Shouldn't happen, but handle gracefully
+                                    trimmed.to_string()
                                 };
 
                                 // Create a fixed version of the entire code block

--- a/crates/mdbook-lint-rulesets/src/standard/md028.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md028.rs
@@ -75,10 +75,16 @@ impl Rule for MD028 {
                     let fix = Fix {
                         description: "Add blockquote marker to blank line".to_string(),
                         replacement: Some(">\n".to_string()),
-                        start: Position { line: line_num, column: 1 },
-                        end: Position { line: line_num, column: line.len() + 1 },
+                        start: Position {
+                            line: line_num,
+                            column: 1,
+                        },
+                        end: Position {
+                            line: line_num,
+                            column: line.len() + 1,
+                        },
                     };
-                    
+
                     violations.push(self.create_violation_with_fix(
                         "Blank line inside blockquote".to_string(),
                         line_num,
@@ -307,7 +313,7 @@ The end.
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Add blockquote marker to blank line");
         assert_eq!(fix.replacement, Some(">\n".to_string()));

--- a/crates/mdbook-lint-rulesets/src/standard/md028.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md028.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Severity, Violation},
+    violation::{Fix, Position, Severity, Violation},
 };
 
 /// Rule to check for blank lines inside blockquotes
@@ -28,6 +28,10 @@ impl Rule for MD028 {
 
     fn metadata(&self) -> RuleMetadata {
         RuleMetadata::stable(RuleCategory::Formatting).introduced_in("mdbook-lint v0.1.0")
+    }
+
+    fn can_fix(&self) -> bool {
+        true
     }
 
     fn check_with_ast<'a>(
@@ -67,11 +71,20 @@ impl Rule for MD028 {
                 // If we have blockquote lines before and after this blank line,
                 // then this blank line breaks the blockquote
                 if prev_is_blockquote && next_is_blockquote {
-                    violations.push(self.create_violation(
+                    // Create fix by adding > to the blank line
+                    let fix = Fix {
+                        description: "Add blockquote marker to blank line".to_string(),
+                        replacement: Some(">\n".to_string()),
+                        start: Position { line: line_num, column: 1 },
+                        end: Position { line: line_num, column: line.len() + 1 },
+                    };
+                    
+                    violations.push(self.create_violation_with_fix(
                         "Blank line inside blockquote".to_string(),
                         line_num,
                         1,
                         Severity::Warning,
+                        fix,
                     ));
                 }
             }
@@ -280,5 +293,29 @@ The end.
         assert_eq!(violations.len(), 2);
         assert_eq!(violations[0].line, 9); // First improper break
         assert_eq!(violations[1].line, 11); // Second improper break
+    }
+
+    #[test]
+    fn test_md028_fix_blank_lines() {
+        let content = r#"> Start of blockquote
+
+> Continuation after blank
+"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD028;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].fix.is_some());
+        
+        let fix = violations[0].fix.as_ref().unwrap();
+        assert_eq!(fix.description, "Add blockquote marker to blank line");
+        assert_eq!(fix.replacement, Some(">\n".to_string()));
+    }
+
+    #[test]
+    fn test_md028_can_fix() {
+        let rule = MD028;
+        assert!(Rule::can_fix(&rule));
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md035.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md035.rs
@@ -179,14 +179,20 @@ impl Rule for MD035 {
                 let line_content = &document.lines[line_number - 1];
                 let leading_whitespace = line_content.len() - line_content.trim_start().len();
                 let indent = &line_content[..leading_whitespace];
-                
+
                 let fix = Fix {
                     description: format!("Change horizontal rule style to '{}'", expected),
                     replacement: Some(format!("{}{}\n", indent, expected)),
-                    start: Position { line: line_number, column: 1 },
-                    end: Position { line: line_number, column: line_content.len() + 1 },
+                    start: Position {
+                        line: line_number,
+                        column: 1,
+                    },
+                    end: Position {
+                        line: line_number,
+                        column: line_content.len() + 1,
+                    },
                 };
-                
+
                 violations.push(self.create_violation_with_fix(
                     format!(
                         "Horizontal rule style mismatch: Expected '{expected}', found '{canonical_style}'"
@@ -475,7 +481,7 @@ More content
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
-        
+
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Change horizontal rule style to '---'");
         assert_eq!(fix.replacement, Some("---\n".to_string()));
@@ -496,7 +502,7 @@ ___
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 2);
-        
+
         // Both should be fixed to ***
         for violation in &violations {
             assert!(violation.fix.is_some());

--- a/crates/mdbook-lint-rulesets/src/standard/md045.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md045.rs
@@ -72,8 +72,7 @@ impl MD045 {
                 .next()
                 .and_then(|f| f.rsplit('.').nth(1))
                 .unwrap_or("image")
-                .replace('_', " ")
-                .replace('-', " ");
+                .replace(['_', '-'], " ");
 
             // Find the image syntax in the line and replace it
             // Look for ![](url) pattern and replace with ![alt](url)


### PR DESCRIPTION
## Summary
- Add auto-fix capability to 4 formatting rules
- Part of the ongoing effort to make more rules fixable

## Rules Made Fixable
- **MD014**: Remove dollar sign prompts from shell commands in code blocks
- **MD028**: Add blockquote markers to blank lines inside blockquotes  
- **MD035**: Standardize horizontal rule style (---, ***, ___)
- **MD045**: Add placeholder alt text to images based on filename

## Changes
- Implement can_fix() returning true for each rule
- Add fix generation logic with appropriate replacements
- Add comprehensive tests for fix functionality
- All fixes preserve formatting like indentation where applicable

## Testing
- Added tests to verify fixes are generated correctly
- Existing tests continue to pass
- Ran cargo fmt and cargo test

Part of #212 (tracking auto-fix implementation)

## Next Steps
Will implement remaining formatting rules (MD044, MD048, MD050) in a follow-up PR to keep changes reviewable.