### PR TITLE
docs: complete individual rule documentation pages

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,77 +16,84 @@
 
 - [Rules Reference](./rules/index.md)
 - [Standard Rules](./rules/standard/index.md)
-
-- [Heading Rules](./rules/standard/headings.md)
-
-- [MD001 - Heading Increment](./rules/standard/md001.md)
-
-- [MD018 - No Space After Hash](./rules/standard/md018.md)
-
-- [MD019 - Multiple Spaces After Hash](./rules/standard/md019.md)
-
-- [MD020 - No Space in Closed Headings](./rules/standard/md020.md)
-
-- [MD021 - Multiple Spaces in Closed Headings](./rules/standard/md021.md)
-
-- [MD023 - Headings Start at Beginning](./rules/standard/md023.md)
-
-- [List Rules](./rules/standard/lists.md)
-
-- [MD030 - Spaces After List Markers](./rules/standard/md030.md)
-
-- [Whitespace Rules](./rules/standard/whitespace.md)
-
-- [MD009 - No Trailing Spaces](./rules/standard/md009.md)
-
-- [MD010 - Hard Tabs](./rules/standard/md010.md)
-
-- [MD012 - Multiple Consecutive Blank Lines](./rules/standard/md012.md)
-
-- [MD027 - Multiple Spaces After Blockquote](./rules/standard/md027.md)
-
-- [MD047 - Files End with Newline](./rules/standard/md047.md)
-
-- [Link Rules](./rules/standard/links.md)
-
-- [MD034 - Bare URL Used](./rules/standard/md034.md)
-
-- [Code Rules](./rules/standard/code.md)
-
-- [MD040 - Fenced Code Blocks Language](./rules/standard/md040.md)
-
-- [Style Rules](./rules/standard/style.md)
-
-- [MD013 - Line Length](./rules/standard/md013.md)
-
+  - [Heading Rules](./rules/standard/headings.md)
+    - [MD001 - Heading Increment](./rules/standard/md001.md)
+    - [MD002 - First Heading H1](./rules/standard/md002.md)
+    - [MD003 - Heading Style](./rules/standard/md003.md)
+    - [MD018 - No Space After Hash](./rules/standard/md018.md)
+    - [MD019 - Multiple Spaces After Hash](./rules/standard/md019.md)
+    - [MD020 - No Space in Closed Headings](./rules/standard/md020.md)
+    - [MD021 - Multiple Spaces in Closed Headings](./rules/standard/md021.md)
+    - [MD022 - Blanks Around Headings](./rules/standard/md022.md)
+    - [MD023 - Headings Start at Beginning](./rules/standard/md023.md)
+    - [MD024 - No Duplicate Headings](./rules/standard/md024.md)
+    - [MD025 - Single Top-Level Heading](./rules/standard/md025.md)
+    - [MD026 - No Trailing Punctuation](./rules/standard/md026.md)
+    - [MD041 - First Line Top-Level Heading](./rules/standard/md041.md)
+  - [List Rules](./rules/standard/lists.md)
+    - [MD004 - Unordered List Style](./rules/standard/md004.md)
+    - [MD005 - List Item Indentation](./rules/standard/md005.md)
+    - [MD006 - List Start Left](./rules/standard/md006.md)
+    - [MD007 - Unordered List Indentation](./rules/standard/md007.md)
+    - [MD029 - Ordered List Prefix](./rules/standard/md029.md)
+    - [MD030 - Spaces After List Markers](./rules/standard/md030.md)
+    - [MD032 - Blanks Around Lists](./rules/standard/md032.md)
+  - [Whitespace Rules](./rules/standard/whitespace.md)
+    - [MD009 - No Trailing Spaces](./rules/standard/md009.md)
+    - [MD010 - Hard Tabs](./rules/standard/md010.md)
+    - [MD012 - Multiple Consecutive Blank Lines](./rules/standard/md012.md)
+    - [MD027 - Multiple Spaces After Blockquote](./rules/standard/md027.md)
+    - [MD028 - No Blanks in Blockquote](./rules/standard/md028.md)
+    - [MD047 - Files End with Newline](./rules/standard/md047.md)
+  - [Link Rules](./rules/standard/links.md)
+    - [MD011 - Reversed Link Syntax](./rules/standard/md011.md)
+    - [MD034 - Bare URL Used](./rules/standard/md034.md)
+    - [MD039 - Spaces Inside Link Text](./rules/standard/md039.md)
+    - [MD042 - No Empty Links](./rules/standard/md042.md)
+    - [MD051 - Link Fragments](./rules/standard/md051.md)
+    - [MD052 - Reference Links and Images](./rules/standard/md052.md)
+    - [MD053 - Reference Definitions](./rules/standard/md053.md)
+    - [MD054 - Link and Image Style](./rules/standard/md054.md)
+    - [MD059 - Descriptive Link Text](./rules/standard/md059.md)
+  - [Code Rules](./rules/standard/code.md)
+    - [MD014 - Dollar Signs in Commands](./rules/standard/md014.md)
+    - [MD031 - Blanks Around Fences](./rules/standard/md031.md)
+    - [MD038 - Spaces Inside Code Spans](./rules/standard/md038.md)
+    - [MD040 - Fenced Code Blocks Language](./rules/standard/md040.md)
+    - [MD046 - Code Block Style](./rules/standard/md046.md)
+    - [MD048 - Code Fence Style](./rules/standard/md048.md)
+  - [Style Rules](./rules/standard/style.md)
+    - [MD013 - Line Length](./rules/standard/md013.md)
+    - [MD035 - Horizontal Rule Style](./rules/standard/md035.md)
+    - [MD043 - Required Heading Structure](./rules/standard/md043.md)
+    - [MD044 - Proper Names Capitalization](./rules/standard/md044.md)
+  - [Emphasis Rules](./rules/standard/emphasis.md)
+    - [MD036 - Emphasis Instead of Heading](./rules/standard/md036.md)
+    - [MD037 - Spaces Inside Emphasis](./rules/standard/md037.md)
+    - [MD049 - Emphasis Style](./rules/standard/md049.md)
+    - [MD050 - Strong Style](./rules/standard/md050.md)
+  - [Table Rules](./rules/standard/tables.md)
+    - [MD055 - Table Pipe Style](./rules/standard/md055.md)
+    - [MD056 - Table Column Count](./rules/standard/md056.md)
+    - [MD058 - Blanks Around Tables](./rules/standard/md058.md)
+  - [Image Rules](./rules/standard/images.md)
+    - [MD045 - Images Should Have Alt Text](./rules/standard/md045.md)
+  - [HTML Rules](./rules/standard/html.md)
+    - [MD033 - No Inline HTML](./rules/standard/md033.md)
 - [mdBook Rules](./rules/mdbook/index.md)
-
-- [MDBOOK001 - Code Block Language Tags](./rules/mdbook/mdbook001.md)
-
-- [MDBOOK002 - Invalid Internal Link](./rules/mdbook/mdbook002.md)
-
-- [MDBOOK003 - Invalid SUMMARY.md Structure](./rules/mdbook/mdbook003.md)
-
-- [MDBOOK004 - No Duplicate Chapter Titles](./rules/mdbook/mdbook004.md)
-
-- [MDBOOK005 - Orphaned Files](./rules/mdbook/mdbook005.md)
-
-- [MDBOOK006 - Invalid Cross-Reference Links](./rules/mdbook/mdbook006.md)
-
-- [MDBOOK007 - Invalid Include Directive](./rules/mdbook/mdbook007.md)
-
-- [MDBOOK008 - Invalid Rustdoc Include](./rules/mdbook/mdbook008.md)
-
-- [MDBOOK009 - Invalid Playground Configuration](./rules/mdbook/mdbook009.md)
-
-- [MDBOOK010 - Invalid Preprocessor Configuration](./rules/mdbook/mdbook010.md)
-
-- [MDBOOK011 - Invalid Template Syntax](./rules/mdbook/mdbook011.md)
-
-- [MDBOOK012 - Invalid Include Line Ranges](./rules/mdbook/mdbook012.md)
-
-- [MDBOOK025 - Multiple H1 in SUMMARY.md](./rules/mdbook/mdbook025.md)
-
+  - [MDBOOK001 - Code Block Language Tags](./rules/mdbook/mdbook001.md)
+  - [MDBOOK002 - Invalid Internal Link](./rules/mdbook/mdbook002.md)
+  - [MDBOOK003 - Invalid SUMMARY.md Structure](./rules/mdbook/mdbook003.md)
+  - [MDBOOK004 - No Duplicate Chapter Titles](./rules/mdbook/mdbook004.md)
+  - [MDBOOK005 - Orphaned Files](./rules/mdbook/mdbook005.md)
+  - [MDBOOK006 - Invalid Cross-Reference Links](./rules/mdbook/mdbook006.md)
+  - [MDBOOK007 - Invalid Include Directive](./rules/mdbook/mdbook007.md)
+  - [MDBOOK008 - Invalid Rustdoc Include](./rules/mdbook/mdbook008.md)
+  - [MDBOOK009 - Invalid Playground Configuration](./rules/mdbook/mdbook009.md)
+  - [MDBOOK010 - Invalid Preprocessor Configuration](./rules/mdbook/mdbook010.md)
+  - [MDBOOK011 - Invalid Template Syntax](./rules/mdbook/mdbook011.md)
+  - [MDBOOK012 - Invalid Include Line Ranges](./rules/mdbook/mdbook012.md)
+  - [MDBOOK025 - Multiple H1 in SUMMARY.md](./rules/mdbook/mdbook025.md)
 - [Configuration Reference](./configuration-reference.md)
 - [Example Configuration](./example-configuration.md)
 - [API Documentation](./api-documentation.md)

--- a/docs/src/rules/mdbook/mdbook004.md
+++ b/docs/src/rules/mdbook/mdbook004.md
@@ -1,173 +1,63 @@
 # MDBOOK004 - No Duplicate Chapter Titles
 
-**Severity**: Warning  
-**Category**: mdBook-specific  
-**Auto-fix**: Not available
-
-## Rule Description
-
-This rule ensures that chapter titles are unique across the entire mdBook project. Duplicate titles can confuse readers and make navigation difficult.
+Chapter titles should be unique across the book.
 
 ## Why This Rule Exists
 
-Unique chapter titles are important because:
-
-- Prevents reader confusion when navigating the book
-- Ensures clear distinction between different chapters
-- Improves search functionality and indexing
-- Makes cross-references unambiguous
-- Helps maintain organized documentation structure
+Duplicate chapter titles create confusion in navigation and can cause issues
+with mdBook's URL generation. Each chapter should have a distinct, identifiable
+title.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
-
-In `chapter1.md`:
+### Incorrect (SUMMARY.md)
 
 ```markdown
-# Introduction
-Content for first introduction...
+# Summary
+
+- [Introduction](./intro.md)
+- [Getting Started](./start.md)
+- [Introduction](./advanced-intro.md)  <!-- Duplicate -->
 ```
 
-In `chapter5.md`:
+### Correct
 
 ```markdown
-# Introduction
-Different content but same title...
+# Summary
+
+- [Introduction](./intro.md)
+- [Getting Started](./start.md)
+- [Advanced Introduction](./advanced-intro.md)
 ```
-
-### ✅ Correct
-
-In `chapter1.md`:
-
-```markdown
-# Getting Started
-Introduction content...
-```
-
-In `chapter5.md`:
-
-```markdown
-# API Introduction
-API-specific introduction...
-```
-
-Or use more specific titles:
-
-```markdown
-# Project Overview
-# Installation Guide
-# Configuration Reference
-# API Documentation
-```
-
-## What This Rule Checks
-
-1. **First-level headings**: Checks all H1 headings across files
-2. **Case sensitivity**: Treats "Introduction" and "introduction" as duplicates
-3. **Cross-file validation**: Compares titles across all book chapters
-4. **SUMMARY.md entries**: Validates chapter titles in the table of contents
 
 ## Configuration
 
-```toml
-[MDBOOK004]
-case_sensitive = false  # Case-sensitive comparison (default: false)
-ignore_prefixes = ["Chapter", "Part"]  # Prefixes to ignore
-```
-
-## Common Issues and Solutions
-
-### Issue: Generic Titles
-
-Many chapters use generic titles like "Introduction" or "Overview":
-
-```markdown
-<!-- Bad: Too generic -->
-# Introduction
-# Overview
-# Configuration
-# Usage
-
-<!-- Good: More specific -->
-# Project Introduction
-# Architecture Overview
-# Database Configuration
-# CLI Usage
-```
-
-### Issue: Section Titles as Chapter Titles
-
-Using section-level titles as chapter titles:
-
-```markdown
-<!-- Bad: Section-like titles -->
-# Installing
-# Configuring
-# Running
-
-<!-- Good: Complete chapter titles -->
-# Installation Guide
-# Configuration Reference
-# Running the Application
-```
+This rule has no configuration options.
 
 ## When to Disable
 
-Consider disabling this rule if:
+- Books with intentionally repeated section names
+- Multi-part books where repetition is meaningful
 
-- Your book intentionally uses duplicate titles (e.g., multiple "Introduction" sections)
-- You're generating content dynamically with potential duplicates
-- You have a large multi-part book where context makes duplicates clear
+## Rule Details
 
-### Disable in Config
+- **Rule ID**: MDBOOK004
+- **Aliases**: no-duplicate-chapter-titles
+- **Category**: MdBook
+- **Severity**: Warning
+- **Auto-fix**: No
 
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MDBOOK004"]
-```
+## Impact
 
-### Disable for Specific Files
+Duplicate titles can cause:
 
-```toml
-[[overrides]]
-path = "appendices/**"
-disabled_rules = ["MDBOOK004"]
-```
-
-## Best Practices
-
-1. **Be specific**: Use descriptive, unique titles for each chapter
-2. **Add context**: Include the subject area in the title
-3. **Use hierarchy**: Let SUMMARY.md structure provide context
-4. **Consider prefixes**: Use part/section prefixes for clarity
-
-### Title Patterns
-
-```markdown
-# [Subject] + [Type]
-# Database Configuration
-# API Reference
-# Testing Guide
-
-# [Action] + [Target]
-# Installing Dependencies
-# Configuring the Server
-# Building from Source
-
-# [Module] + [Aspect]
-# Authentication Overview
-# Storage Implementation
-# Network Architecture
-```
+- Confusing navigation sidebar
+- Ambiguous URL paths
+- Search result confusion
+- Poor user experience
 
 ## Related Rules
 
-- [MDBOOK003](./mdbook003.html) - SUMMARY.md structure validation
-- [MD024](../standard/md024.html) - Multiple headings with same content
-- [MD025](../standard/md025.html) - Multiple top-level headings
-
-## References
-
-- [mdBook - SUMMARY.md](https://rust-lang.github.io/mdBook/format/summary.html)
-- [mdBook Structure](https://rust-lang.github.io/mdBook/guide/creating.html)
+- [MD024](../standard/md024.md) - No duplicate headings
+- [MDBOOK003](./mdbook003.md) - SUMMARY.md structure
+- [MDBOOK025](./mdbook025.md) - SUMMARY.md heading structure

--- a/docs/src/rules/mdbook/mdbook006.md
+++ b/docs/src/rules/mdbook/mdbook006.md
@@ -1,203 +1,64 @@
-# MDBOOK006 - Invalid Cross-Reference Links
+# MDBOOK006 - Internal Cross-References
 
-**Severity**: Error  
-**Category**: mdBook-specific  
-**Auto-fix**: Not available
-
-## Rule Description
-
-This rule validates internal cross-reference links that point to headings in other files. It ensures that both the target file exists and contains the referenced heading anchor.
+Internal cross-reference links must point to valid headings in target files.
 
 ## Why This Rule Exists
 
-Valid cross-references are crucial because:
-
-- Ensures readers can navigate between related sections
-- Prevents broken links in published documentation
-- Maintains documentation integrity across chapters
-- Enables proper mdBook navigation features
-- Helps identify outdated references after refactoring
+Cross-references between chapters using anchor fragments must resolve to actual
+headings in the target file. Invalid fragments create broken navigation.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
+### Incorrect
 
 ```markdown
