### PR TITLE
feat: add CONTENT002, MDBOOK021, MDBOOK022 rules

### DIFF
--- a/crates/mdbook-lint-rulesets/src/content/content002.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content002.rs
@@ -1,0 +1,446 @@
+//! CONTENT002: Placeholder text detection
+//!
+//! Detects common placeholder text patterns like "Lorem ipsum", "TBD",
+//! "coming soon", etc. that shouldn't appear in production documentation.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex patterns for placeholder text (case-insensitive)
+static PLACEHOLDER_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    vec![
+        // Lorem ipsum variants
+        (
+            Regex::new(r"(?i)\blorem\s+ipsum\b").unwrap(),
+            "Lorem ipsum placeholder text",
+        ),
+        (
+            Regex::new(r"(?i)\bipsum\s+dolor\b").unwrap(),
+            "Lorem ipsum placeholder text",
+        ),
+        // Status placeholders
+        (
+            Regex::new(r"(?i)\bTBD\b").unwrap(),
+            "TBD (To Be Determined) placeholder",
+        ),
+        (
+            Regex::new(r"(?i)\bTBA\b").unwrap(),
+            "TBA (To Be Announced) placeholder",
+        ),
+        (
+            Regex::new(r"(?i)\bTBC\b").unwrap(),
+            "TBC (To Be Confirmed) placeholder",
+        ),
+        // Coming soon variants
+        (
+            Regex::new(r"(?i)\bcoming\s+soon\b").unwrap(),
+            "Coming soon placeholder",
+        ),
+        (
+            Regex::new(r"(?i)\bunder\s+construction\b").unwrap(),
+            "Under construction placeholder",
+        ),
+        (
+            Regex::new(r"(?i)\bwork\s+in\s+progress\b").unwrap(),
+            "Work in progress placeholder",
+        ),
+        // Insert/add placeholders
+        (
+            Regex::new(r"(?i)\binsert\s+\w+\s+here\b").unwrap(),
+            "Insert here placeholder",
+        ),
+        (
+            Regex::new(r"(?i)\badd\s+\w+\s+here\b").unwrap(),
+            "Add here placeholder",
+        ),
+        (
+            Regex::new(r"(?i)\bput\s+\w+\s+here\b").unwrap(),
+            "Put here placeholder",
+        ),
+        // N/A and placeholder
+        (
+            Regex::new(r"(?i)\bN/A\b").unwrap(),
+            "N/A placeholder - consider removing or providing actual content",
+        ),
+        (
+            Regex::new(r"(?i)\bplaceholder\b").unwrap(),
+            "Placeholder text detected",
+        ),
+        // Draft/pending
+        (Regex::new(r"(?i)\[draft\]").unwrap(), "Draft marker found"),
+        (
+            Regex::new(r"(?i)\[pending\]").unwrap(),
+            "Pending marker found",
+        ),
+        // Example placeholders
+        (
+            Regex::new(r"(?i)\bexample\.com\b").unwrap(),
+            "Example.com placeholder URL",
+        ),
+        (
+            Regex::new(r"(?i)\bfoo\s*bar\s*baz\b").unwrap(),
+            "Foo bar baz placeholder",
+        ),
+        // Empty section markers
+        (
+            Regex::new(r"(?i)\bthis\s+section\s+(is\s+)?(empty|blank|incomplete)\b").unwrap(),
+            "Empty section marker",
+        ),
+        (
+            Regex::new(r"(?i)\bcontent\s+goes\s+here\b").unwrap(),
+            "Content placeholder",
+        ),
+        // Your/my name placeholders
+        (
+            Regex::new(r"(?i)\byour\s+name\s+here\b").unwrap(),
+            "Name placeholder",
+        ),
+        (
+            Regex::new(r"(?i)\b<your[_\s]name>\b").unwrap(),
+            "Name placeholder",
+        ),
+        // XXX as content (not code comment - that's CONTENT001)
+        (
+            Regex::new(r"(?i)^XXX+$").unwrap(),
+            "XXX placeholder content",
+        ),
+        // Ellipsis as placeholder content (standalone)
+        (
+            Regex::new(r"^\s*\.\.\.\s*$").unwrap(),
+            "Ellipsis placeholder - provide actual content",
+        ),
+    ]
+});
+
+/// CONTENT002: Detects placeholder text
+///
+/// This rule flags common placeholder patterns that indicate
+/// incomplete documentation. These should be replaced with
+/// actual content before publishing.
+pub struct CONTENT002 {
+    /// Whether to check inside code blocks
+    check_code_blocks: bool,
+    /// Whether to allow example.com in examples
+    allow_example_urls: bool,
+}
+
+impl Default for CONTENT002 {
+    fn default() -> Self {
+        Self {
+            check_code_blocks: false,
+            allow_example_urls: true, // example.com is acceptable in code examples
+        }
+    }
+}
+
+impl CONTENT002 {
+    /// Set whether to check inside code blocks
+    #[allow(dead_code)]
+    pub fn check_code_blocks(mut self, check: bool) -> Self {
+        self.check_code_blocks = check;
+        self
+    }
+
+    /// Set whether to allow example.com URLs
+    #[allow(dead_code)]
+    pub fn allow_example_urls(mut self, allow: bool) -> Self {
+        self.allow_example_urls = allow;
+        self
+    }
+
+    /// Check if a position is inside a code block
+    fn is_in_code_block(&self, lines: &[String], line_idx: usize) -> bool {
+        let mut in_fenced_block = false;
+
+        for (idx, line) in lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            // Check for fenced code block markers
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_fenced_block = !in_fenced_block;
+            }
+
+            if idx == line_idx {
+                return in_fenced_block;
+            }
+        }
+
+        false
+    }
+
+    /// Check if a position is inside inline code
+    fn is_in_inline_code(&self, line: &str, col: usize) -> bool {
+        let before = &line[..col.min(line.len())];
+
+        // Count backticks before the position
+        let backtick_count = before.chars().filter(|&c| c == '`').count();
+
+        // Odd number of backticks means we're inside inline code
+        backtick_count % 2 == 1
+    }
+}
+
+impl Rule for CONTENT002 {
+    fn id(&self) -> &'static str {
+        "CONTENT002"
+    }
+
+    fn name(&self) -> &'static str {
+        "no-placeholder-text"
+    }
+
+    fn description(&self) -> &'static str {
+        "Placeholder text should be replaced with actual content"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let line_num = line_idx + 1; // 1-based
+
+            // Skip code blocks unless configured to check them
+            if !self.check_code_blocks && self.is_in_code_block(&document.lines, line_idx) {
+                continue;
+            }
+
+            // Check each pattern
+            for (pattern, description) in PLACEHOLDER_PATTERNS.iter() {
+                // Skip example.com check if allowed
+                if self.allow_example_urls && *description == "Example.com placeholder URL" {
+                    // Only flag if not in a code context
+                    if self.is_in_code_block(&document.lines, line_idx) {
+                        continue;
+                    }
+                }
+
+                for mat in pattern.find_iter(line) {
+                    let col = mat.start() + 1; // 1-based
+
+                    // Skip if inside inline code (unless checking code blocks)
+                    if !self.check_code_blocks && self.is_in_inline_code(line, mat.start()) {
+                        continue;
+                    }
+
+                    violations.push(self.create_violation(
+                        format!("{} - replace with actual content", description),
+                        line_num,
+                        col,
+                        Severity::Warning,
+                    ));
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_no_placeholders() {
+        let content = "# Title\n\nThis is real, complete documentation.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_lorem_ipsum_detected() {
+        let content = "# Title\n\nLorem ipsum dolor sit amet.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(!violations.is_empty());
+        assert!(violations[0].message.contains("Lorem ipsum"));
+    }
+
+    #[test]
+    fn test_tbd_detected() {
+        let content = "# Title\n\nThis feature is TBD.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("TBD"));
+    }
+
+    #[test]
+    fn test_coming_soon_detected() {
+        let content = "# Title\n\nThis section is coming soon.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Coming soon"));
+    }
+
+    #[test]
+    fn test_under_construction_detected() {
+        let content = "# Title\n\nThis page is under construction.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Under construction"));
+    }
+
+    #[test]
+    fn test_insert_here_detected() {
+        let content = "# Title\n\nInsert content here.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Insert here"));
+    }
+
+    #[test]
+    fn test_placeholder_word_detected() {
+        let content = "# Title\n\nThis is placeholder text.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Placeholder"));
+    }
+
+    #[test]
+    fn test_draft_marker_detected() {
+        let content = "# Title [draft]\n\nContent here.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Draft"));
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let content = "# Title\n\nCOMING SOON\ncoming Soon\nComing soon";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 3);
+    }
+
+    #[test]
+    fn test_skip_code_blocks() {
+        let content = "# Title\n\n```\nLorem ipsum in code\n```\n\nLorem ipsum outside";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 7);
+    }
+
+    #[test]
+    fn test_skip_inline_code() {
+        let content = "# Title\n\nUse `TBD` as status.\n\nActual TBD here";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        // Only line 5 should be flagged - line 3 has TBD in inline code
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 5);
+        assert!(violations[0].message.contains("TBD"));
+    }
+
+    #[test]
+    fn test_ellipsis_placeholder() {
+        let content = "# Title\n\n...\n\nActual content.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Ellipsis"));
+    }
+
+    #[test]
+    fn test_na_detected() {
+        let content = "# Title\n\nDescription: N/A";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("N/A"));
+    }
+
+    #[test]
+    fn test_content_goes_here() {
+        let content = "# Title\n\nContent goes here.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_example_com_allowed_by_default() {
+        let content = "# Title\n\nVisit https://example.com for more.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        // Should still detect since it's not in code block
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_your_name_here() {
+        let content = "# Title\n\nAuthor: Your name here";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Name placeholder"));
+    }
+
+    #[test]
+    fn test_work_in_progress() {
+        let content = "# Title\n\nThis section is a work in progress.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Work in progress"));
+    }
+
+    #[test]
+    fn test_multiple_placeholders() {
+        let content = "# Title\n\nTBD\n\nLorem ipsum dolor\n\nComing soon";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.len() >= 3);
+    }
+
+    #[test]
+    fn test_empty_section_marker() {
+        let content = "# Title\n\nThis section is empty.";
+        let doc = create_test_document(content);
+        let rule = CONTENT002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Empty section"));
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/content/mod.rs
@@ -4,6 +4,7 @@
 //! such as TODO comments, placeholder text, and incomplete sections.
 
 mod content001;
+mod content002;
 
 use crate::{RuleProvider, RuleRegistry};
 
@@ -20,14 +21,15 @@ impl RuleProvider for ContentRuleProvider {
     }
 
     fn version(&self) -> &'static str {
-        "0.11.0"
+        "0.12.0"
     }
 
     fn register_rules(&self, registry: &mut RuleRegistry) {
         registry.register(Box::new(content001::CONTENT001::default()));
+        registry.register(Box::new(content002::CONTENT002::default()));
     }
 
     fn rule_ids(&self) -> Vec<&'static str> {
