### PR TITLE
fix: MD007 now correctly ignores code blocks

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md007.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md007.rs
@@ -1,7 +1,7 @@
-use comrak::nodes::AstNode;
+use comrak::nodes::{AstNode, NodeValue};
 use mdbook_lint_core::Document;
 use mdbook_lint_core::error::Result;
-use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::violation::{Fix, Position, Severity, Violation};
 
 /// MD007 - Unordered list indentation
@@ -154,6 +154,38 @@ impl MD007 {
     fn has_ordered_ancestors(&self, list_stack: &[(usize, char, bool)]) -> bool {
         list_stack.iter().any(|&(_, _, is_ordered)| is_ordered)
     }
+
+    /// Get line ranges for code blocks to skip them
+    fn get_code_block_line_ranges<'a>(
+        &self,
+        ast: &'a AstNode<'a>,
+    ) -> Vec<(usize, usize)> {
+        let mut ranges = Vec::new();
+        self.collect_code_block_ranges(ast, &mut ranges);
+        ranges
+    }
+
+    /// Recursively collect code block line ranges (both fenced and indented)
+    fn collect_code_block_ranges<'a>(
+        &self,
+        node: &'a AstNode<'a>,
+        ranges: &mut Vec<(usize, usize)>,
+    ) {
+        match &node.data.borrow().value {
+            NodeValue::CodeBlock(_) => {
+                // Fenced or indented code block
+                let sourcepos = node.data.borrow().sourcepos;
+                if sourcepos.start.line > 0 && sourcepos.end.line > 0 {
+                    ranges.push((sourcepos.start.line, sourcepos.end.line));
+                }
+            }
+            _ => {}
+        }
+
+        for child in node.children() {
+            self.collect_code_block_ranges(child, ranges);
+        }
+    }
 }
 
 impl Default for MD007 {
@@ -162,7 +194,7 @@ impl Default for MD007 {
     }
 }
 
-impl Rule for MD007 {
+impl AstRule for MD007 {
     fn id(&self) -> &'static str {
         "MD007"
     }
@@ -179,18 +211,34 @@ impl Rule for MD007 {
         RuleMetadata::stable(RuleCategory::Formatting)
     }
 
-    fn check_with_ast<'a>(
+    fn can_fix(&self) -> bool {
+        true
+    }
+
+    fn check_ast<'a>(
         &self,
         document: &Document,
-        _ast: Option<&'a AstNode<'a>>,
+        ast: &'a AstNode<'a>,
     ) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let lines: Vec<&str> = document.content.lines().collect();