-<!-- Target heading doesn't exist -->
-See [configuration details](./config.md#database-setup)
-
-<!-- File exists but anchor is wrong -->
-Check the [API reference](./api.md#rest-endpoints)
-
-<!-- Typo in anchor -->
-Read about [authentication](./auth.md#authentification)
+See the [configuration section](./config.md#settings) for details.
 ```
 
-### ✅ Correct
+Where `config.md` has no `## Settings` heading.
+
+### Correct
 
 ```markdown
-<!-- Valid file and anchor -->
-See [configuration details](./config.md#database-configuration)
-
-<!-- Correct anchor format -->
-Check the [API reference](./api.md#rest-api-endpoints)
-
-<!-- Valid cross-reference -->
-Read about [authentication](./auth.md#authentication)
+See the [configuration section](./config.md#configuration-options) for details.
 ```
 
-## What This Rule Checks
-
-1. **File existence**: Target `.md` file must exist
-2. **Heading presence**: Referenced heading must exist in target file
-3. **Anchor format**: Anchor must match mdBook's heading ID generation
-4. **Case sensitivity**: Anchors are case-insensitive but should match
-
-### Anchor Generation Rules
-
-mdBook generates anchors from headings:
-
-- Convert to lowercase
-- Replace spaces with hyphens
-- Remove special characters (except hyphens and underscores)
-- Handle duplicate anchors with numeric suffixes
+Where `config.md` contains:
 
 ```markdown
-## Hello World!           → #hello-world
-## User's Guide          → #users-guide
-## API Reference (v2)    → #api-reference-v2
-## 1.2.3 Version Notes   → #123-version-notes
+## Configuration Options
+
+Content here.
 ```
+
+## How Fragments Are Generated
+
+mdBook generates fragments from headings:
+
+| Heading | Fragment |
+|---------|----------|
+| `## Getting Started` | `#getting-started` |
+| `## API Reference` | `#api-reference` |
+| `## What's New?` | `#whats-new` |
 
 ## Configuration
 
-```toml
-[MDBOOK006]
-check_external = false   # Don't check external URLs (default: false)
-ignore_missing = false   # Report missing files (default: false)
-case_sensitive = false   # Case-sensitive anchor matching (default: false)
-```
-
-## Common Issues and Solutions
-
-### Issue: Heading Text Changed
-
-When heading text changes, anchors break:
-
-```markdown
-<!-- Original heading in config.md -->
-## Database Setup
-
-<!-- Link that breaks after heading change -->
-[See database setup](./config.md#database-setup)
-
-<!-- After heading renamed to "Database Configuration" -->
-[See database configuration](./config.md#database-configuration)
-```
-
-**Solution**: Update all cross-references when changing headings
-
-### Issue: Special Characters in Headings
-
-Special characters affect anchor generation:
-
-```markdown
-<!-- Heading with special characters -->
-## What's New? (2024)
-
-<!-- Wrong anchor -->
-[What's new](./changelog.md#whats-new-2024)  ✗
-
-<!-- Correct anchor -->
-[What's new](./changelog.md#whats-new-2024)   ✓
-```
-
-### Issue: Duplicate Headings
-
-Multiple headings with same text get numeric suffixes:
-
-```markdown
-<!-- In api.md -->
-## Authentication
-...
-## Authentication  <!-- Gets #authentication-1 -->
-
-<!-- Linking to second occurrence -->
-[Second auth section](./api.md#authentication-1)
-```
+This rule has no configuration options.
 
 ## When to Disable
 
-Consider disabling this rule if:
+- Books using custom anchor IDs
+- Content with JavaScript-based navigation
 
-- You're in the middle of major documentation restructuring
-- Your build process generates files dynamically
-- You use external tools that create anchors differently
-- You have many legacy cross-references to update
+## Rule Details
 
-### Disable in Config
-
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MDBOOK006"]
-```
-
-### Disable Inline
-
-```markdown
-<!-- mdbook-lint-disable MDBOOK006 -->
-[Temporarily broken cross-reference](./future.md#todo-section)
-<!-- mdbook-lint-enable MDBOOK006 -->
-```
-
-## Best Practices
-
-1. **Use descriptive anchors**: Make headings clear and unique
-2. **Test after refactoring**: Verify links after changing headings
-3. **Maintain a link registry**: Document important cross-references
-4. **Use consistent heading style**: Makes anchors predictable
-5. **Avoid special characters**: Simplifies anchor generation
-
-### Cross-Reference Patterns
-
-```markdown
-<!-- Good: Clear, specific references -->
-[See configuration options](./config.md#available-options)
-[Authentication guide](./auth.md#oauth2-setup)
-[API error codes](./api.md#error-handling)
-
-<!-- Avoid: Vague or fragile references -->
-[See here](./config.md#options)
-[More info](./auth.md#setup)
-[Errors](./api.md#errors)
-```
-
-## Tools and Tips
-
-### Finding Broken Cross-References
-
-```bash
-# Run linter to find all cross-reference issues
-mdbook-lint lint --rules MDBOOK006 docs/
-
-# Test all links with mdBook
-mdbook test
-```
-
-### Generating Anchor Lists
-
-```bash
-# List all headings and their anchors
-grep "^#" docs/**/*.md | sed 's/#\+//'
-```
+- **Rule ID**: MDBOOK006
+- **Aliases**: internal-cross-references
+- **Category**: MdBook
+- **Severity**: Warning
+- **Auto-fix**: No
 
 ## Related Rules
 
-- [MDBOOK002](./mdbook002.html) - Invalid internal link
-- [MD051](../standard/md051.html) - Link fragments are valid
-- [MD052](../standard/md052.html) - Reference links and images
-
-## References
-
-- [mdBook - Links and References](https://rust-lang.github.io/mdBook/format/markdown.html#links)
-- [CommonMark - Links](https://spec.commonmark.org/0.30/#links)
+- [MD051](../standard/md051.md) - Link fragments (same-file)
+- [MDBOOK002](./mdbook002.md) - Internal link validation

--- a/docs/src/rules/mdbook/mdbook007.md
+++ b/docs/src/rules/mdbook/mdbook007.md
@@ -1,250 +1,68 @@
-# MDBOOK007 - Invalid Include Directive
+# MDBOOK007 - Include Validation
 
-**Severity**: Error  
-**Category**: mdBook-specific  
-**Auto-fix**: Not available
-
-## Rule Description
-
-This rule validates `{{#include}}` directives used to include content from other files. It ensures the syntax is correct and the referenced files exist.
+Include directives must point to existing files with valid syntax.
 
 ## Why This Rule Exists
 
-Valid include directives are essential because:
-
-- Prevents build failures from broken includes
-- Ensures included content is available
-- Maintains documentation modularity
-- Enables content reuse across chapters
-- Helps identify moved or renamed files
+mdBook's `\{{#include}}` directive embeds content from other files. Invalid
+paths or syntax cause build failures or missing content.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
+### Incorrect
 
-```markdown
-<!-- File doesn't exist -->
-\{{#include ./missing-file.md}}
+```text
+\{{#include missing-file.rs}}
 
-<!-- Invalid syntax -->
-\{{include ./file.md}}
-\{{#includes ./file.md}}
+\{{#include ../src/lib.rs:nonexistent_anchor}}
 
-<!-- Malformed path -->
-\{{#include file.md}}  <!-- Missing ./ prefix -->
-\{{#include ../../../outside-project.md}}
-
-<!-- Invalid line range syntax -->
-\{{#include ./file.md:1-}}
-\{{#include ./file.md:a-b}}
+\{{include src/main.rs}}  <!-- Missing # -->
 ```
 
-### ✅ Correct
+### Correct
 
-```markdown
-<!-- Include entire file -->
-\{{#include ./examples/sample.md}}
+```text
+\{{#include ../src/lib.rs}}
 
-<!-- Include specific lines -->
-\{{#include ./code.rs:1:10}}
-\{{#include ./code.rs:5:}}
-\{{#include ./code.rs::10}}
+\{{#include ../src/lib.rs:main_function}}
 
-<!-- Include with anchor -->
-\{{#include ./file.md:anchor}}
-
-<!-- Include from parent directory -->
-\{{#include ../shared/header.md}}
+\{{#include ./snippets/example.rs:5:10}}
 ```
 
-## Include Directive Syntax
+## Include Syntax
 
-### Basic Include
+```text
+<!-- Full file -->
+\{{#include path/to/file.rs}}
 
-```markdown
-\{{#include filepath}}
-```
+<!-- Line range -->
+\{{#include path/to/file.rs:5:10}}
 
-### Line Range Selection
+<!-- From line to end -->
+\{{#include path/to/file.rs:5:}}
 
-```markdown
-\{{#include filepath:start:end}}  <!-- Lines start to end -->
-\{{#include filepath:start:}}     <!-- From start to EOF -->
-\{{#include filepath::end}}       <!-- From beginning to end -->
-\{{#include filepath:line}}       <!-- Single line -->
-```
-
-### Anchor-based Include
-
-```markdown
-\{{#include filepath:anchor}}     <!-- Include anchor section -->
-```
-
-In the source file:
-
-```markdown
-<!-- ANCHOR: example -->
-Content to include
-<!-- ANCHOR_END: example -->
+<!-- Named anchor -->
+\{{#include path/to/file.rs:anchor_name}}
 ```
 
 ## Configuration
 
-```toml
-[MDBOOK007]
-check_line_ranges = true    # Validate line numbers exist (default: true)
-allow_external = false      # Allow includes outside src/ (default: false)
-max_depth = 3              # Maximum directory traversal depth (default: 3)
-```
-
-## Common Issues and Solutions
-
-### Issue: Relative Path Confusion
-
-```markdown
-<!-- Current file: src/chapter1/section.md -->
-
-<!-- Wrong: Assumes path from src/ -->
-\{{#include examples/code.rs}}  ✗
-
-<!-- Correct: Relative to current file -->
-\{{#include ../examples/code.rs}}  ✓
-```
-
-### Issue: Line Numbers Out of Range
-
-```markdown
-<!-- file.md has 50 lines -->
-
-<!-- Error: End line exceeds file length -->
-\{{#include ./file.md:1:100}}
-
-<!-- Fix: Use open-ended range -->
-\{{#include ./file.md:1:}}
-```
-
-### Issue: Platform-Specific Paths
-
-```markdown
-<!-- Windows-style path (avoid) -->
-\{{#include .\examples\code.rs}}
-
-<!-- Unix-style path (preferred) -->
-\{{#include ./examples/code.rs}}
-```
-
-## Advanced Usage
-
-### Including Code with Hidden Lines
-
-```rust
-\{{#include ./examples/main.rs}}
-```
-
-In `main.rs`:
-
-```rust
-# fn hidden_function() {
-# // This line is hidden in mdBook output
-
-# }
-
-fn visible_function() {
-    // This is shown
-}
-```
-
-### Nested Includes
-
-Includes can contain other includes:
-
-```markdown
-<!-- chapter.md -->
-\{{#include ./sections/intro.md}}
-
-<!-- sections/intro.md -->
-This is the introduction.
-\{{#include ../examples/sample.md}}
-```
+This rule has no configuration options.
 
 ## When to Disable
 
-Consider disabling this rule if:
+- Files with includes resolved at a different build stage
+- Templates with dynamic include paths
 
-- You're generating included files during the build process
-- You're migrating content with many broken includes
-- You use a custom preprocessor that handles includes differently
-- You're prototyping with placeholder includes
+## Rule Details
 
-### Disable in Config
-
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MDBOOK007"]
-```
-
-### Disable Inline
-
-```markdown
-<!-- mdbook-lint-disable MDBOOK007 -->
-\{{#include ./todo-file.md}}
-<!-- mdbook-lint-enable MDBOOK007 -->
-```
-
-## Best Practices
-
-1. **Use relative paths**: More maintainable than absolute paths
-2. **Keep includes close**: Avoid deep directory traversal
-3. **Document anchors**: Comment what each anchor contains
-4. **Test after moving files**: Update include paths when reorganizing
-5. **Prefer anchors over line numbers**: More stable than line ranges
-
-### Include Organization
-
-```
-book/
-├── src/
-│   ├── chapter1.md
-│   ├── chapter2.md
-│   └── includes/        <!-- Dedicated includes directory -->
-│       ├── header.md
-│       ├── footer.md
-│       └── examples/
-│           └── code.rs
-```
-
-### Anchor Documentation
-
-```markdown
-<!-- ANCHOR: configuration_example -->
-<!-- This anchor includes a complete configuration example -->
-```toml
-[book]
-title = "My Book"
-```
-
-<!-- ANCHOR_END: configuration_example -->
-
-```
-
-## Error Messages
-
-Common error messages and their solutions:
-
-| Error | Solution |
-|-------|----------|
-| "File not found" | Check file path and spelling |
-| "Invalid line range" | Verify line numbers exist |
-| "Anchor not found" | Ensure anchor tags match |
-| "Path traversal too deep" | Simplify directory structure |
+- **Rule ID**: MDBOOK007
+- **Aliases**: include-validation
+- **Category**: MdBook
+- **Severity**: Error
+- **Auto-fix**: No
 
 ## Related Rules
 
-- [MDBOOK008](./mdbook008.html) - Rustdoc include validation
-- [MDBOOK011](./mdbook011.html) - Template include syntax
-- [MDBOOK012](./mdbook012.html) - Include line ranges
-
-## References
-
-- [mdBook - Including Files](https://rust-lang.github.io/mdBook/format/markdown.html#including-files)
-- [mdBook Preprocessors](https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html)
+- [MDBOOK008](./mdbook008.md) - Rustdoc include validation
+- [MDBOOK012](./mdbook012.md) - Include line range validation

--- a/docs/src/rules/mdbook/mdbook009.md
+++ b/docs/src/rules/mdbook/mdbook009.md
@@ -1,281 +1,73 @@
-# MDBOOK009 - Invalid Playground Configuration
+# MDBOOK009 - Playground Validation
 
-**Severity**: Warning  
-**Category**: mdBook-specific  
-**Auto-fix**: Not available
-
-## Rule Description
-
-This rule validates `{{#playground}}` directives and playground configuration in code blocks. It ensures proper syntax for making code examples editable and runnable in the Rust Playground.
+Invalid `\{{#playground}}` configuration.
 
 ## Why This Rule Exists
 
-Valid playground configuration is important because:
-
-- Enables interactive code examples for readers
-- Ensures code can run in the Rust Playground
-- Provides hands-on learning experiences
-- Validates that examples are executable
-- Maintains consistent playground behavior
+The `\{{#playground}}` directive creates interactive Rust code examples. Invalid
+paths or configuration cause build failures or non-functional playgrounds.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
+### Incorrect
 
-````markdown
-<!-- Invalid directive syntax -->
-\{{#playgrounds ./file.rs}}
-\{{playground ./file.rs}}
+```text
+\{{#playground missing-file.rs}}
 
-<!-- Invalid playground attributes -->
-```rust,playground
-fn main() {
-    println!("Hello");
-}
+\{{#playground ../src/example.rs invalid_option}}
+
+\{{playground src/demo.rs}}  <!-- Missing # -->
 ```
 
-<!-- Missing file -->
-\{{#playground ./missing.rs}}
-````
+### Correct
 
-### ✅ Correct
+```text
+\{{#playground ../src/example.rs}}
 
-````markdown
-<!-- Include file as playground -->
-\{{#playground ./examples/hello.rs}}
+\{{#playground ../src/example.rs editable}}
 
-<!-- Inline editable code -->
-```rust,editable
-fn main() {
-    println!("Hello, world!");
-}
+\{{#playground ../src/example.rs editable hide_lines=1-3}}
 ```
 
-<!-- Non-editable but runnable -->
-```rust,no_run
-fn main() {
-    // This compiles but won't run
-}
+## Playground Options
+
+```text
+<!-- Basic playground -->
+\{{#playground path/to/file.rs}}
+
+<!-- Editable playground -->
+\{{#playground path/to/file.rs editable}}
+
+<!-- Hide specific lines -->
+\{{#playground path/to/file.rs hide_lines=1-3}}
+
+<!-- Multiple options -->
+\{{#playground path/to/file.rs editable no_run}}
 ```
 
-<!-- Editable with hidden lines -->
-```rust,editable
-# fn hidden_setup() {}
-fn main() {
-    println!("Visible code");
-}
-```
-````
+## Available Options
 
-## Playground Attributes
-
-### Code Block Attributes
-
-| Attribute | Description |
-|-----------|-------------|
-| `editable` | Makes code block editable in browser |
-| `no_run` | Code compiles but doesn't run |
-| `compile_fail` | Example that should fail compilation |
-| `ignore` | Code block is not tested |
-| `should_panic` | Code should panic when run |
-
-### Examples with Attributes
-
-````markdown
-<!-- Editable example -->
-```rust,editable
-fn main() {
-    let x = 5;
-    println!("x = {}", x);
-}
-```
-
-<!-- Example that should fail -->
-```rust,compile_fail
-fn main() {
-    let x: i32 = "not a number";
-}
-```
-
-<!-- Example that panics -->
-```rust,should_panic
-fn main() {
-    panic!("This is expected!");
-}
-```
-````
+| Option | Description |
+|--------|-------------|
+| `editable` | Allow users to edit the code |
+| `no_run` | Show code but disable running |
+| `ignore` | Don't test this code |
+| `hide_lines` | Hide specific line ranges |
 
 ## Configuration
 
-```toml
-# book.toml
-[output.html.playground]
-editable = true         # Make code blocks editable by default
-copyable = true         # Add copy button to code blocks
-copy-js = true          # Include JavaScript for copy functionality
-line-numbers = false    # Show line numbers in code blocks
+This rule has no configuration options.
 
-[MDBOOK009]
-require_editable = false  # Require editable attribute (default: false)
-validate_compilation = false  # Check if code compiles (default: false)
-```
+## Rule Details
 
-## Common Issues and Solutions
-
-### Issue: Playground Not Enabled
-
-```toml
-# book.toml - Enable playground
-[output.html.playground]
-editable = true
-```
-
-### Issue: Code Doesn't Compile
-
-````markdown
-<!-- Missing main function -->
-```rust,editable
-println!("Hello");  // Error: not in a function
-```
-
-<!-- Fixed -->
-```rust,editable
-fn main() {
-    println!("Hello");
-}
-```
-````
-
-### Issue: Hidden Lines Shown
-
-````markdown
-<!-- Wrong: Hidden lines visible in playground -->
-```rust,editable
-# use std::io;
-# fn setup() {}
-fn main() {
-    // User code
-}
-```
-
-<!-- Note: Hidden lines work but are still editable -->
-````
-
-## Best Practices
-
-1. **Provide complete examples**: Include all necessary code
-2. **Use hidden lines sparingly**: Only for necessary boilerplate
-3. **Test in playground**: Verify examples work in actual playground
-4. **Add context**: Explain what users should try changing
-5. **Keep examples focused**: One concept per playground
-
-### Interactive Example Template
-
-````markdown
-## Try It Yourself
-
-Modify the code below to experiment with different values:
-
-```rust,editable
-fn calculate_area(width: f64, height: f64) -> f64 {
-    width * height
-}
-
-fn main() {
-    // Try changing these values!
-    let width = 10.0;
-    let height = 5.0;
-    
-    let area = calculate_area(width, height);
-    println!("Area: {} square units", area);
-    
-    // Challenge: Add a perimeter calculation
-}
-```
-
-**Suggestions to try:**
-- Change the dimensions
-- Add a perimeter function
-- Handle negative values
-````
-
-## Advanced Usage
-
-### Custom Playground URL
-
-```toml
-# book.toml
-[output.html.playground]
-editable = true
-site = "https://play.rust-lang.org"
-```
-
-### Playground with Dependencies
-
-````markdown
-<!-- Note: Dependencies must be available in playground -->
-```rust,editable
-// Available in playground: rand, regex, lazy_static, etc.
-use rand::Rng;
-
-fn main() {
-    let mut rng = rand::thread_rng();
-    let n: u32 = rng.gen_range(0..10);
-    println!("Random number: {}", n);
-}
-```
-````
-
-## When to Disable
-
-Consider disabling this rule if:
-
-- Your book doesn't use playground features
-- You're targeting offline readers
-- You have custom code execution environment
-- Your examples require local dependencies
-
-### Disable in Config
-
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MDBOOK009"]
-```
-
-### Disable Inline
-
-````markdown
-<!-- mdbook-lint-disable MDBOOK009 -->
-\{{#playground ./complex-example.rs}}
-<!-- mdbook-lint-enable MDBOOK009 -->
-````
-
-## Troubleshooting
-
-### Playground Not Working
-
-1. Check `book.toml` configuration
-2. Verify code compiles standalone
-3. Test in actual Rust Playground
-4. Check browser console for errors
-
-### Common Error Messages
-
-| Error | Solution |
-|-------|----------|
-| "Playground not configured" | Enable in book.toml |
-| "Code doesn't compile" | Add missing imports/main function |
-| "File not found" | Check file path in directive |
-| "Invalid attribute" | Use supported attributes only |
+- **Rule ID**: MDBOOK009
+- **Aliases**: playground-validation
+- **Category**: MdBook
+- **Severity**: Warning
+- **Stability**: Experimental
+- **Auto-fix**: No
 
 ## Related Rules
 
-- [MDBOOK007](./mdbook007.html) - Include directive validation
-- [MDBOOK008](./mdbook008.html) - Rustdoc include validation
-- [MD040](../standard/md040.html) - Code block language tags
-
-## References
-
-- [mdBook - Rust Playground](https://rust-lang.github.io/mdBook/format/theme/editor.html)
-- [Rust Playground](https://play.rust-lang.org/)
-- [mdBook Configuration](https://rust-lang.github.io/mdBook/format/configuration/index.html)
+- [MDBOOK001](./mdbook001.md) - Code block language tags
+- [MDBOOK007](./mdbook007.md) - Include validation

--- a/docs/src/rules/mdbook/mdbook010.md
+++ b/docs/src/rules/mdbook/mdbook010.md
@@ -1,282 +1,65 @@
-# MDBOOK010 - Invalid Preprocessor Configuration
+# MDBOOK010 - Preprocessor Validation
 
-**Severity**: Warning  
-**Category**: mdBook-specific  
-**Auto-fix**: Not available
-
-## Rule Description
-
-This rule validates preprocessor directives and configuration, including math blocks, mermaid diagrams, and other mdBook preprocessor syntax. It ensures proper formatting for preprocessor features.
+Missing or invalid preprocessor configuration.
 
 ## Why This Rule Exists
 
-Valid preprocessor configuration is important because:
-
-- Prevents build failures from malformed directives
-- Ensures special content renders correctly
-- Maintains compatibility with mdBook preprocessors
-- Validates math notation and diagram syntax
-- Helps identify configuration issues early
+mdBook preprocessors transform content before rendering. Using preprocessor
+directives without proper configuration causes silent failures or build errors.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
+### Incorrect
 
-````markdown
-<!-- Invalid math block syntax -->
-$$
-x = \frac{-b \pm \sqrt{b^2 - 4ac}{2a}  <!-- Missing closing brace -->
-$$
+Using a directive without configuring the preprocessor:
 
-<!-- Wrong delimiter -->
-$$$
+```text
+\{{#katex}}
 E = mc^2
-$$$
-
-<!-- Invalid mermaid block -->
-```mermaid
-graph LR
-    A --> B  <!-- Missing semicolons in some cases -->
+\{{/katex}}
 ```
 
-<!-- Malformed preprocessor directive -->
-{{#math}}x^2{{/math}}  <!-- Wrong syntax -->
-````
+Without `[preprocessor.katex]` in `book.toml`.
 
-### ✅ Correct
+### Correct
 
-````markdown
-<!-- Valid inline math -->
-When $a \ne 0$, there are two solutions
+First, configure in `book.toml`:
 
-<!-- Valid math block -->
-$$
-x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
-$$
-
-<!-- Valid KaTeX block -->
-```math
-\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
+```toml
+[preprocessor.katex]
 ```
 
-<!-- Valid mermaid diagram -->
-```mermaid
-graph LR
-    A[Start] --> B{Decision}
-    B -->|Yes| C[Result 1]
-    B -->|No| D[Result 2]
-```
-````
+Then use the directive:
 
-## Supported Preprocessors
-
-### Math Rendering (mdbook-katex)
-
-````markdown
-<!-- Inline math -->
-The equation $a^2 + b^2 = c^2$ is famous.
-
-<!-- Block math with $$ -->
-$$
-\begin{aligned}
-\nabla \cdot \vec{E} &= \frac{\rho}{\epsilon_0} \\
-\nabla \cdot \vec{B} &= 0
-\end{aligned}
-$$
-
-<!-- Block math with code fence -->
-```math
-\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
-```
-````
-
-### Mermaid Diagrams (mdbook-mermaid)
-
-````markdown
-```mermaid
-sequenceDiagram
-    participant A as Alice
-    participant B as Bob
-    A->>B: Hello Bob!
-    B->>A: Hi Alice!
-```
-````
-
-### Other Common Preprocessors
-
-````markdown
-<!-- mdbook-admonish -->
-```admonish warning
-This is a warning message.
+```text
+\{{#katex}}
+E = mc^2
+\{{/katex}}
 ```
 
-<!-- mdbook-toc -->
-{{#toc}}
+## Common Preprocessors
 
-<!-- mdbook-plantuml -->
-```plantuml
-@startuml
-Alice -> Bob: Hello
-@enduml
-```
-````
+| Preprocessor | Purpose |
+|--------------|---------|
+| `katex` | Math equations |
+| `mermaid` | Diagrams |
+| `toc` | Table of contents |
+| `template` | Template expansion |
+| `admonish` | Callout boxes |
 
 ## Configuration
 
-```toml
-# book.toml - Preprocessor configuration
-[preprocessor.katex]
-after = ["links"]
+This rule has no configuration options.
 
-[preprocessor.mermaid]
-command = "mdbook-mermaid"
+## Rule Details
 
-[preprocessor.admonish]
-command = "mdbook-admonish"
-
-# .mdbook-lint.toml - Rule configuration
-[MDBOOK010]
-check_math = true       # Validate math syntax (default: true)
-check_mermaid = true    # Validate mermaid syntax (default: true)
-allowed_preprocessors = ["katex", "mermaid", "admonish"]
-```
-
-## Common Issues and Solutions
-
-### Issue: Math Not Rendering
-
-```toml
-# book.toml - Ensure preprocessor is installed
-[preprocessor.katex]
-```
-
-```bash
-# Install the preprocessor
-cargo install mdbook-katex
-```
-
-### Issue: Delimiter Conflicts
-
-````markdown
-<!-- Problem: Dollar signs in code -->
-```bash
-echo "Price: $10"  # $ conflicts with math
-```
-
-<!-- Solution: Use code fence -->
-```text
-Price: $10
-```
-
-<!-- Or escape in inline code -->
-The price is `$10` (literal dollar sign)
-````
-
-### Issue: Complex Math Expressions
-
-````markdown
-<!-- Break complex expressions for readability -->
-$$
-\begin{aligned}
-f(x) &= \int_{0}^{x} t^2 dt \\
-     &= \left[ \frac{t^3}{3} \right]_{0}^{x} \\
-     &= \frac{x^3}{3}
-\end{aligned}
-$$
-````
-
-## Best Practices
-
-1. **Test preprocessors locally**: Verify rendering before committing
-2. **Use appropriate delimiters**: Choose based on content type
-3. **Document requirements**: List required preprocessors in README
-4. **Escape special characters**: Prevent delimiter conflicts
-5. **Keep it simple**: Break complex expressions into parts
-
-### Math Block Guidelines
-
-````markdown
-<!-- Good: Clear, well-formatted -->
-$$
-E = mc^2
-$$
-
-<!-- Better: With context -->
-Einstein's famous equation:
-$$
-E = mc^2
-$$
-where $E$ is energy, $m$ is mass, and $c$ is the speed of light.
-````
-
-### Diagram Guidelines
-
-````markdown
-<!-- Good: Simple, clear diagram -->
-```mermaid
-graph TD
-    A[Input] --> B[Process]
-    B --> C[Output]
-```
-
-<!-- Better: With descriptive labels -->
-```mermaid
-graph TD
-    A[User Input] --> B{Validate}
-    B -->|Valid| C[Process Data]
-    B -->|Invalid| D[Show Error]
-    C --> E[Return Result]
-```
-````
-
-## When to Disable
-
-Consider disabling this rule if:
-
-- You use custom preprocessors with different syntax
-- Your documentation doesn't use math or diagrams
-- You're migrating from another documentation system
-- You handle preprocessing externally
-
-### Disable in Config
-
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MDBOOK010"]
-```
-
-### Disable Inline
-
-````markdown
-<!-- mdbook-lint-disable MDBOOK010 -->
-$$
-\custom{syntax}
-$$
-<!-- mdbook-lint-enable MDBOOK010 -->
-````
-
-## Testing Preprocessor Output
-
-```bash
-# Build and check output
-mdbook build
-open book/index.html
-
-# Test specific preprocessor
-mdbook test
-
-# Clean build
-mdbook clean && mdbook build
-```
+- **Rule ID**: MDBOOK010
+- **Aliases**: preprocessor-validation
+- **Category**: MdBook
+- **Severity**: Warning
+- **Stability**: Experimental
+- **Auto-fix**: No
 
 ## Related Rules
 
-- [MD040](../standard/md040.html) - Code block language tags
-- [MD031](../standard/md031.html) - Fenced code blocks surrounded by blank lines
-
-## References
-
-- [mdBook Preprocessors](https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html)
-- [mdbook-katex](https://github.com/lzanini/mdbook-katex)
-- [mdbook-mermaid](https://github.com/badboy/mdbook-mermaid)
-- [mdbook-admonish](https://github.com/tommilligan/mdbook-admonish)
+- [MDBOOK011](./mdbook011.md) - Template validation

--- a/docs/src/rules/mdbook/mdbook011.md
+++ b/docs/src/rules/mdbook/mdbook011.md
@@ -1,307 +1,71 @@
-# MDBOOK011 - Invalid Template Syntax
+# MDBOOK011 - Template Validation
 
-**Severity**: Error  
-**Category**: mdBook-specific  
-**Auto-fix**: Not available
-
-## Rule Description
-
-This rule validates `{{#template}}` directives used with the mdbook-template preprocessor. It ensures correct syntax for template inclusion and variable substitution.
+Invalid `\{{#template}}` syntax.
 
 ## Why This Rule Exists
 
-Valid template syntax is important because:
-
-- Prevents build failures from malformed templates
-- Ensures consistent content across chapters
-- Enables proper variable substitution
-- Maintains template reusability
-- Helps identify template errors early
+The `\{{#template}}` directive expands templates with variable substitution.
+Invalid syntax or missing variables cause build failures.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
+### Incorrect
 
-```markdown
-<!-- Invalid directive syntax -->
-{{template file.md}}
-{{#templates file.md}}
+```text
+\{{#template missing-template.md}}
 
-<!-- Missing template file -->
-{{#template ./missing-template.md}}
+\{{#template ./template.md var1=value}}  <!-- Missing closing -->
 
-<!-- Invalid variable syntax -->
-{{#template ./template.md
-    name=value with spaces
-    key = value
-}}
-
-<!-- Unclosed directive -->
-{{#template ./template.md
-    var1=value1
+\{{template ./template.md}}  <!-- Missing # -->
 ```
 
-### ✅ Correct
+### Correct
 
-```markdown
-<!-- Basic template inclusion -->
-{{#template ./templates/header.md}}
+```text
+\{{#template ./templates/note.md}}
 
-<!-- Template with variables -->
-{{#template ./templates/api-doc.md
-    method=GET
-    endpoint=/api/users
-    description=Retrieves all users
-}}
-
-<!-- Multi-line variables -->
-{{#template ./templates/example.md
-    title=Introduction
-    content=This is the content
-    footer=Copyright 2024
-}}
+\{{#template ./templates/warning.md title="Important" content="Read carefully"}}
 ```
 
-## Template File Syntax
+## Template Syntax
 
-### Template Definition
+```text
+<!-- Basic template -->
+\{{#template path/to/template.md}}
 
-```markdown
-<!-- templates/api-doc.md -->
-## {{method}} {{endpoint}}
-
-{{description}}
-
-### Request
-```http
-{{method}} {{endpoint}} HTTP/1.1
-Host: api.example.com
+<!-- With variables -->
+\{{#template path/to/template.md var1="value1" var2="value2"}}
 ```
 
-### Response
+### Template File
 
-```json
-{
-    "status": "success",
-    "data": {{response_data}}
-}
+```text
+<!-- templates/note.md -->
+> **\{{title}}**
+>
+> \{{content}}
 ```
 
-```
+### Usage
 
-### Using the Template
-
-```markdown
-{{#template ./templates/api-doc.md
-    method=POST
-    endpoint=/api/users
-    description=Creates a new user
-    response_data={"id": 123, "name": "John"}
-}}
+```text
+\{{#template templates/note.md title="Note" content="This is important."}}
 ```
 
 ## Configuration
 
-```toml
-# book.toml
-[preprocessor.template]
+This rule has no configuration options.
 
-# .mdbook-lint.toml
-[MDBOOK011]
-template_dir = "./templates"  # Default template directory
-check_variables = true         # Validate variable substitution
-allow_missing_vars = false     # Allow undefined variables
-```
+## Rule Details
 
-## Common Issues and Solutions
-
-### Issue: Spaces in Variable Values
-
-```markdown
-<!-- Wrong: Unquoted spaces -->
-{{#template ./template.md
-    title=My Great Title
-}}
-
-<!-- Correct: Use quotes or underscores -->
-{{#template ./template.md
-    title="My Great Title"
-}}
-
-<!-- Or use underscores -->
-{{#template ./template.md
-    title=My_Great_Title
-}}
-```
-
-### Issue: Variable Not Replaced
-
-```markdown
-<!-- Template -->
-Hello {{name}}!
-
-<!-- Wrong variable name -->
-{{#template ./greeting.md
-    username=Alice  <!-- Should be 'name' -->
-}}
-
-<!-- Correct -->
-{{#template ./greeting.md
-    name=Alice
-}}
-```
-
-### Issue: Nested Templates
-
-```markdown
-<!-- templates/outer.md -->
-# {{title}}
-
-{{#template ./inner.md
-    content={{inner_content}}
-}}
-
-<!-- Using nested templates -->
-{{#template ./templates/outer.md
-    title=Documentation
-    inner_content=Details here
-}}
-```
-
-## Best Practices
-
-1. **Organize templates**: Keep in dedicated directory
-2. **Name variables clearly**: Use descriptive names
-3. **Document variables**: List required variables in template
-4. **Provide defaults**: Handle missing variables gracefully
-5. **Test substitution**: Verify all variables are replaced
-
-### Template Organization
-
-```
-book/
-├── src/
-│   ├── chapter1.md
-│   └── chapter2.md
-├── templates/
-│   ├── api/
-│   │   ├── request.md
-│   │   └── response.md
-│   ├── components/
-│   │   ├── header.md
-│   │   └── footer.md
-│   └── examples/
-│       └── code-block.md
-```
-
-### Self-Documenting Templates
-
-```markdown
-<!-- templates/documented.md -->
-<!--
-Template: API Endpoint Documentation
-Required variables:
-  - method: HTTP method (GET, POST, etc.)
-  - path: API endpoint path
-  - description: What this endpoint does
-Optional variables:
-  - params: Query parameters
-  - body: Request body example
--->
-
-## {{method}} {{path}}
-
-{{description}}
-
-{{#if params}}
-### Parameters
-{{params}}
-{{/if}}
-
-{{#if body}}
-### Request Body
-```json
-{{body}}
-```
-
-{{/if}}
-
-```
-
-## Advanced Usage
-
-### Conditional Content
-
-```markdown
-<!-- Template with conditional sections -->
-{{#if premium}}
-This content is only for premium users.
-{{/if}}
-
-{{#unless beta}}
-This feature is available in stable release.
-{{/unless}}
-```
-
-### Loops and Lists
-
-```markdown
-<!-- Template with repeated content -->
-{{#each items}}
-- {{this.name}}: {{this.description}}
-{{/each}}
-```
-
-### Default Values
-
-```markdown
-<!-- Template with defaults -->
-# {{title|Default Title}}
-
-Author: {{author|Anonymous}}
-Date: {{date|TBD}}
-```
-
-## When to Disable
-
-Consider disabling this rule if:
-
-- You don't use the template preprocessor
-- You use a different template system
-- Your templates are generated dynamically
-- You're migrating template syntax
-
-### Disable in Config
-
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MDBOOK011"]
-```
-
-### Disable Inline
-
-```markdown
-<!-- mdbook-lint-disable MDBOOK011 -->
-{{#template ./experimental-template.md}}
-<!-- mdbook-lint-enable MDBOOK011 -->
-```
-
-## Error Messages
-
-| Error | Solution |
-|-------|----------|
-| "Template file not found" | Check file path and existence |
-| "Invalid variable syntax" | Use key=value format |
-| "Undefined variable" | Ensure all variables are provided |
-| "Unclosed template directive" | Add closing }} |
+- **Rule ID**: MDBOOK011
+- **Aliases**: template-validation
+- **Category**: MdBook
+- **Severity**: Warning
+- **Stability**: Experimental
+- **Auto-fix**: No
 
 ## Related Rules
 
-- [MDBOOK007](./mdbook007.html) - Include directive validation
-- [MDBOOK012](./mdbook012.html) - Include line ranges
-
-## References
-
-- [mdbook-template](https://github.com/sgoudham/mdbook-template)
-- [mdBook Preprocessors](https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html)
-- [Handlebars Template Syntax](https://handlebarsjs.com/)
+- [MDBOOK007](./mdbook007.md) - Include validation
+- [MDBOOK010](./mdbook010.md) - Preprocessor validation

--- a/docs/src/rules/mdbook/mdbook012.md
+++ b/docs/src/rules/mdbook/mdbook012.md
@@ -1,252 +1,68 @@
-# MDBOOK012 - Invalid Include Line Ranges
+# MDBOOK012 - Include Line Range Validation
 
-**Severity**: Error  
-**Category**: mdBook-specific  
-**Auto-fix**: Not available
-
-## Rule Description
-
-This rule validates line range specifications in `{{#include}}` and `{{#rustdoc_include}}` directives. It ensures line numbers are valid and the specified ranges exist in the target files.
+Broken `\{{#include}}` line ranges.
 
 ## Why This Rule Exists
 
-Valid line ranges are important because:
-
-- Prevents build failures from invalid ranges
-- Ensures included content is accurate
-- Maintains documentation accuracy
-- Helps identify outdated line references
-- Prevents missing content in output
+Include directives with line ranges must reference valid line numbers. Ranges
+that exceed the file length or have invalid syntax cause build failures or
+unexpected content.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
+### Incorrect
 
-```markdown
-<!-- Invalid range syntax -->
-\{{#include ./file.md:1-10}}      <!-- Should use colons -->
-\{{#include ./file.md:10:5}}      <!-- End before start -->
-\{{#include ./file.md:0:10}}      <!-- Line numbers start at 1 -->
-\{{#include ./file.md:-5:10}}     <!-- Negative line number -->
+```text
+<!-- File has only 50 lines -->
+\{{#include ../src/lib.rs:100:150}}
 
-<!-- Out of bounds (file has 50 lines) -->
-\{{#include ./file.md:45:60}}     <!-- End exceeds file length -->
-\{{#include ./file.md:100}}       <!-- Line doesn't exist -->
+<!-- Invalid range (end before start) -->
+\{{#include ../src/lib.rs:20:10}}
 
-<!-- Invalid format -->
-\{{#include ./file.md:a:b}}       <!-- Non-numeric -->
-\{{#include ./file.md::}}         <!-- Empty range -->
+<!-- Non-numeric range -->
+\{{#include ../src/lib.rs:start:end}}
 ```
 
-### ✅ Correct
+### Correct
 
-```markdown
-<!-- Include specific lines -->
-\{{#include ./file.md:1:10}}      <!-- Lines 1-10 -->
-\{{#include ./file.md:5}}         <!-- Only line 5 -->
+```text
+\{{#include ../src/lib.rs:1:10}}
 
-<!-- Open-ended ranges -->
-\{{#include ./file.md:10:}}       <!-- From line 10 to end -->
-\{{#include ./file.md::20}}       <!-- From start to line 20 -->
+\{{#include ../src/lib.rs:5:}}
 
-<!-- Using anchors instead of lines -->
-\{{#include ./file.md:example}}   <!-- More stable than line numbers -->
+\{{#include ../src/lib.rs::20}}
 ```
 
 ## Line Range Syntax
 
-### Syntax Options
+```text
+<!-- Lines 5 through 10 -->
+\{{#include file.rs:5:10}}
 
-| Syntax | Description | Example |
-|--------|-------------|---------|
-| `:start:end` | Lines from start to end | `:1:10` |
-| `:line` | Single line | `:42` |
-| `:start:` | From start to end of file | `:10:` |
-| `::end` | From beginning to end | `::25` |
-| `:anchor` | Include anchor section | `:my_example` |
+<!-- Line 5 to end of file -->
+\{{#include file.rs:5:}}
 
-### Examples 2
+<!-- Start of file through line 10 -->
+\{{#include file.rs::10}}
 
-```markdown
-<!-- Include lines 5-10 -->
-\{{#include ./example.rs:5:10}}
-
-<!-- Include from line 20 to end -->
-\{{#include ./example.rs:20:}}
-
-<!-- Include first 15 lines -->
-\{{#include ./example.rs::15}}
-
-<!-- Include single line -->
-\{{#include ./example.rs:7}}
+<!-- Single line (line 5 only) -->
+\{{#include file.rs:5:5}}
 ```
 
 ## Configuration
 
-```toml
-[MDBOOK012]
-validate_bounds = true    # Check if line numbers exist (default: true)
-warn_large_ranges = true  # Warn for ranges > 100 lines (default: true)
-max_range_size = 100      # Maximum lines in a range (default: 100)
-prefer_anchors = true     # Suggest anchors over line numbers (default: true)
-```
+This rule has no configuration options.
 
-## Common Issues and Solutions
+## Rule Details
 
-### Issue: File Changes Break Ranges
-
-```markdown
-<!-- Original: function at lines 10-15 -->
-\{{#include ./code.rs:10:15}}
-
-<!-- After refactoring: function moved to lines 25-30 -->
-<!-- BROKEN: Still references old location -->
-\{{#include ./code.rs:10:15}}
-
-<!-- Solution: Use anchors -->
-\{{#include ./code.rs:my_function}}
-```
-
-### Issue: Off-by-One Errors
-
-```markdown
-<!-- Want to include lines with function (lines 5-8) -->
-
-<!-- Wrong: Missing first line -->
-\{{#include ./code.rs:6:8}}
-
-<!-- Correct: Include all lines -->
-\{{#include ./code.rs:5:8}}
-```
-
-### Issue: Including Too Much
-
-```markdown
-<!-- Bad: Including entire file when only need part -->
-\{{#include ./large-file.md:1:500}}
-
-<!-- Better: Include specific section -->
-\{{#include ./large-file.md:45:67}}
-
-<!-- Best: Use anchor -->
-\{{#include ./large-file.md:relevant_section}}
-```
-
-## Best Practices
-
-1. **Prefer anchors over line numbers**: More stable across edits
-2. **Keep ranges small**: Include only what's necessary
-3. **Document ranges**: Comment what's being included
-4. **Update after refactoring**: Check includes after moving code
-5. **Test includes**: Verify correct content is included
-
-### Using Anchors Instead
-
-```rust
-// code.rs
-// ANCHOR: database_connection
-fn connect_to_database() -> Result<Connection, Error> {
-    let url = env::var("DATABASE_URL")?;
-    Connection::new(&url)
-}
-// ANCHOR_END: database_connection
-```
-
-```markdown
-<!-- More stable than line numbers -->
-\{{#include ./code.rs:database_connection}}
-```
-
-### Documenting Includes
-
-```markdown
-<!-- Include the main function (lines 15-25) -->
-\{{#include ./example.rs:15:25}}
-
-<!-- Include error handling example -->
-\{{#include ./errors.rs:error_handling}}
-```
-
-## Line Counting Rules
-
-1. **Line numbers start at 1**: First line is line 1, not 0
-2. **Inclusive ranges**: Both start and end lines are included
-3. **Empty lines count**: Blank lines are counted in numbering
-4. **Comments count**: Comment lines are included in count
-
-### Example File Numbering
-
-```rust
-// Line 1: Comment
-// Line 2: Another comment
-                          // Line 3: Empty line
-fn main() {               // Line 4
-    println!("Hello");    // Line 5
-}                         // Line 6
-```
-
-## When to Disable
-
-Consider disabling this rule if:
-
-- Your files are generated and line numbers are stable
-- You're migrating content with many includes
-- You use a different include mechanism
-- Your build process validates includes separately
-
-### Disable in Config
-
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MDBOOK012"]
-```
-
-### Disable Inline
-
-```markdown
-<!-- mdbook-lint-disable MDBOOK012 -->
-\{{#include ./generated.md:1:1000}}
-<!-- mdbook-lint-enable MDBOOK012 -->
-```
-
-## Debugging Line Ranges
-
-### View File with Line Numbers
-
-```bash
-# Show file with line numbers
-cat -n file.md
-
-# Show specific lines
-sed -n '10,20p' file.md
-
-# Count total lines
-wc -l file.md
-```
-
-### Test Include Output
-
-```bash
-# Build and check included content
-mdbook build
-grep -A5 -B5 "included content" book/chapter.html
-```
-
-## Error Messages
-
-| Error | Solution |
-|-------|----------|
-| "Line number out of range" | Check file length |
-| "Invalid range syntax" | Use correct format `:start:end` |
-| "End before start" | Ensure start < end |
-| "File not found" | Verify file path |
+- **Rule ID**: MDBOOK012
+- **Aliases**: include-line-range-validation
+- **Category**: MdBook
+- **Severity**: Error
+- **Stability**: Experimental
+- **Auto-fix**: No
 
 ## Related Rules
 
-- [MDBOOK007](./mdbook007.html) - Include directive validation
-- [MDBOOK008](./mdbook008.html) - Rustdoc include validation
-
-## References
-
-- [mdBook - Including Files](https://rust-lang.github.io/mdBook/format/markdown.html#including-files)
-- [mdBook - Including Portions](https://rust-lang.github.io/mdBook/format/markdown.html#including-portions-of-files)
+- [MDBOOK007](./mdbook007.md) - Include validation
+- [MDBOOK008](./mdbook008.md) - Rustdoc include validation

--- a/docs/src/rules/standard/emphasis.md
+++ b/docs/src/rules/standard/emphasis.md
@@ -1,0 +1,30 @@
+# Emphasis Rules
+
+Rules for formatting bold and italic text.
+
+## Rules in This Category
+
+| Rule | Description | Auto-fix |
+|------|-------------|----------|
+| [MD036](./md036.md) | Emphasis used instead of heading | No |
+| [MD037](./md037.md) | Spaces inside emphasis markers | Yes |
+| [MD049](./md049.md) | Emphasis style consistency | Yes |
+| [MD050](./md050.md) | Strong emphasis style consistency | Yes |
+
+## Overview
+
+Emphasis rules ensure consistent formatting of bold (`**text**`) and italic
+(`*text*`) text throughout your documents.
+
+### Common Issues
+
+- Using `**bold**` on a line by itself as a pseudo-heading
+- Spaces inside markers like `**bold**` that may not render
+
+- Mixing asterisks and underscores inconsistently
+
+### Best Practices
+
+- Use real headings (`##`) instead of bold text for sections
+- Keep emphasis markers tight against text (no internal spaces)
+- Choose one style (asterisks or underscores) and use it consistently

--- a/docs/src/rules/standard/headings.md
+++ b/docs/src/rules/standard/headings.md
@@ -56,13 +56,13 @@ Heading 2
 Some prefer closed ATX headings for symmetry:
 
 ```markdown
-# Heading 1#
+#Heading 1#
 
 
-## Heading 2##
+##Heading 2##
 
 
-### Heading 3###
+###Heading 3###
 
 
 ```

--- a/docs/src/rules/standard/html.md
+++ b/docs/src/rules/standard/html.md
@@ -1,0 +1,40 @@
+# HTML Rules
+
+Rules for inline HTML usage in Markdown.
+
+## Rules in This Category
+
+| Rule | Description | Auto-fix |
+|------|-------------|----------|
+| [MD033](./md033.md) | Inline HTML should be avoided | No |
+
+## Overview
+
+HTML rules control the use of raw HTML within Markdown documents. While
+Markdown supports inline HTML, using it reduces portability and can
+introduce security concerns.
+
+### Why Avoid HTML
+
+- **Portability**: Not all Markdown renderers support HTML
+- **Security**: HTML can introduce XSS vulnerabilities
+- **Maintainability**: Markdown is easier to read and maintain
+- **Consistency**: Mixing HTML and Markdown creates inconsistent documents
+
+### When HTML Is Acceptable
+
+Some features require HTML:
+
+- Collapsible sections (`<details>`)
+- Keyboard shortcuts (`<kbd>`)
+- Subscript/superscript (`<sub>`, `<sup>`)
+- Complex layouts not possible in Markdown
+
+### Configuration
+
+Allow specific HTML elements while blocking others:
+
+```toml
+[MD033]
+allowed_elements = ["details", "summary", "kbd", "br"]
+```

--- a/docs/src/rules/standard/images.md
+++ b/docs/src/rules/standard/images.md
@@ -1,0 +1,34 @@
+# Image Rules
+
+Rules for image formatting and accessibility.
+
+## Rules in This Category
+
+| Rule | Description | Auto-fix |
+|------|-------------|----------|
+| [MD045](./md045.md) | Images should have alt text | Yes |
+
+## Overview
+
+Image rules ensure that images are accessible and properly formatted.
+
+### Why Alt Text Matters
+
+Alt text (alternative text) serves multiple purposes:
+
+- **Accessibility**: Screen readers use alt text to describe images
+- **Fallback**: Displays when images fail to load
+- **SEO**: Search engines use alt text to understand image content
+
+### Best Practices
+
+- Write descriptive alt text that conveys the image's purpose
+- Keep alt text concise but informative
+- For decorative images, use empty alt text `![](image.png)`
+- Describe charts and diagrams with their key data points
+
+### Example
+
+```markdown
+![Bar chart showing 50% increase in sales from Q1 to Q4](sales-chart.png)
+```

--- a/docs/src/rules/standard/md002.md
+++ b/docs/src/rules/standard/md002.md
@@ -1,0 +1,60 @@
+# MD002 - First Heading H1
+
+First heading should be a top-level heading (H1).
+
+> **Deprecated**: This rule is superseded by [MD041](./md041.md) which offers an
+> improved implementation. Consider using MD041 instead.
+
+## Why This Rule Exists
+
+Documents should start with a top-level heading (H1) to establish proper
+hierarchy. This ensures consistent document structure and helps screen readers
+and document outlines understand the content organization.
+
+## Examples
+
+### Incorrect
+
+```markdown
+## Introduction
+
+This document starts with an H2.
+```
+
+### Correct
+
+```markdown
+# Document Title
+
+## Introduction
+
+The document properly starts with an H1.
+```
+
+## Configuration
+
+```toml
+[MD002]
+level = 1  # Expected first heading level (default: 1)
+```
+
+## When to Disable
+
+- When using MD041 instead (recommended)
+- Documents that are fragments or partials
+- Auto-generated content with different conventions
+
+## Rule Details
+
+- **Rule ID**: MD002
+- **Aliases**: first-heading-h1
+- **Category**: Structure
+- **Severity**: Warning
+- **Auto-fix**: Yes (can add H1 if missing)
+- **Deprecated**: Yes (use MD041)
+
+## Related Rules
+
+- [MD001](./md001.md) - Heading increment
+- [MD041](./md041.md) - First line should be a top-level heading (replacement)
+- [MD025](./md025.md) - Single top-level heading

--- a/docs/src/rules/standard/md003.md
+++ b/docs/src/rules/standard/md003.md
@@ -1,0 +1,95 @@
+# MD003 - Heading Style
+
+Heading style should be consistent throughout the document.
+
+## Why This Rule Exists
+
+Markdown supports multiple heading styles. Mixing styles within a document creates
+visual inconsistency and can confuse readers and tooling.
+
+## Heading Styles
+
+### ATX Style (Recommended)
+
+```markdown
+# Heading 1
+## Heading 2
+### Heading 3
+```
+
+### ATX Closed Style
+
+```markdown
+#Heading 1#
+
+##Heading 2##
+
+###Heading 3###
+
+```
+
+### Setext Style (H1 and H2 only)
+
+```markdown
+Heading 1
+=========
+
+Heading 2
+---------
+```
+
+## Examples
+
+### Incorrect
+
+```markdown
+# ATX Heading
+
+Setext Heading
+--------------
+
+### Another ATX
+```
+
+### Correct
+
+```markdown
+# Main Title
+
+## Section One
+
+### Subsection
+```
+
+## Configuration
+
+```toml
+[MD003]
+style = "atx"  # Options: "atx", "atx_closed", "setext", "consistent"
+```
+
+| Value | Description |
+|-------|-------------|
+| `atx` | Use `#` style headings |
+| `atx_closed` | Use `# Heading #` style |
+| `setext` | Use underline style (H1/H2 only) |
+| `consistent` | Match the first heading's style |
+
+## When to Disable
+
+- Working with legacy documents using mixed styles
+- Importing content from multiple sources
+
+## Rule Details
+
+- **Rule ID**: MD003
+- **Aliases**: heading-style
+- **Category**: Structure
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD001](./md001.md) - Heading increment
+- [MD018](./md018.md) - Space after hash in ATX headings
+- [MD019](./md019.md) - Multiple spaces after hash

--- a/docs/src/rules/standard/md004.md
+++ b/docs/src/rules/standard/md004.md
@@ -1,0 +1,69 @@
+# MD004 - Unordered List Style
+
+Unordered list style should be consistent.
+
+## Why This Rule Exists
+
+Markdown supports three markers for unordered lists: `-`, `*`, and `+`. Using
+different markers inconsistently creates visual noise and can indicate
+accidental mixing of content from different sources.
+
+## Examples
+
+### Incorrect
+
+```markdown
+- Item one
+* Item two
++ Item three
+```
+
+### Correct
+
+```markdown
+- Item one
+- Item two
+- Item three
+```
+
+Or consistently using asterisks:
+
+```markdown
+* Item one
+* Item two
+* Item three
+```
+
+## Configuration
+
+```toml
+[MD004]
+style = "dash"  # Options: "dash", "asterisk", "plus", "consistent"
+```
+
+| Value | Marker | Example |
+|-------|--------|---------|
+| `dash` | `-` | `- Item` |
+| `asterisk` | `*` | `* Item` |
+| `plus` | `+` | `+ Item` |
+| `consistent` | First used | Matches first list marker |
+
+## When to Disable
+
+- Documents intentionally using different markers to distinguish list types
+- Importing content from multiple sources
+
+## Rule Details
+
+- **Rule ID**: MD004
+- **Aliases**: ul-style
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD005](./md005.md) - List item indentation
+- [MD006](./md006.md) - Lists start at beginning of line
+- [MD007](./md007.md) - Unordered list indentation
+- [MD029](./md029.md) - Ordered list prefix style

--- a/docs/src/rules/standard/md005.md
+++ b/docs/src/rules/standard/md005.md
@@ -1,0 +1,61 @@
+# MD005 - List Item Indentation
+
+List item indentation should be consistent within a list.
+
+## Why This Rule Exists
+
+Inconsistent indentation within lists can cause rendering issues and makes
+documents harder to read in source form. Proper indentation also ensures
+nested lists render correctly.
+
+## Examples
+
+### Incorrect
+
+```markdown
+- Item one
+ - Item two (wrong indentation)
+- Item three
+```
+
+### Correct
+
+```markdown
+- Item one
+- Item two
+- Item three
+```
+
+### Nested Lists (Correct)
+
+```markdown
+- Item one
+  - Nested item
+  - Another nested
+- Item two
+```
+
+## Configuration
+
+This rule has no configuration options. It enforces consistent indentation
+within each list.
+
+## When to Disable
+
+- Working with auto-generated content that has intentional spacing
+- Documents with complex nested structures requiring manual control
+
+## Rule Details
+
+- **Rule ID**: MD005
+- **Aliases**: list-indent
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD004](./md004.md) - Unordered list style
+- [MD006](./md006.md) - Lists start at beginning of line
+- [MD007](./md007.md) - Unordered list indentation depth
+- [MD030](./md030.md) - Spaces after list markers

--- a/docs/src/rules/standard/md006.md
+++ b/docs/src/rules/standard/md006.md
@@ -1,0 +1,60 @@
+# MD006 - List Start Left
+
+Consider starting bulleted lists at the beginning of the line.
+
+## Why This Rule Exists
+
+Lists that don't start at the beginning of the line can cause unexpected
+rendering behavior in some Markdown parsers. Starting lists at column 0
+ensures consistent rendering across all platforms.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Some text:
+  - Indented list item
+  - Another indented item
+```
+
+### Correct
+
+```markdown
+Some text:
+
+- List item at start of line
+- Another item at start of line
+```
+
+### Nested Lists (Allowed)
+
+```markdown
+- Top level item
+  - Nested item (indentation is fine for nesting)
+  - Another nested item
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Documents with intentionally indented lists for specific formatting
+- Content that uses indentation for semantic meaning
+
+## Rule Details
+
+- **Rule ID**: MD006
+- **Aliases**: ul-start-left
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD004](./md004.md) - Unordered list style
+- [MD005](./md005.md) - List item indentation consistency
+- [MD007](./md007.md) - Unordered list indentation
+- [MD023](./md023.md) - Headings start at beginning of line

--- a/docs/src/rules/standard/md007.md
+++ b/docs/src/rules/standard/md007.md
@@ -1,0 +1,70 @@
+# MD007 - Unordered List Indentation
+
+Unordered list indentation should use consistent spacing.
+
+## Why This Rule Exists
+
+Proper indentation of nested lists ensures correct rendering and improves
+readability. Different Markdown parsers may interpret inconsistent indentation
+differently.
+
+## Examples
+
+### Incorrect (4-space indent when 2 expected)
+
+```markdown
+- Item one
+    - Nested too far
+- Item two
+```
+
+### Correct (2-space indent)
+
+```markdown
+- Item one
+  - Properly nested
+  - Another nested item
+- Item two
+```
+
+### Correct (4-space indent with configuration)
+
+```markdown
+- Item one
+    - Nested with 4 spaces
+    - Another nested item
+- Item two
+```
+
+## Configuration
+
+```toml
+[MD007]
+indent = 2           # Spaces per indentation level (default: 2)
+start_indented = false  # Allow first level to be indented
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `indent` | 2 | Number of spaces per nesting level |
+| `start_indented` | false | Allow top-level items to be indented |
+
+## When to Disable
+
+- Documents following a different indentation standard
+- Content imported from tools using different conventions
+
+## Rule Details
+
+- **Rule ID**: MD007
+- **Aliases**: ul-indent
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD004](./md004.md) - Unordered list style
+- [MD005](./md005.md) - List item indentation consistency
+- [MD006](./md006.md) - Lists start at beginning of line
+- [MD029](./md029.md) - Ordered list prefix style

--- a/docs/src/rules/standard/md011.md
+++ b/docs/src/rules/standard/md011.md
@@ -1,0 +1,49 @@
+# MD011 - Reversed Link Syntax
+
+Reversed link syntax should be corrected.
+
+## Why This Rule Exists
+
+A common typo when writing Markdown links is reversing the bracket order,
+writing `](url)[text` instead of `[text](url)`. This rule catches these
+mistakes before they break your rendered documentation.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Check out ](https://example.com)[this link for more info.
+
+See ](./other-page.md)[the other page.
+```
+
+### Correct
+
+```markdown
+Check out [this link](https://example.com) for more info.
+
+See [the other page](./other-page.md).
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Generally should not be disabled as reversed links never render correctly
+
+## Rule Details
+
+- **Rule ID**: MD011
+- **Aliases**: no-reversed-links
+- **Category**: Content
+- **Severity**: Error
+- **Auto-fix**: Yes (swaps to correct order)
+
+## Related Rules
+
+- [MD034](./md034.md) - Bare URLs
+- [MD039](./md039.md) - Spaces inside link text
+- [MD042](./md042.md) - Empty links

--- a/docs/src/rules/standard/md014.md
+++ b/docs/src/rules/standard/md014.md
@@ -1,0 +1,69 @@
+# MD014 - Dollar Signs in Commands
+
+Dollar signs used before commands without showing output.
+
+## Why This Rule Exists
+
+Including `$` prompts in shell code blocks makes it harder for users to copy
+and paste commands. If the code block shows command output, the prompt helps
+distinguish input from output. Otherwise, it's just noise.
+
+## Examples
+
+### Incorrect
+
+```markdown
+```bash
+$ npm install
+$ npm run build
+```
+
+
+```
+
+### Correct (no prompts)
+
+```markdown
+```bash
+npm install
+npm run build
+```
+
+
+```
+
+### Correct (showing output)
+
+```markdown
+```bash
+$ echo "Hello"
+Hello
+$ ls
+file1.txt  file2.txt
+```
+
+
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Tutorial content where prompts help indicate user input
+- Documents showing interactive shell sessions
+- Content distinguishing between different shell types
+
+## Rule Details
+
+- **Rule ID**: MD014
+- **Aliases**: no-dollar-signs, commands-show-output
+- **Category**: Content
+- **Severity**: Warning
+- **Auto-fix**: Yes (removes `$` prefix)
+
+## Related Rules
+
+- [MD040](./md040.md) - Fenced code blocks should have language
+- [MD046](./md046.md) - Code block style

--- a/docs/src/rules/standard/md020.md
+++ b/docs/src/rules/standard/md020.md
@@ -22,7 +22,7 @@ Proper closed heading format is important because:
 ### ❌ Incorrect (violates rule)
 
 ```markdown
-# Heading with space before closing#
+#Heading with space before closing#
 
 
 ## Another heading ##  
@@ -32,13 +32,13 @@ Proper closed heading format is important because:
 ### ✅ Correct
 
 ```markdown
-# Heading with proper closing#
+#Heading with proper closing#
 
 
-## Another heading##
+##Another heading##
 
 
-### Correctly closed heading###
+###Correctly closed heading###
 
 
 # Open heading is also fine

--- a/docs/src/rules/standard/md021.md
+++ b/docs/src/rules/standard/md021.md
@@ -22,13 +22,13 @@ Single space inside closed headings is important because:
 ### ❌ Incorrect (violates rule)
 
 ```markdown
-# Heading with multiple spaces#
+#Heading with multiple spaces#
 
 
-## Another heading##
+##Another heading##
 
 
-### Too many internal spaces###
+###Too many internal spaces###
 
 
 ```
@@ -36,13 +36,13 @@ Single space inside closed headings is important because:
 ### ✅ Correct
 
 ```markdown
-# Heading with single spaces#
+#Heading with single spaces#
 
 
-## Another heading##
+##Another heading##
 
 
-### Properly spaced heading###
+###Properly spaced heading###
 
 
 # Open heading is also fine
@@ -88,7 +88,7 @@ disabled_rules = ["MD021"]
 
 ```markdown
 <!-- mdbook-lint-disable MD021 -->
-## Heading with multiple spaces##
+##Heading with multiple spaces##
 
 
 <!-- mdbook-lint-enable MD021 -->

--- a/docs/src/rules/standard/md022.md
+++ b/docs/src/rules/standard/md022.md
@@ -1,0 +1,56 @@
+# MD022 - Blanks Around Headings
+
+Headings should be surrounded by blank lines.
+
+## Why This Rule Exists
+
+Blank lines around headings improve readability and ensure consistent rendering
+across Markdown parsers. Some parsers require blank lines to properly recognize
+headings.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Some paragraph text.
+## Heading
+More text here.
+```
+
+### Correct
+
+```markdown
+Some paragraph text.
+
+## Heading
+
+More text here.
+```
+
+## Configuration
+
+```toml
+[MD022]
+lines_above = 1  # Blank lines before heading (default: 1)
+lines_below = 1  # Blank lines after heading (default: 1)
+```
+
+## When to Disable
+
+- Documents with compact formatting requirements
+- Content where headings immediately follow other headings
+
+## Rule Details
+
+- **Rule ID**: MD022
+- **Aliases**: blanks-around-headings
+- **Category**: Structure
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD023](./md023.md) - Headings start at beginning of line
+- [MD031](./md031.md) - Blanks around fenced code blocks
+- [MD032](./md032.md) - Blanks around lists

--- a/docs/src/rules/standard/md024.md
+++ b/docs/src/rules/standard/md024.md
@@ -1,0 +1,82 @@
+# MD024 - No Duplicate Headings
+
+Multiple headings with the same content.
+
+## Why This Rule Exists
+
+Duplicate headings can confuse readers and break anchor links. Each heading
+generates a URL fragment, and duplicates create ambiguous navigation targets.
+
+## Examples
+
+### Incorrect
+
+```markdown
+# Guide
+
+## Introduction
+
+Some content.
+
+## Introduction
+
+More content with same heading.
+```
+
+### Correct
+
+```markdown
+# Guide
+
+## Introduction
+
+Some content.
+
+## Getting Started
+
+Different heading for different section.
+```
+
+### Siblings Only Mode
+
+With `siblings_only: true`, duplicates are allowed in different sections:
+
+```markdown
+# Chapter 1
+
+## Summary
+
+Chapter 1 summary.
+
+# Chapter 2
+
+## Summary
+
+Chapter 2 summary (allowed - different parent).
+```
+
+## Configuration
+
+```toml
+[MD024]
+siblings_only = false  # Only check sibling headings (default: false)
+allow_different_nesting = false  # Allow same text at different levels
+```
+
+## When to Disable
+
+- Documents with intentionally repeated section names
+- Auto-generated content with structured repetition
+
+## Rule Details
+
+- **Rule ID**: MD024
+- **Aliases**: no-duplicate-heading
+- **Category**: Content
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Related Rules
+
+- [MD025](./md025.md) - Single top-level heading
+- [MD051](./md051.md) - Link fragments validation

--- a/docs/src/rules/standard/md025.md
+++ b/docs/src/rules/standard/md025.md
@@ -1,0 +1,72 @@
+# MD025 - Single Top-Level Heading
+
+Multiple top-level headings in the same document.
+
+## Why This Rule Exists
+
+A document should have a single H1 heading that serves as its title. Multiple
+H1 headings suggest the content should be split into separate documents or
+the heading hierarchy needs adjustment.
+
+## Examples
+
+### Incorrect
+
+```markdown
+# First Title
+
+Content here.
+
+# Second Title
+
+More content.
+```
+
+### Correct
+
+```markdown
+# Document Title
+
+## First Section
+
+Content here.
+
+## Second Section
+
+More content.
+```
+
+## Configuration
+
+```toml
+[MD025]
+level = 1        # Heading level to check (default: 1)
+front_matter_title = ""  # Regex for front matter title
+```
+
+## When to Disable
+
+- SUMMARY.md files in mdBook (use MDBOOK025 instead)
+- Documents intentionally containing multiple articles
+- Changelog files with version headings as H1
+
+## Rule Details
+
+- **Rule ID**: MD025
+- **Aliases**: single-title, single-h1
+- **Category**: Structure
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## mdBook Integration
+
+For SUMMARY.md files, this rule is automatically relaxed. Use
+[MDBOOK025](../mdbook/mdbook025.md) which understands mdBook's
+multi-section SUMMARY format.
+
+## Related Rules
+
+- [MD001](./md001.md) - Heading increment
+- [MD002](./md002.md) - First heading H1
+- [MD041](./md041.md) - First line top-level heading
+- [MDBOOK025](../mdbook/mdbook025.md) - SUMMARY.md heading structure

--- a/docs/src/rules/standard/md026.md
+++ b/docs/src/rules/standard/md026.md
@@ -1,0 +1,67 @@
+# MD026 - No Trailing Punctuation
+
+Trailing punctuation in headings.
+
+## Why This Rule Exists
+
+Headings typically don't end with punctuation like periods or commas.
+Trailing punctuation can look awkward in tables of contents and navigation
+menus.
+
+## Examples
+
+### Incorrect
+
+```markdown
+# Welcome to the Guide.
+
+## Getting Started:
+
+### What is Markdown?
+```
+
+### Correct
+
+```markdown
+# Welcome to the Guide
+
+## Getting Started
+
+### What is Markdown
+```
+
+### Questions (Configurable)
+
+```markdown
+## Frequently Asked Questions
+
+### How do I install it?
+```
+
+## Configuration
+
+```toml
+[MD026]
+punctuation = ".,;:!?"  # Characters to flag (default: ".,;:!")
+```
+
+The `?` is excluded by default to allow question headings in FAQ sections.
+
+## When to Disable
+
+- Documents with headings that are complete sentences
+- Stylistic choice to include punctuation
+- FAQ sections with question marks (or adjust `punctuation` config)
+
+## Rule Details
+
+- **Rule ID**: MD026
+- **Aliases**: no-trailing-punctuation
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes (removes trailing punctuation)
+
+## Related Rules
+
+- [MD018](./md018.md) - Space after hash
+- [MD021](./md021.md) - Spaces in closed ATX headings

--- a/docs/src/rules/standard/md027.md
+++ b/docs/src/rules/standard/md027.md
@@ -24,8 +24,10 @@ Consistent blockquote spacing is important because:
 ```markdown
 > Multiple spaces after blockquote marker
 >
+>
 
 > Even more spaces here
+>
 >
 
 > Too much spacing
@@ -38,6 +40,7 @@ Consistent blockquote spacing is important because:
 > Single space after marker
 > Consistent spacing throughout
 > Clean and readable
+>
 >
 >
 

--- a/docs/src/rules/standard/md028.md
+++ b/docs/src/rules/standard/md028.md
@@ -1,0 +1,59 @@
+# MD028 - No Blanks in Blockquote
+
+Blank line inside blockquote.
+
+## Why This Rule Exists
+
+A blank line inside a blockquote ends the quote in most Markdown parsers.
+This can cause unexpected rendering where content intended to be quoted
+appears as regular text.
+
+## Examples
+
+### Incorrect
+
+```markdown
+> First paragraph of quote.
+>
+
+> Second paragraph (this is a new blockquote).
+```
+
+### Correct
+
+```markdown
+> First paragraph of quote.
+>
+> Second paragraph (still in same blockquote).
+```
+
+### Multiple Paragraphs
+
+```markdown
+> This is a long quote that spans
+> multiple paragraphs.
+>
+> The blank line has a `>` marker
+> to continue the blockquote.
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Documents intentionally using separate blockquotes
+- Content where visual separation is desired
+
+## Rule Details
+
+- **Rule ID**: MD028
+- **Aliases**: no-blanks-blockquote
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes (adds `>` to blank lines)
+
+## Related Rules
+
+- [MD027](./md027.md) - Multiple spaces after blockquote symbol

--- a/docs/src/rules/standard/md029.md
+++ b/docs/src/rules/standard/md029.md
@@ -1,0 +1,88 @@
+# MD029 - Ordered List Prefix
+
+Ordered list item prefix consistency.
+
+## Why This Rule Exists
+
+Markdown supports different numbering styles for ordered lists. Consistent
+style improves readability and makes reordering items easier.
+
+## Styles
+
+### One-Based (All 1s)
+
+```markdown
+1. First item
+1. Second item
+1. Third item
+```
+
+Advantage: Easy to reorder without renumbering.
+
+### Sequential (Ordered)
+
+```markdown
+1. First item
+2. Second item
+3. Third item
+```
+
+Advantage: Source reflects rendered numbers.
+
+### Zero-Based
+
+```markdown
+0. First item
+0. Second item
+0. Third item
+```
+
+## Examples
+
+### Incorrect (Mixed)
+
+```markdown
+1. First item
+2. Second item
+1. Third item
+```
+
+### Correct
+
+```markdown
+1. First item
+2. Second item
+3. Third item
+```
+
+## Configuration
+
+```toml
+[MD029]
+style = "one_or_ordered"  # Options: "one", "ordered", "zero", "one_or_ordered"
+```
+
+| Value | Description |
+|-------|-------------|
+| `one` | All items use `1.` |
+| `ordered` | Sequential numbering (1, 2, 3...) |
+| `zero` | All items use `0.` |
+| `one_or_ordered` | Allow either `1.` or sequential |
+
+## When to Disable
+
+- Documents with intentional mixed numbering
+- Content using numbers for reference purposes
+
+## Rule Details
+
+- **Rule ID**: MD029
+- **Aliases**: ol-prefix
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD004](./md004.md) - Unordered list style
+- [MD030](./md030.md) - Spaces after list markers

--- a/docs/src/rules/standard/md031.md
+++ b/docs/src/rules/standard/md031.md
@@ -1,0 +1,63 @@
+# MD031 - Blanks Around Fences
+
+Fenced code blocks should be surrounded by blank lines.
+
+## Why This Rule Exists
+
+Blank lines around code blocks improve readability and ensure consistent
+rendering. Some parsers may not correctly identify code blocks without
+surrounding blank lines.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Some text here.
+```code
+let x = 1;
+```
+
+More text here.
+
+```
+
+### Correct
+
+```markdown
+Some text here.
+
+```code
+let x = 1;
+```
+
+More text here.
+
+```
+
+## Configuration
+
+```toml
+[MD031]
+list_items = true  # Apply rule inside list items (default: true)
+```
+
+## When to Disable
+
+- Documents with compact formatting requirements
+- Content where code blocks intentionally flow with text
+
+## Rule Details
+
+- **Rule ID**: MD031
+- **Aliases**: blanks-around-fences
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD022](./md022.md) - Blanks around headings
+- [MD032](./md032.md) - Blanks around lists
+- [MD040](./md040.md) - Fenced code blocks language
+- [MD046](./md046.md) - Code block style

--- a/docs/src/rules/standard/md032.md
+++ b/docs/src/rules/standard/md032.md
@@ -1,0 +1,53 @@
+# MD032 - Blanks Around Lists
+
+Lists should be surrounded by blank lines.
+
+## Why This Rule Exists
+
+Blank lines around lists ensure proper parsing and improve readability. Without
+blank lines, some Markdown parsers may not correctly identify list boundaries.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Some introductory text.
+- Item one
+- Item two
+Following paragraph.
+```
+
+### Correct
+
+```markdown
+Some introductory text.
+
+- Item one
+- Item two
+
+Following paragraph.
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Documents with compact formatting requirements
+- Content with tight list-to-text flow
+
+## Rule Details
+
+- **Rule ID**: MD032
+- **Aliases**: blanks-around-lists
+- **Category**: Structure
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD022](./md022.md) - Blanks around headings
+- [MD031](./md031.md) - Blanks around fenced code blocks
+- [MD058](./md058.md) - Blanks around tables

--- a/docs/src/rules/standard/md033.md
+++ b/docs/src/rules/standard/md033.md
@@ -1,0 +1,77 @@
+# MD033 - No Inline HTML
+
+Inline HTML should be avoided.
+
+## Why This Rule Exists
+
+Markdown documents should remain portable and renderable in environments
+that don't support HTML. Raw HTML also makes documents harder to maintain
+and can introduce security concerns in some contexts.
+
+## Examples
+
+### Incorrect
+
+```markdown
+<div class="warning">
+This is a warning message.
+</div>
+
+Click <a href="https://example.com">here</a> for more.
+
+<br>
+
+<img src="image.png" alt="An image">
+```
+
+### Correct
+
+```markdown
+> **Warning**: This is a warning message.
+
+Click [here](https://example.com) for more.
+
+![An image](image.png)
+```
+
+## Configuration
+
+```toml
+[MD033]
+allowed_elements = []  # HTML elements to allow (default: none)
+```
+
+### Allow Specific Elements
+
+```toml
+[MD033]
+allowed_elements = ["br", "details", "summary"]
+```
+
+## When to Disable
+
+- Documents requiring HTML features not in Markdown
+- Content using HTML for accessibility features
+- mdBook projects using HTML preprocessors
+
+## Rule Details
+
+- **Rule ID**: MD033
+- **Aliases**: no-inline-html
+- **Category**: Content
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Common Allowed Elements
+
+| Element | Use Case |
+|---------|----------|
+| `br` | Line breaks within paragraphs |
+| `details` | Collapsible sections |
+| `summary` | Summary for details |
+| `kbd` | Keyboard input |
+| `sub`, `sup` | Subscript/superscript |
+
+## Related Rules
+
+- [MD045](./md045.md) - Images should have alt text

--- a/docs/src/rules/standard/md035.md
+++ b/docs/src/rules/standard/md035.md
@@ -1,0 +1,91 @@
+# MD035 - Horizontal Rule Style
+
+Horizontal rule style should be consistent.
+
+## Why This Rule Exists
+
+Markdown supports multiple horizontal rule syntaxes. Consistent style throughout
+a document improves readability and maintainability.
+
+## Styles
+
+```markdown
+---
+
+---
+
+
+---
+
+
+---
+
+
+** *
+
+```
+
+All render as horizontal rules but mixing them is inconsistent.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Section one content.
+
+---
+
+Section two content.
+
+---
+
+
+Section three content.
+```
+
+### Correct
+
+```markdown
+Section one content.
+
+---
+
+Section two content.
+
+---
+
+Section three content.
+```
+
+## Configuration
+
+```toml
+[MD035]
+style = "---"  # Options: "---", "***", "___", "consistent"
+```
+
+| Value | Description |
+|-------|-------------|
+| `---` | Three dashes |
+| `***` | Three asterisks |
+| `___` | Three underscores |
+| `consistent` | Match first occurrence |
+
+## When to Disable
+
+- Documents with intentional style variation
+- Content imported from multiple sources
+
+## Rule Details
+
+- **Rule ID**: MD035
+- **Aliases**: hr-style
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD003](./md003.md) - Heading style consistency
+- [MD004](./md004.md) - Unordered list style consistency

--- a/docs/src/rules/standard/md036.md
+++ b/docs/src/rules/standard/md036.md
@@ -1,0 +1,74 @@
+# MD036 - Emphasis Instead of Heading
+
+Emphasis used instead of a heading.
+
+## Why This Rule Exists
+
+Using bold or italic text on its own line as a pseudo-heading breaks document
+structure. Real headings provide proper hierarchy for navigation, accessibility,
+and table of contents generation.
+
+## Examples
+
+### Incorrect
+
+```markdown
+**Introduction**
+
+This section introduces the topic.
+
+*Getting Started*
+
+Follow these steps to begin.
+```
+
+### Correct
+
+```markdown
+## Introduction
+
+This section introduces the topic.
+
+## Getting Started
+
+Follow these steps to begin.
+```
+
+## Configuration
+
+```toml
+[MD036]
+punctuation = ".,;:!?。；：！？"  # Punctuation that indicates not a heading
+```
+
+Lines ending with punctuation are assumed to be emphasized text, not
+pseudo-headings.
+
+## When to Disable
+
+- Documents using emphasis for visual styling
+- Content where headings aren't appropriate
+- Presentations or slides with different formatting needs
+
+## Rule Details
+
+- **Rule ID**: MD036
+- **Aliases**: no-emphasis-as-heading
+- **Category**: Emphasis
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Why This Matters
+
+Pseudo-headings created with emphasis:
+
+- Don't appear in table of contents
+- Break accessibility for screen readers
+- Can't be linked to with anchors
+- Don't contribute to document outline
+
+## Related Rules
+
+- [MD001](./md001.md) - Heading increment
+- [MD003](./md003.md) - Heading style
+- [MD022](./md022.md) - Blanks around headings

--- a/docs/src/rules/standard/md037.md
+++ b/docs/src/rules/standard/md037.md
@@ -1,0 +1,57 @@
+# MD037 - Spaces Inside Emphasis
+
+Spaces inside emphasis markers.
+
+## Why This Rule Exists
+
+Spaces immediately inside emphasis markers may prevent proper rendering in
+some Markdown parsers. The emphasis won't be applied, leaving literal
+asterisks or underscores in the output.
+
+## Examples
+
+### Incorrect
+
+```markdown
+This is **bold** text.
+
+
+This is *italic* text.
+
+
+Here is __also bold__ text.
+
+```
+
+### Correct
+
+```markdown
+This is **bold** text.
+
+This is *italic* text.
+
+Here is __also bold__ text.
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Generally should not be disabled as spaced emphasis rarely renders correctly
+
+## Rule Details
+
+- **Rule ID**: MD037
+- **Aliases**: no-space-in-emphasis
+- **Category**: Emphasis
+- **Severity**: Warning
+- **Auto-fix**: Yes (removes spaces inside markers)
+
+## Related Rules
+
+- [MD038](./md038.md) - Spaces inside code spans
+- [MD039](./md039.md) - Spaces inside link text
+- [MD049](./md049.md) - Emphasis style
+- [MD050](./md050.md) - Strong style

--- a/docs/src/rules/standard/md038.md
+++ b/docs/src/rules/standard/md038.md
@@ -1,0 +1,57 @@
+# MD038 - Spaces Inside Code Spans
+
+Spaces inside code span markers.
+
+## Why This Rule Exists
+
+Extra spaces inside backticks create inconsistent code formatting. The spaces
+become part of the rendered code, which usually isn't intended.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Use the ` print() ` function.
+
+Run ` npm install ` to install.
+```
+
+### Correct
+
+```markdown
+Use the `print()` function.
+
+Run `npm install` to install.
+```
+
+### Intentional Spaces
+
+If you need a backtick inside code, use double backticks with spaces:
+
+```markdown
+Use `` `backticks` `` for code.
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Documents using spaces for specific code formatting
+- Content requiring literal spaces in code spans
+
+## Rule Details
+
+- **Rule ID**: MD038
+- **Aliases**: no-space-in-code
+- **Category**: Code
+- **Severity**: Warning
+- **Auto-fix**: Yes (removes extra spaces)
+
+## Related Rules
+
+- [MD037](./md037.md) - Spaces inside emphasis
+- [MD039](./md039.md) - Spaces inside link text
+- [MD040](./md040.md) - Fenced code blocks language

--- a/docs/src/rules/standard/md039.md
+++ b/docs/src/rules/standard/md039.md
@@ -1,0 +1,53 @@
+# MD039 - Spaces Inside Link Text
+
+Spaces inside link text brackets.
+
+## Why This Rule Exists
+
+Leading or trailing spaces inside link text brackets create inconsistent
+formatting and may render with unwanted whitespace in the clickable text.
+
+## Examples
+
+### Incorrect
+
+```markdown
+[ Click here ](https://example.com)
+
+[  Documentation  ](./docs.md)
+
+[ Link ](url)
+```
+
+### Correct
+
+```markdown
+[Click here](https://example.com)
+
+[Documentation](./docs.md)
+
+[Link](url)
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Generally should not be disabled as spaced link text is usually unintentional
+
+## Rule Details
+
+- **Rule ID**: MD039
+- **Aliases**: no-space-in-links
+- **Category**: Links
+- **Severity**: Warning
+- **Auto-fix**: Yes (removes extra spaces)
+
+## Related Rules
+
+- [MD037](./md037.md) - Spaces inside emphasis
+- [MD038](./md038.md) - Spaces inside code spans
+- [MD042](./md042.md) - Empty links
+- [MD051](./md051.md) - Link fragments

--- a/docs/src/rules/standard/md041.md
+++ b/docs/src/rules/standard/md041.md
@@ -1,0 +1,78 @@
+# MD041 - First Line Top-Level Heading
+
+First line in a file should be a top-level heading.
+
+## Why This Rule Exists
+
+Documents should start with a title heading to establish context. This helps
+with document navigation, accessibility, and table of contents generation.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Some introductory text before the heading.
+
+# Document Title
+
+Content here.
+```
+
+### Correct
+
+```markdown
+# Document Title
+
+Some introductory text.
+
+Content here.
+```
+
+### With Front Matter
+
+```markdown
+---
+title: My Document
+---
+
+# Document Title
+
+Content here.
+```
+
+## Configuration
+
+```toml
+[MD041]
+level = 1              # Expected heading level (default: 1)
+front_matter_title = "^\\s*title\\s*[:=]"  # Regex for front matter title
+```
+
+If `front_matter_title` matches, the document is considered to have a title
+and the rule passes.
+
+## When to Disable
+
+- Fragment documents included in larger documents
+- Files with front matter providing the title
+- Auto-generated content with different structure
+
+## Rule Details
+
+- **Rule ID**: MD041
+- **Aliases**: first-line-heading, first-line-h1
+- **Category**: Structure
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Replaces MD002
+
+This rule supersedes [MD002](./md002.md) with improved handling of front
+matter and more configuration options.
+
+## Related Rules
+
+- [MD001](./md001.md) - Heading increment
+- [MD002](./md002.md) - First heading H1 (deprecated)
+- [MD025](./md025.md) - Single top-level heading

--- a/docs/src/rules/standard/md042.md
+++ b/docs/src/rules/standard/md042.md
@@ -1,0 +1,63 @@
+# MD042 - No Empty Links
+
+No empty links allowed.
+
+## Why This Rule Exists
+
+Empty links with no URL serve no purpose and indicate incomplete content
+or a mistake during editing. They create broken user experiences when clicked.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Click [here]() for more information.
+
+See the [documentation]().
+
+[Empty link]()
+```
+
+### Correct
+
+```markdown
+Click [here](https://example.com) for more information.
+
+See the [documentation](./docs.md).
+
+[Valid link](https://example.com)
+```
+
+### Placeholder Links
+
+If you need placeholders during drafting, use comments:
+
+```markdown
+<!-- TODO: Add link -->
+Click [here](#) for more information.
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Draft documents with intentional placeholders
+- Templates where links are filled programmatically
+
+## Rule Details
+
+- **Rule ID**: MD042
+- **Aliases**: no-empty-links
+- **Category**: Links
+- **Severity**: Error
+- **Auto-fix**: No
+
+## Related Rules
+
+- [MD011](./md011.md) - Reversed link syntax
+- [MD039](./md039.md) - Spaces inside link text
+- [MD051](./md051.md) - Link fragments
+- [MD052](./md052.md) - Reference links and images

--- a/docs/src/rules/standard/md043.md
+++ b/docs/src/rules/standard/md043.md
@@ -1,0 +1,89 @@
+# MD043 - Required Heading Structure
+
+Required heading structure not found.
+
+## Why This Rule Exists
+
+Some documents must follow a specific heading structure for consistency
+across a project. This rule enforces a predefined heading pattern.
+
+## Examples
+
+### Configuration
+
+```toml
+[MD043]
+headings = ["# Title", "## Introduction", "## Usage", "## API", "## License"]
+```
+
+### Incorrect
+
+```markdown
+# My Project
+
+## Getting Started
+
+## API Reference
+```
+
+Missing required "Introduction" and has different heading names.
+
+### Correct
+
+```markdown
+# Title
+
+## Introduction
+
+## Usage
+
+## API
+
+## License
+```
+
+## Configuration 2
+
+
+```toml
+[MD043]
+headings = []          # Required headings in order
+match_case = true      # Case-sensitive matching (default: true)
+```
+
+### Wildcards
+
+Use `*` to allow any heading at a position:
+
+```toml
+[MD043]
+headings = ["# *", "## Introduction", "##*"]
+
+```
+
+## When to Disable
+
+- Documents that don't follow a template
+- Creative content without structure requirements
+- Auto-generated files
+
+## Rule Details
+
+- **Rule ID**: MD043
+- **Aliases**: required-headings
+- **Category**: Structure
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Use Cases
+
+- README templates across repositories
+- Documentation standards
+- API documentation structure
+- Legal documents with required sections
+
+## Related Rules
+
+- [MD001](./md001.md) - Heading increment
+- [MD024](./md024.md) - Duplicate headings
+- [MD025](./md025.md) - Single top-level heading

--- a/docs/src/rules/standard/md044.md
+++ b/docs/src/rules/standard/md044.md
@@ -1,0 +1,88 @@
+# MD044 - Proper Names Capitalization
+
+Proper names should have correct capitalization.
+
+## Why This Rule Exists
+
+Brand names, product names, and technical terms often have specific
+capitalization. Consistent capitalization improves professionalism and
+readability.
+
+## Examples
+
+### Configuration
+
+```toml
+[MD044]
+names = ["JavaScript", "GitHub", "macOS", "iOS"]
+code_blocks = false  # Don't check inside code blocks
+```
+
+### Incorrect
+
+```markdown
+Install the package using Github.
+
+This works on MacOS and IOS devices.
+
+Learn javascript programming.
+```
+
+### Correct
+
+```markdown
+Install the package using GitHub.
+
+This works on macOS and iOS devices.
+
+Learn JavaScript programming.
+```
+
+## Configuration 2
+
+
+```toml
+[MD044]
+names = []            # List of proper names with correct capitalization
+code_blocks = false   # Check inside code blocks (default: false)
+html_elements = false # Check inside HTML elements (default: false)
+```
+
+### Common Names
+
+```toml
+[MD044]
+names = [
+  "JavaScript", "TypeScript", "Node.js", "npm",
+  "GitHub", "GitLab", "Bitbucket",
+  "macOS", "iOS", "iPadOS", "watchOS", "tvOS",
+  "MySQL", "PostgreSQL", "MongoDB", "SQLite",
+  "Rust", "Python", "Ruby", "Kotlin"
+]
+```
+
+## When to Disable
+
+- Documents where capitalization varies intentionally
+- Code-heavy content where names appear in identifiers
+- Historical documents preserving original text
+
+## Rule Details
+
+- **Rule ID**: MD044
+- **Aliases**: proper-names
+- **Category**: Style
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Notes
+
+The rule is smart about context:
+
+- Ignores text inside code blocks (configurable)
+- Ignores text inside inline code spans
+- Ignores URLs and link destinations
+
+## Related Rules
+
+- [MD038](./md038.md) - Spaces inside code spans

--- a/docs/src/rules/standard/md045.md
+++ b/docs/src/rules/standard/md045.md
@@ -1,0 +1,77 @@
+# MD045 - Images Should Have Alt Text
+
+Images should have alternate text (alt text).
+
+## Why This Rule Exists
+
+Alt text is essential for accessibility. Screen readers use it to describe
+images to visually impaired users. It also displays when images fail to load.
+
+## Examples
+
+### Incorrect
+
+```markdown
+![](image.png)
+
+![][logo]
+
+[logo]: logo.png
+```
+
+### Correct
+
+```markdown
+![Screenshot of the dashboard](image.png)
+
+![Company logo][logo]
+
+[logo]: logo.png "Company Logo"
+```
+
+### Good Alt Text
+
+```markdown
+![Bar chart showing sales growth from 2020 to 2024](sales-chart.png)
+
+![Red error icon indicating a failed operation](error-icon.svg)
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Decorative images that don't convey information
+- Documents where images are supplementary
+
+## Rule Details
+
+- **Rule ID**: MD045
+- **Aliases**: no-alt-text
+- **Category**: Images
+- **Severity**: Warning
+- **Auto-fix**: Yes (adds placeholder alt text)
+
+## Writing Good Alt Text
+
+| Image Type | Alt Text Approach |
+|------------|-------------------|
+| Informative | Describe the content and purpose |
+| Decorative | Use empty alt `!["](decorative.png)` |
+| Charts | Summarize the data shown |
+| Screenshots | Describe what the screenshot shows |
+| Icons | Describe the action or meaning |
+
+## Accessibility Standards
+
+This rule helps comply with:
+
+- WCAG 2.1 Success Criterion 1.1.1 (Non-text Content)
+- Section 508 accessibility requirements
+
+## Related Rules
+
+- [MD033](./md033.md) - No inline HTML
+- [MD052](./md052.md) - Reference links and images

--- a/docs/src/rules/standard/md046.md
+++ b/docs/src/rules/standard/md046.md
@@ -1,0 +1,92 @@
+# MD046 - Code Block Style
+
+Code block style should be consistent.
+
+## Why This Rule Exists
+
+Markdown supports both fenced code blocks (triple backticks) and indented
+code blocks (4 spaces). Consistent style improves readability.
+
+## Styles
+
+### Fenced (Recommended)
+
+````markdown
+```rust
+fn main() {
+    println!("Hello");
+}
+```
+````
+
+### Indented
+
+```markdown
+    fn main() {
+        println!("Hello");
+    }
+```
+
+## Examples
+
+### Incorrect (Mixed)
+
+````markdown
+```python
+print("Hello")
+```
+
+    # Indented code block
+    echo "World"
+````
+
+### Correct (Consistent Fenced)
+
+````markdown
+```python
+print("Hello")
+```
+
+```bash
+echo "World"
+```
+````
+
+## Configuration
+
+```toml
+[MD046]
+style = "fenced"  # Options: "fenced", "indented", "consistent"
+```
+
+| Value | Description |
+|-------|-------------|
+| `fenced` | Use triple backticks |
+| `indented` | Use 4-space indentation |
+| `consistent` | Match first code block's style |
+
+## When to Disable
+
+- Documents mixing styles intentionally
+- Legacy content with established patterns
+
+## Rule Details
+
+- **Rule ID**: MD046
+- **Aliases**: code-block-style
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Why Fenced is Recommended
+
+- Supports language specification for syntax highlighting
+- Clearer visual boundaries
+- Easier to copy and paste
+- Works better with nested content
+
+## Related Rules
+
+- [MD031](./md031.md) - Blanks around fences
+- [MD040](./md040.md) - Fenced code blocks language
+- [MD048](./md048.md) - Code fence style

--- a/docs/src/rules/standard/md048.md
+++ b/docs/src/rules/standard/md048.md
@@ -1,0 +1,96 @@
+# MD048 - Code Fence Style
+
+Code fence style should be consistent.
+
+## Why This Rule Exists
+
+Markdown supports two fence styles: backticks and tildes. Consistent style
+throughout a document improves readability and maintainability.
+
+## Styles
+
+### Backticks (Common)
+
+````markdown
+```rust
+let x = 1;
+```
+````
+
+### Tildes
+
+```markdown
+~~~rust
+let x = 1;
+~~~
+```
+
+## Examples
+
+### Incorrect (Mixed)
+
+````markdown
+```python
+print("Hello")
+```
+
+~~~bash
+echo "World"
+~~~
+````
+
+### Correct
+
+````markdown
+```python
+print("Hello")
+```
+
+```bash
+echo "World"
+```
+````
+
+## Configuration
+
+```toml
+[MD048]
+style = "backtick"  # Options: "backtick", "tilde", "consistent"
+```
+
+| Value | Description |
+|-------|-------------|
+| `backtick` | Use triple backticks |
+| `tilde` | Use triple tildes |
+| `consistent` | Match first fence's style |
+
+## When to Disable
+
+- Documents with intentional style mixing
+- Content with nested code blocks (tildes inside backticks)
+
+## Rule Details
+
+- **Rule ID**: MD048
+- **Aliases**: code-fence-style
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Nesting Code Blocks
+
+To show code fences inside code blocks, use different styles:
+
+`````markdown
+````markdown
+```rust
+let x = 1;
+```
+````
+`````
+
+## Related Rules
+
+- [MD031](./md031.md) - Blanks around fences
+- [MD040](./md040.md) - Fenced code blocks language
+- [MD046](./md046.md) - Code block style

--- a/docs/src/rules/standard/md049.md
+++ b/docs/src/rules/standard/md049.md
@@ -1,0 +1,79 @@
+# MD049 - Emphasis Style
+
+Emphasis style should be consistent.
+
+## Why This Rule Exists
+
+Markdown supports two emphasis markers: asterisks and underscores. Consistent
+style improves readability and maintainability.
+
+## Styles
+
+### Asterisks
+
+```markdown
+This is *italic* text.
+```
+
+### Underscores
+
+```markdown
+This is _italic_ text.
+```
+
+## Examples
+
+### Incorrect (Mixed)
+
+```markdown
+This is *italic* and this is _also italic_.
+
+Use *consistent* formatting _throughout_ the document.
+```
+
+### Correct
+
+```markdown
+This is *italic* and this is *also italic*.
+
+Use *consistent* formatting *throughout* the document.
+```
+
+## Configuration
+
+```toml
+[MD049]
+style = "asterisk"  # Options: "asterisk", "underscore", "consistent"
+```
+
+| Value | Description |
+|-------|-------------|
+| `asterisk` | Use `*text*` |
+| `underscore` | Use `_text_` |
+| `consistent` | Match first occurrence |
+
+## When to Disable
+
+- Documents with intentional style variation
+- Content imported from multiple sources
+
+## Rule Details
+
+- **Rule ID**: MD049
+- **Aliases**: emphasis-style
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Note on Underscores
+
+Underscores inside words are not treated as emphasis:
+
+```markdown
+some_variable_name  <!-- Not italic, just text -->
+```
+
+## Related Rules
+
+- [MD037](./md037.md) - Spaces inside emphasis
+- [MD050](./md050.md) - Strong style

--- a/docs/src/rules/standard/md050.md
+++ b/docs/src/rules/standard/md050.md
@@ -1,0 +1,68 @@
+# MD050 - Strong Style
+
+Strong emphasis style should be consistent.
+
+## Why This Rule Exists
+
+Markdown supports two strong emphasis markers: double asterisks and double
+underscores. Consistent style improves readability.
+
+## Styles
+
+### Asterisks (Common)
+
+```markdown
+This is **bold** text.
+```
+
+### Underscores
+
+```markdown
+This is __bold__ text.
+```
+
+## Examples
+
+### Incorrect (Mixed)
+
+```markdown
+This is **bold** and this is __also bold__.
+```
+
+### Correct
+
+```markdown
+This is **bold** and this is **also bold**.
+```
+
+## Configuration
+
+```toml
+[MD050]
+style = "asterisk"  # Options: "asterisk", "underscore", "consistent"
+```
+
+| Value | Description |
+|-------|-------------|
+| `asterisk` | Use `**text**` |
+| `underscore` | Use `**text**` |
+
+| `consistent` | Match first occurrence |
+
+## When to Disable
+
+- Documents with intentional style variation
+- Content imported from multiple sources
+
+## Rule Details
+
+- **Rule ID**: MD050
+- **Aliases**: strong-style
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD037](./md037.md) - Spaces inside emphasis
+- [MD049](./md049.md) - Emphasis style

--- a/docs/src/rules/standard/md051.md
+++ b/docs/src/rules/standard/md051.md
@@ -1,0 +1,80 @@
+# MD051 - Link Fragments
+
+Link fragments should be valid.
+
+## Why This Rule Exists
+
+Fragment links (anchors) like `#section-name` should point to actual headings
+in the document. Invalid fragments create broken navigation.
+
+## Examples
+
+### Incorrect
+
+```markdown
+# Introduction
+
+See the [configuration](#config) section.
+
+## Configuration Options
+
+Content here.
+```
+
+The fragment `#config` doesn't match `#configuration-options`.
+
+### Correct
+
+```markdown
+# Introduction
+
+See the [configuration](#configuration-options) section.
+
+## Configuration Options
+
+Content here.
+```
+
+## How Fragments Are Generated
+
+Headings become fragments by:
+
+1. Converting to lowercase
+2. Replacing spaces with hyphens
+3. Removing special characters
+
+| Heading | Fragment |
+|---------|----------|
+| `## Getting Started` | `#getting-started` |
+| `## API Reference` | `#api-reference` |
+| `## What's New?` | `#whats-new` |
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Documents with custom anchor IDs
+- Content using JavaScript-based navigation
+- Files processed by tools that modify anchors
+
+## Rule Details
+
+- **Rule ID**: MD051
+- **Aliases**: link-fragments
+- **Category**: Links
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Performance
+
+This rule is optimized for large documents. It builds a heading index
+once and validates all fragments efficiently.
+
+## Related Rules
+
+- [MD024](./md024.md) - Duplicate headings
+- [MD042](./md042.md) - Empty links
+- [MD052](./md052.md) - Reference links and images
+- [MDBOOK002](../mdbook/mdbook002.md) - Internal link validation

--- a/docs/src/rules/standard/md052.md
+++ b/docs/src/rules/standard/md052.md
@@ -1,0 +1,78 @@
+# MD052 - Reference Links and Images
+
+Reference links and images should use a label that is defined.
+
+## Why This Rule Exists
+
+Reference-style links like `[text][label]` must have a corresponding definition.
+Undefined references render as plain text instead of links.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Check out the [documentation][docs] for more info.
+
+Visit [our website][site].
+
+<!-- Missing definitions for 'docs' and 'site' -->
+```
+
+### Correct
+
+```markdown
+Check out the [documentation][docs] for more info.
+
+Visit [our website][site].
+
+[docs]: https://docs.example.com
+[site]: https://example.com
+```
+
+### Images
+
+```markdown
+![Logo][logo]
+
+[logo]: ./images/logo.png "Company Logo"
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Documents where references are defined in included files
+- Templates with programmatically injected definitions
+
+## Rule Details
+
+- **Rule ID**: MD052
+- **Aliases**: reference-links-images
+- **Category**: Links
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Reference Link Syntax
+
+```markdown
+<!-- Full reference -->
+[Link text][label]
+
+<!-- Collapsed reference (label matches text) -->
+[Example][]
+
+<!-- Shortcut reference -->
+[Example]
+
+<!-- Definition -->
+[label]: url "Optional Title"
+```
+
+## Related Rules
+
+- [MD042](./md042.md) - Empty links
+- [MD051](./md051.md) - Link fragments
+- [MD053](./md053.md) - Unused reference definitions

--- a/docs/src/rules/standard/md053.md
+++ b/docs/src/rules/standard/md053.md
@@ -1,0 +1,68 @@
+# MD053 - Link and Image Reference Definitions
+
+Link and image reference definitions should be needed.
+
+## Why This Rule Exists
+
+Unused reference definitions clutter documents and may indicate dead links
+or incomplete edits. Keeping only used definitions improves maintainability.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Check out the [documentation](https://docs.example.com).
+
+[unused]: https://example.com
+[also-unused]: https://other.com
+```
+
+The definitions are never used.
+
+### Correct
+
+```markdown
+Check out the [documentation][docs].
+
+[docs]: https://docs.example.com
+```
+
+Or remove unused definitions:
+
+```markdown
+Check out the [documentation](https://docs.example.com).
+```
+
+## Configuration
+
+```toml
+[MD053]
+ignored_definitions = []  # Definitions to ignore (e.g., for includes)
+```
+
+### Ignoring Definitions
+
+```toml
+[MD053]
+ignored_definitions = ["//", "TODO"]
+```
+
+## When to Disable
+
+- Documents with definitions used in included content
+- Templates with conditional reference usage
+- Files serving as definition libraries
+
+## Rule Details
+
+- **Rule ID**: MD053
+- **Aliases**: link-image-reference-definitions
+- **Category**: Links
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Related Rules
+
+- [MD052](./md052.md) - Reference links must be defined
+- [MD054](./md054.md) - Link and image style

--- a/docs/src/rules/standard/md054.md
+++ b/docs/src/rules/standard/md054.md
@@ -1,0 +1,90 @@
+# MD054 - Link and Image Style
+
+Link and image style should be consistent.
+
+## Why This Rule Exists
+
+Markdown supports inline and reference-style links. Consistent style throughout
+a document improves readability and maintainability.
+
+## Styles
+
+### Inline
+
+```markdown
+[Link text](https://example.com)
+![Alt text](image.png)
+```
+
+### Reference (Full)
+
+```markdown
+[Link text][ref]
+![Alt text][img]
+
+[ref]: https://example.com
+[img]: image.png
+```
+
+### Reference (Collapsed)
+
+```markdown
+[Example][]
+
+[Example]: https://example.com
+```
+
+### Reference (Shortcut)
+
+```markdown
+[Example]
+
+[Example]: https://example.com
+```
+
+## Examples
+
+### Incorrect (Mixed)
+
+```markdown
+See [inline link](https://example.com) and [reference link][ref].
+
+[ref]: https://other.com
+```
+
+### Correct
+
+```markdown
+See [inline link](https://example.com) and [other link](https://other.com).
+```
+
+## Configuration
+
+```toml
+[MD054]
+autolink = true           # Allow autolinks <https://example.com>
+inline = true             # Allow inline style
+full = true               # Allow full reference style
+collapsed = true          # Allow collapsed reference style
+shortcut = true           # Allow shortcut reference style
+url_inline = true         # Allow inline for URLs only
+```
+
+## When to Disable
+
+- Documents with intentional style mixing
+- Content where different styles serve different purposes
+
+## Rule Details
+
+- **Rule ID**: MD054
+- **Aliases**: link-image-style
+- **Category**: Links
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Related Rules
+
+- [MD052](./md052.md) - Reference links must be defined
+- [MD053](./md053.md) - Unused reference definitions
+- [MD059](./md059.md) - Descriptive link text

--- a/docs/src/rules/standard/md055.md
+++ b/docs/src/rules/standard/md055.md
@@ -1,0 +1,85 @@
+# MD055 - Table Pipe Style
+
+Table pipe style should be consistent.
+
+## Why This Rule Exists
+
+Markdown tables can have leading and trailing pipes or omit them. Consistent
+style improves readability and source formatting.
+
+## Styles
+
+### Leading and Trailing (Recommended)
+
+```markdown
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+```
+
+### No Leading/Trailing
+
+```markdown
+Header 1 | Header 2
+---------|----------
+Cell 1   | Cell 2
+```
+
+### Leading Only
+
+```markdown
+| Header 1 | Header 2
+|----------|----------
+| Cell 1   | Cell 2
+```
+
+## Examples
+
+### Incorrect (Mixed)
+
+```markdown
+| Header 1 | Header 2 |
+|----------|----------|
+Cell 1   | Cell 2
+```
+
+### Correct
+
+```markdown
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+```
+
+## Configuration
+
+```toml
+[MD055]
+style = "leading_and_trailing"  # Options: see below
+```
+
+| Value | Description |
+|-------|-------------|
+| `leading_and_trailing` | Pipes on both ends |
+| `leading_only` | Only leading pipes |
+| `trailing_only` | Only trailing pipes |
+| `no_leading_or_trailing` | No outer pipes |
+| `consistent` | Match first table's style |
+
+## When to Disable
+
+- Documents with tables from different sources
+- Content where specific formatting is required
+
+## Rule Details
+
+- **Rule ID**: MD055
+- **Aliases**: table-pipe-style
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD056](./md056.md) - Table column count
+- [MD058](./md058.md) - Blanks around tables

--- a/docs/src/rules/standard/md056.md
+++ b/docs/src/rules/standard/md056.md
@@ -1,0 +1,61 @@
+# MD056 - Table Column Count
+
+Table column count should be consistent.
+
+## Why This Rule Exists
+
+All rows in a table should have the same number of columns. Mismatched column
+counts cause rendering issues and indicate data entry errors.
+
+## Examples
+
+### Incorrect
+
+```markdown
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Cell 1   | Cell 2   |
+| Cell 1   | Cell 2   | Cell 3   | Cell 4 |
+```
+
+Row 2 has too few columns, row 3 has too many.
+
+### Correct
+
+```markdown
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+```
+
+### Empty Cells
+
+```markdown
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Cell 1   |          | Cell 3   |
+| Cell 4   | Cell 5   |          |
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Tables intentionally using colspan-like behavior
+- Content from sources with non-standard table formats
+
+## Rule Details
+
+- **Rule ID**: MD056
+- **Aliases**: table-column-count
+- **Category**: Structure
+- **Severity**: Error
+- **Auto-fix**: Yes (adds empty cells)
+
+## Related Rules
+
+- [MD055](./md055.md) - Table pipe style
+- [MD058](./md058.md) - Blanks around tables

--- a/docs/src/rules/standard/md058.md
+++ b/docs/src/rules/standard/md058.md
@@ -1,0 +1,58 @@
+# MD058 - Blanks Around Tables
+
+Tables should be surrounded by blank lines.
+
+## Why This Rule Exists
+
+Blank lines around tables ensure proper parsing and improve readability.
+Some Markdown parsers require blank lines to correctly identify table
+boundaries.
+
+## Examples
+
+### Incorrect
+
+```markdown
+Some text here.
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+More text here.
+```
+
+### Correct
+
+```markdown
+Some text here.
+
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+
+More text here.
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- Documents with compact formatting requirements
+- Content where tables flow tightly with surrounding text
+
+## Rule Details
+
+- **Rule ID**: MD058
+- **Aliases**: blanks-around-tables
+- **Category**: Formatting
+- **Severity**: Warning
+- **Auto-fix**: Yes
+
+## Related Rules
+
+- [MD022](./md022.md) - Blanks around headings
+- [MD031](./md031.md) - Blanks around fenced code blocks
+- [MD032](./md032.md) - Blanks around lists
+- [MD055](./md055.md) - Table pipe style
+- [MD056](./md056.md) - Table column count

--- a/docs/src/rules/standard/md059.md
+++ b/docs/src/rules/standard/md059.md
@@ -1,0 +1,82 @@
+# MD059 - Descriptive Link Text
+
+Link text should be descriptive.
+
+## Why This Rule Exists
+
+Generic link text like "click here" or "this link" provides no context about
+the destination. Descriptive text improves accessibility and helps users
+understand where links lead.
+
+## Examples
+
+### Incorrect
+
+```markdown
+For more information, [click here](https://docs.example.com).
+
+See [this link](./guide.md) for details.
+
+[Here](https://api.example.com) is the API documentation.
+
+Read more [here](./faq.md).
+```
+
+### Correct
+
+```markdown
+For more information, see the [complete documentation](https://docs.example.com).
+
+See the [installation guide](./guide.md) for details.
+
+Read the [API documentation](https://api.example.com).
+
+Read the [frequently asked questions](./faq.md).
+```
+
+## Configuration
+
+This rule has no configuration options.
+
+## When to Disable
+
+- UI documentation where "click here" matches actual button text
+- Content with intentionally brief link descriptions
+
+## Rule Details
+
+- **Rule ID**: MD059
+- **Aliases**: descriptive-link-text
+- **Category**: Accessibility
+- **Severity**: Warning
+- **Auto-fix**: No
+
+## Common Non-Descriptive Phrases
+
+The rule flags these common patterns:
+
+- "click here"
+- "here"
+- "this link"
+- "this"
+- "link"
+- "read more"
+
+## Why Descriptive Text Matters
+
+1. **Screen Readers**: Users often navigate by links; "click here" provides no context
+2. **Scanning**: Users scan pages looking for relevant links
+3. **SEO**: Search engines use link text to understand content relationships
+4. **Mobile**: Touch targets benefit from clear labels
+
+## Accessibility Standards
+
+This rule helps comply with:
+
+- WCAG 2.1 Success Criterion 2.4.4 (Link Purpose in Context)
+- WCAG 2.1 Success Criterion 2.4.9 (Link Purpose Link Only)
+
+## Related Rules
+
+- [MD042](./md042.md) - No empty links
+- [MD045](./md045.md) - Images should have alt text

--- a/docs/src/rules/standard/tables.md
+++ b/docs/src/rules/standard/tables.md
@@ -1,0 +1,40 @@
+# Table Rules
+
+Rules for formatting Markdown tables.
+
+## Rules in This Category
+
+| Rule | Description | Auto-fix |
+|------|-------------|----------|
+| [MD055](./md055.md) | Table pipe style consistency | Yes |
+| [MD056](./md056.md) | Table column count | Yes |
+| [MD058](./md058.md) | Tables surrounded by blank lines | Yes |
+
+## Overview
+
+Table rules ensure consistent and valid table formatting. Properly formatted
+tables render correctly across all Markdown parsers.
+
+### Common Issues
+
+- Inconsistent pipe style (leading/trailing pipes)
+- Rows with different numbers of columns
+- Tables not separated from surrounding content
+
+### Best Practices
+
+- Use leading and trailing pipes for clarity
+- Ensure all rows have the same number of columns
+- Surround tables with blank lines
+- Align columns for readable source (optional)
+
+### Example Table
+
+```markdown
+
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+
+```


### PR DESCRIPTION
## Summary

This PR completes the individual rule documentation for all 67 rules, addressing issue #45.

## Changes

### Standard Rules (41 new pages)
- **Heading rules**: MD002, MD003, MD022, MD024-MD026, MD041
- **List rules**: MD004-MD007, MD029, MD032
- **Whitespace rules**: MD028
- **Link rules**: MD011, MD039, MD042, MD051-MD054, MD059
- **Code rules**: MD014, MD031, MD038, MD046, MD048
- **Style rules**: MD035, MD043, MD044
- **Emphasis rules**: MD036, MD037, MD049, MD050
- **Table rules**: MD055, MD056, MD058
- **Image rules**: MD045
- **HTML rules**: MD033

### mdBook Rules (7 new pages)
- MDBOOK004: Duplicate chapter titles
- MDBOOK006: Cross-reference validation
- MDBOOK007: Include validation
- MDBOOK008: Rustdoc include validation
- MDBOOK009: Playground validation
- MDBOOK010: Preprocessor validation
- MDBOOK011: Template validation
- MDBOOK012: Include line range validation

### Category Index Pages (4 new)
- emphasis.md
- tables.md
- images.md
- html.md

### Updated
- SUMMARY.md: Reorganized with proper hierarchy for all rules

## Documentation Structure

Each rule page includes:
- Description of what the rule checks
- Examples of correct and incorrect usage
- Configuration options (where applicable)
- When to disable the rule
- Rule details (ID, aliases, category, severity, auto-fix)
- Related rules

Closes #45