-        vec!["CONTENT001"]
+        vec!["CONTENT001", "CONTENT002"]
     }
 }

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook021.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook021.rs
@@ -1,0 +1,170 @@
+//! MDBOOK021: Single title directive per chapter
+//!
+//! Ensures that `{{#title}}` appears only once per chapter file.
+//! Multiple title directives can cause unexpected behavior in mdBook.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex pattern for matching {{#title ...}} directives
+static TITLE_DIRECTIVE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\{\{#title\s+[^}]+\}\}").unwrap());
+
+/// MDBOOK021: Ensures {{#title}} appears only once per chapter
+///
+/// The `{{#title}}` directive in mdBook sets the page title in the browser.
+/// Having multiple title directives can cause unexpected behavior where
+/// only one is applied (usually the last one), leading to confusion.
+pub struct MDBOOK021;
+
+impl Rule for MDBOOK021 {
+    fn id(&self) -> &'static str {
+        "MDBOOK021"
+    }
+
+    fn name(&self) -> &'static str {
+        "single-title-directive"
+    }
+
+    fn description(&self) -> &'static str {
+        "{{#title}} directive should appear only once per chapter"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::MdBook).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut title_occurrences: Vec<(usize, usize)> = Vec::new(); // (line, col)
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let line_num = line_idx + 1; // 1-based
+
+            // Find all {{#title}} directives in this line
+            for mat in TITLE_DIRECTIVE_REGEX.find_iter(line) {
+                let col = mat.start() + 1; // 1-based
+                title_occurrences.push((line_num, col));
+            }
+        }
+
+        // If more than one title directive found, flag all but the first
+        if title_occurrences.len() > 1 {
+            let first = &title_occurrences[0];
+            for (line, col) in title_occurrences.iter().skip(1) {
+                violations.push(self.create_violation(
+                    format!(
+                        "Duplicate {{{{#title}}}} directive - first occurrence at line {}. \
+                         Only one title directive should be used per chapter",
+                        first.0
+                    ),
+                    *line,
+                    *col,
+                    Severity::Warning,
+                ));
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_no_title_directive() {
+        let content = "# Chapter Title\n\nSome content here.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_single_title_directive() {
+        let content = "{{#title My Page Title}}\n\n# Chapter Title\n\nContent.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_duplicate_title_directives() {
+        let content = "{{#title First Title}}\n\n# Chapter\n\n{{#title Second Title}}\n\nContent.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Duplicate"));
+        assert!(violations[0].message.contains("line 1"));
+        assert_eq!(violations[0].line, 5);
+    }
+
+    #[test]
+    fn test_multiple_title_directives() {
+        let content = "{{#title First}}\n{{#title Second}}\n{{#title Third}}";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 2);
+        assert_eq!(violations[0].line, 2);
+        assert_eq!(violations[1].line, 3);
+    }
+
+    #[test]
+    fn test_title_in_code_block_still_detected() {
+        // Note: This rule doesn't skip code blocks because {{#title}}
+        // in a code block would still be processed by mdBook preprocessor
+        // (unless escaped). This is intentional.
+        let content = "{{#title Real Title}}\n\n```\n{{#title In Code}}\n```";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        // Code blocks might contain example title directives, but they'd still
+        // be processed unless properly escaped. We detect them for awareness.
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_title_with_special_characters() {
+        let content = "{{#title My Book: A Guide to Rust}}\n\n# Chapter";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_titles_on_same_line() {
+        let content = "{{#title First}} {{#title Second}}\n\n# Chapter";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_similar_but_not_title_directive() {
+        let content = "{{#include file.rs}}\n\n# Chapter\n\nThe `{{#title}}` directive is useful.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK021;
+        let violations = rule.check(&doc).unwrap();
+        // The inline code mention doesn't match the pattern (no actual title after it)
+        assert_eq!(violations.len(), 0);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook022.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook022.rs
@@ -1,0 +1,215 @@
+//! MDBOOK022: Title directive should appear near the top of the file
+//!
+//! The `{{#title}}` directive should appear within the first few lines
+//! of a chapter file for consistency and to ensure it's processed early.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Default maximum line number for title directive
+const DEFAULT_MAX_LINE: usize = 5;
+
+/// Regex pattern for matching {{#title ...}} directives
+static TITLE_DIRECTIVE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\{\{#title\s+[^}]+\}\}").unwrap());
+
+/// MDBOOK022: Ensures {{#title}} appears near the top of the file
+///
+/// The `{{#title}}` directive sets the page title in the browser tab.
+/// For consistency and readability, it should appear near the top of
+/// the file, typically before or just after the main heading.
+#[derive(Clone)]
+pub struct MDBOOK022 {
+    /// Maximum line number where title directive is acceptable
+    max_line: usize,
+}
+
+impl Default for MDBOOK022 {
+    fn default() -> Self {
+        Self {
+            max_line: DEFAULT_MAX_LINE,
+        }
+    }
+}
+
+impl MDBOOK022 {
+    /// Create with a custom maximum line threshold
+    #[allow(dead_code)]
+    pub fn with_max_line(max_line: usize) -> Self {
+        Self { max_line }
+    }
+}
+
+impl Rule for MDBOOK022 {
+    fn id(&self) -> &'static str {
+        "MDBOOK022"
+    }
+
+    fn name(&self) -> &'static str {
+        "title-near-top"
+    }
+
+    fn description(&self) -> &'static str {
+        "{{#title}} directive should appear near the top of the file"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::MdBook).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let line_num = line_idx + 1; // 1-based
+
+            // Find {{#title}} directives in this line
+            if let Some(mat) = TITLE_DIRECTIVE_REGEX.find(line) {
+                let col = mat.start() + 1; // 1-based
+
+                // Check if it's beyond the acceptable threshold
+                if line_num > self.max_line {
+                    violations.push(self.create_violation(
+                        format!(
+                            "{{{{#title}}}} directive at line {} should appear within the first {} lines of the file",
+                            line_num, self.max_line
+                        ),
+                        line_num,
+                        col,
+                        Severity::Warning,
+                    ));
+                }
+
+                // Only check the first occurrence (MDBOOK021 handles duplicates)
+                break;
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_no_title_directive() {
+        let content = "# Chapter Title\n\nSome content here.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_title_on_first_line() {
+        let content = "{{#title My Page Title}}\n\n# Chapter Title\n\nContent.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_title_on_line_five() {
+        let content = "# Chapter\n\nIntro paragraph.\n\n{{#title My Title}}\n\nMore content.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(
+            violations.len(),
+            0,
+            "Line 5 should be within default threshold"
+        );
+    }
+
+    #[test]
+    fn test_title_beyond_threshold() {
+        let content =
+            "# Chapter\n\nParagraph 1.\n\nParagraph 2.\n\n{{#title Late Title}}\n\nContent.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("line 7"));
+        assert!(violations[0].message.contains("first 5 lines"));
+    }
+
+    #[test]
+    fn test_custom_threshold() {
+        let content = "# Chapter\n\nParagraph.\n\n{{#title Title on Line 5}}";
+        let doc = create_test_document(content);
+
+        // With threshold of 3, line 5 should fail
+        let rule = MDBOOK022::with_max_line(3);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+
+        // With threshold of 10, line 5 should pass
+        let rule = MDBOOK022::with_max_line(10);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_title_after_frontmatter() {
+        // Common pattern: frontmatter-style content before title
+        let content = "---\ndate: 2024-01-01\n---\n\n{{#title My Title}}\n\n# Chapter";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0, "Title on line 5 should pass");
+    }
+
+    #[test]
+    fn test_title_way_down_in_file() {
+        let content = "# Chapter\n\n\
+            Paragraph 1.\n\n\
+            Paragraph 2.\n\n\
+            Paragraph 3.\n\n\
+            Paragraph 4.\n\n\
+            Paragraph 5.\n\n\
+            {{#title Very Late Title}}\n\n\
+            More content.";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 13);
+    }
+
+    #[test]
+    fn test_only_first_title_checked() {
+        // If there are multiple titles, only check the first one's position
+        // (MDBOOK021 handles the duplicate issue)
+        let content = "{{#title First}}\n\n# Chapter\n\n\n\n\n\n\n\n{{#title Second}}";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        // First title is on line 1, so no violation from this rule
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_title_with_empty_lines_before() {
+        let content = "\n\n\n\n\n\n{{#title Late Start}}\n\n# Chapter";
+        let doc = create_test_document(content);
+        let rule = MDBOOK022::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 7);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
@@ -15,6 +15,8 @@ mod mdbook009;
 mod mdbook010;
 mod mdbook011;
 mod mdbook012;
+mod mdbook021;
+mod mdbook022;
 mod mdbook023;
 mod mdbook025;
 
@@ -49,6 +51,8 @@ impl RuleProvider for MdBookRuleProvider {
         registry.register(Box::new(mdbook010::MDBOOK010));
         registry.register(Box::new(mdbook011::MDBOOK011));
         registry.register(Box::new(mdbook012::MDBOOK012));
+        registry.register(Box::new(mdbook021::MDBOOK021));
+        registry.register(Box::new(mdbook022::MDBOOK022::default()));
         registry.register(Box::new(mdbook023::MDBOOK023::default()));
         registry.register(Box::new(mdbook025::MDBOOK025));
     }
@@ -67,6 +71,8 @@ impl RuleProvider for MdBookRuleProvider {
             "MDBOOK010",
             "MDBOOK011",
             "MDBOOK012",
+            "MDBOOK021",
+            "MDBOOK022",
             "MDBOOK023",
             "MDBOOK025",
         ]


### PR DESCRIPTION
Add three new linting rules from issue #16:

## New Rules

### CONTENT002: no-placeholder-text
Detects common placeholder text patterns that shouldn't appear in production documentation:
- Lorem ipsum variants
- TBD, TBA, TBC markers
- "Coming soon", "Under construction"
- "Insert X here", "Add X here"
- "N/A", "placeholder", "[draft]", "[pending]"
- example.com URLs (outside code)
- Ellipsis-only lines (`...`)

### MDBOOK021: single-title-directive
Ensures `{{#title}}` appears only once per chapter. Multiple title directives can cause unexpected behavior where only one is applied.

### MDBOOK022: title-near-top
Ensures `{{#title}}` appears within the first 5 lines of the file (configurable). The title directive should be near the top for consistency and early processing.

## Testing
- All rules have comprehensive unit tests
- Tested manually with stdin input
- All existing tests pass

Partial progress on #16