+
+        // Get code block line ranges from AST
+        let code_block_lines = self.get_code_block_line_ranges(ast);
 
         let mut list_stack: Vec<(usize, char, bool)> = Vec::new(); // (indent, marker, is_ordered)
 
         for (line_number, line) in lines.iter().enumerate() {
             let line_number = line_number + 1;
+
+            // Skip lines inside code blocks
+            let in_code_block = code_block_lines
+                .iter()
+                .any(|(start, end)| line_number >= *start && line_number <= *end);
+            
+            if in_code_block {
+                continue;
+            }
 
             // Skip empty lines
             if line.trim().is_empty() {
@@ -248,16 +296,12 @@ impl Rule for MD007 {
 
         Ok(violations)
     }
-
-    fn can_fix(&self) -> bool {
-        true
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mdbook_lint_core::Document;
+    use mdbook_lint_core::{Document, rule::Rule};
     use std::path::PathBuf;
 
     #[test]
@@ -595,5 +639,64 @@ mod tests {
             fix2.replacement,
             Some("    * Star item (wrong indent)".to_string())
         );
+    }
+
+    #[test]
+    fn test_md007_ignores_lists_in_code_blocks() {
+        let content = r#"Regular list:
+* Item 1
+  * Item 2
+
+Code block with list:
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - name: Install mdBook and mdbook-lint
+    run: |
+      cargo install mdbook
+      cargo install mdbook-lint
+  - name: Build book
+    run: mdbook build
+```
+
+Another regular list:
+* Item 3
+    * Too much indent (4 spaces)
+"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD007::new();
+        let violations = rule.check(&document).unwrap();
+
+        // Should only have 1 violation for the last list item (too much indent)
+        // Should NOT have violations for the YAML list inside the code block
+        assert_eq!(violations.len(), 1, "Should only flag the regular list item with wrong indent, not the YAML in code block");
+        
+        // Verify it's the right violation (line 19 is the "    * Too much indent" line)
+        assert_eq!(violations[0].line, 19);
+        assert!(violations[0].message.contains("Expected 2 spaces, found 4"));
+    }
+
+    #[test]
+    fn test_md007_ignores_indented_code_blocks() {
+        let content = r#"Regular list:
+* Item 1
+  * Item 2
+
+Indented code block:
+
+    * This is code, not a list
+      * Should not be checked
+        * Even with multiple levels
+
+Another list:
+* Item 3
+  * Correct indent
+"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD007::new();
+        let violations = rule.check(&document).unwrap();
+
+        // Should have no violations - the indented code block should be ignored
+        assert_eq!(violations.len(), 0, "Should not flag items in indented code blocks");
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md007.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md007.rs
@@ -156,10 +156,7 @@ impl MD007 {
     }
 
     /// Get line ranges for code blocks to skip them
-    fn get_code_block_line_ranges<'a>(
-        &self,
-        ast: &'a AstNode<'a>,
-    ) -> Vec<(usize, usize)> {
+    fn get_code_block_line_ranges<'a>(&self, ast: &'a AstNode<'a>) -> Vec<(usize, usize)> {
         let mut ranges = Vec::new();
         self.collect_code_block_ranges(ast, &mut ranges);
         ranges
@@ -215,11 +212,7 @@ impl AstRule for MD007 {
         true
     }
 
-    fn check_ast<'a>(
-        &self,
-        document: &Document,
-        ast: &'a AstNode<'a>,
-    ) -> Result<Vec<Violation>> {
+    fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
         let lines: Vec<&str> = document.content.lines().collect();
 
@@ -235,7 +228,7 @@ impl AstRule for MD007 {
             let in_code_block = code_block_lines
                 .iter()
                 .any(|(start, end)| line_number >= *start && line_number <= *end);
-            
+
             if in_code_block {
                 continue;
             }
@@ -669,8 +662,12 @@ Another regular list:
 
         // Should only have 1 violation for the last list item (too much indent)
         // Should NOT have violations for the YAML list inside the code block
-        assert_eq!(violations.len(), 1, "Should only flag the regular list item with wrong indent, not the YAML in code block");
-        
+        assert_eq!(
+            violations.len(),
+            1,
+            "Should only flag the regular list item with wrong indent, not the YAML in code block"
+        );
+
         // Verify it's the right violation (line 19 is the "    * Too much indent" line)
         assert_eq!(violations[0].line, 19);
         assert!(violations[0].message.contains("Expected 2 spaces, found 4"));
@@ -697,6 +694,10 @@ Another list:
         let violations = rule.check(&document).unwrap();
 
         // Should have no violations - the indented code block should be ignored
-        assert_eq!(violations.len(), 0, "Should not flag items in indented code blocks");
+        assert_eq!(
+            violations.len(),
+            0,
+            "Should not flag items in indented code blocks"
+        );
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md007.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md007.rs
@@ -163,20 +163,18 @@ impl MD007 {
     }
 
     /// Recursively collect code block line ranges (both fenced and indented)
+    #[allow(clippy::only_used_in_recursion)]
     fn collect_code_block_ranges<'a>(
         &self,
         node: &'a AstNode<'a>,
         ranges: &mut Vec<(usize, usize)>,
     ) {
-        match &node.data.borrow().value {
-            NodeValue::CodeBlock(_) => {
-                // Fenced or indented code block
-                let sourcepos = node.data.borrow().sourcepos;
-                if sourcepos.start.line > 0 && sourcepos.end.line > 0 {
-                    ranges.push((sourcepos.start.line, sourcepos.end.line));
-                }
+        if let NodeValue::CodeBlock(_) = &node.data.borrow().value {
+            // Fenced or indented code block
+            let sourcepos = node.data.borrow().sourcepos;
+            if sourcepos.start.line > 0 && sourcepos.end.line > 0 {
+                ranges.push((sourcepos.start.line, sourcepos.end.line));
             }
-            _ => {}
         }
 
         for child in node.children() {

--- a/docs/src/rules-reference.md
+++ b/docs/src/rules-reference.md
@@ -15,16 +15,16 @@ This page provides a comprehensive reference for all **67 linting rules** availa
 ### Standard Rules (54 rules)
 | Rule | Name | Auto-fix | Category |
 |------|------|----------|----------|
-| [MD001](./rules/standard/md001.html) | Heading increment | | Structure |
-| [MD002](#md002) | First heading should be top level | | Structure |
-| [MD003](#md003) | Heading style consistency | | Style |
-| [MD004](#md004) | Unordered list style | | Lists |
-| [MD005](#md005) | List item indentation consistency | | Lists |
-| [MD006](#md006) | Start lists at beginning of line | | Lists |
-| [MD007](#md007) | Unordered list indentation | | Lists |
+| [MD001](./rules/standard/md001.html) | Heading increment | ✓ | Structure |
+| [MD002](#md002) | First heading should be top level | ✓ | Structure |
+| [MD003](#md003) | Heading style consistency | ✓ | Style |
+| [MD004](#md004) | Unordered list style | ✓ | Lists |
+| [MD005](#md005) | List item indentation consistency | ✓ | Lists |
+| [MD006](#md006) | Start lists at beginning of line | ✓ | Lists |
+| [MD007](#md007) | Unordered list indentation | ✓ | Lists |
 | [MD009](./rules/standard/md009.html) | No trailing spaces | ✓ | Whitespace |
 | [MD010](./rules/standard/md010.html) | Hard tabs | ✓ | Whitespace |
-| [MD011](#md011) | Reversed link syntax | | Links |
+| [MD011](#md011) | Reversed link syntax | ✓ | Links |
 | [MD012](./rules/standard/md012.html) | Multiple consecutive blank lines | ✓ | Whitespace |
 | [MD013](./rules/standard/md013.html) | Line length | | Style |
 | [MD014](#md014) | Dollar signs in shell code | ✓ | Code |
@@ -34,32 +34,32 @@ This page provides a comprehensive reference for all **67 linting rules** availa
 | [MD021](./rules/standard/md021.html) | Multiple spaces in closed headings | ✓ | Headings |
 | [MD022](#md022) | Headings surrounded by blank lines | ✓ | Headings |
 | [MD023](./rules/standard/md023.html) | Headings start at beginning | ✓ | Headings |
-| [MD024](#md024) | Multiple headings same content | | Headings |
-| [MD025](#md025) | Multiple top-level headings | | Headings |
-| [MD026](#md026) | Trailing punctuation in headings | | Headings |
+| [MD024](#md024) | Multiple headings same content | ✓ | Headings |
+| [MD025](#md025) | Multiple top-level headings | ✓ | Headings |
+| [MD026](#md026) | Trailing punctuation in headings | ✓ | Headings |
 | [MD027](./rules/standard/md027.html) | Multiple spaces after blockquote | ✓ | Blockquotes |
 | [MD028](#md028) | Blank line inside blockquote | ✓ | Blockquotes |
 | [MD029](#md029) | Ordered list item prefix | ✓ | Lists |
 | [MD030](./rules/standard/md030.html) | Spaces after list markers | ✓ | Lists |
-| [MD031](#md031) | Fenced code blocks surrounded | | Code |
-| [MD032](#md032) | Lists surrounded by blank lines | | Lists |
+| [MD031](#md031) | Fenced code blocks surrounded | ✓ | Code |
+| [MD032](#md032) | Lists surrounded by blank lines | ✓ | Lists |
 | [MD033](#md033) | Inline HTML | | HTML |
 | [MD034](./rules/standard/md034.html) | Bare URL used | ✓ | Links |
 | [MD035](#md035) | Horizontal rule style | ✓ | Style |
 | [MD036](#md036) | Emphasis instead of heading | | Emphasis |
-| [MD037](#md037) | Spaces inside emphasis markers | | Emphasis |
-| [MD038](#md038) | Spaces inside code spans | | Code |
-| [MD039](#md039) | Spaces inside link text | | Links |
+| [MD037](#md037) | Spaces inside emphasis markers | ✓ | Emphasis |
+| [MD038](#md038) | Spaces inside code spans | ✓ | Code |
+| [MD039](#md039) | Spaces inside link text | ✓ | Links |
 | [MD040](./rules/standard/md040.html) | Fenced code blocks language | | Code |
 | [MD041](#md041) | First line top-level heading | | Structure |
 | [MD042](#md042) | No empty links | | Links |
 | [MD043](#md043) | Required heading structure | | Structure |
 | [MD044](#md044) | Proper names capitalization | | Style |
 | [MD045](#md045) | Images should have alt text | ✓ | Images |
-| [MD046](#md046) | Code block style | | Code |
+| [MD046](#md046) | Code block style | ✓ | Code |
 | [MD047](./rules/standard/md047.html) | Files end with newline | ✓ | Whitespace |
 | [MD048](#md048) | Code fence style | ✓ | Code |
-| [MD049](#md049) | Emphasis style consistency | | Emphasis |
+| [MD049](#md049) | Emphasis style consistency | ✓ | Emphasis |
 | [MD050](#md050) | Strong style consistency | ✓ | Emphasis |
 | [MD051](#md051) | Link fragments | | Links |
 | [MD052](#md052) | Reference links and images | | Links |
@@ -67,7 +67,7 @@ This page provides a comprehensive reference for all **67 linting rules** availa
 | [MD054](#md054) | Link and image style | | Links |
 | [MD055](#md055) | Table pipe style | ✓ | Tables |
 | [MD056](#md056) | Table column count | ✓ | Tables |
-| [MD058](#md058) | Table row syntax | | Tables |
+| [MD058](#md058) | Tables surrounded by blank lines | ✓ | Tables |
 | [MD059](#md059) | Link and image reference style | | Links |
 
 ### mdBook Rules (13 rules)
@@ -160,7 +160,7 @@ Ensure proper links and images:
 
 ## Auto-Fix Rules
 
-**25 rules** support automatic fixing with `--fix`:
+**41 rules** support automatic fixing with `--fix`:
 
 ### Whitespace & Formatting
 - **MD009** - Remove trailing spaces


### PR DESCRIPTION
## Summary

Fixes MD007 to properly ignore list indentation checks inside code blocks (both fenced and indented).

## Problem

MD007 was incorrectly checking list indentation inside code blocks, causing false positives. For example, YAML in code blocks with list-like syntax was being flagged:

```yaml
steps:
  - uses: actions/checkout@v4  # MD007 was incorrectly flagging this
  - name: Build
```

This was discovered during tool comparison analysis (#227) where mdbook-lint reported 46 MD007 violations while markdownlint correctly reported 0.

## Solution

1. **Changed MD007 from `Rule` to `AstRule` trait** - This gives access to the AST for proper code block detection
2. **Added code block detection** - Collects line ranges of all code blocks (fenced and indented) from AST
3. **Skip lines in code blocks** - During line-by-line processing, skip any lines within code block ranges

## Tests

Added comprehensive tests:
- `test_md007_ignores_lists_in_code_blocks` - Verifies YAML in fenced code blocks is ignored
- `test_md007_ignores_indented_code_blocks` - Verifies indented code blocks are ignored
- Fixed configuration test that was inadvertently creating code blocks with 4+ space indentation

## Impact

- Eliminates 46 false positives in our own documentation
- Brings MD007 behavior in line with markdownlint
- Properly handles both fenced (```) and indented (4+ spaces) code blocks

Resolves the MD007 bug identified in #227