### PR TITLE
feat: add CONTENT003, CONTENT004, CONTENT005 rules

### DIFF
--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -421,9 +421,20 @@ mod tests {
     #[test]
     fn test_process_chapter_clean() {
         let preprocessor = MdBookLint::new();
+        // Content needs 50+ words to pass CONTENT003 (short chapter detection)
+        // and lines under 80 chars to pass MD013
+        let content = "# Test Chapter
+
+This is a clean chapter with enough content to pass all linting rules.
+We need to write several sentences here to make sure we have at least
+fifty words in total for the content quality checks.
+
+Let me add some more text to ensure we definitely pass the minimum word
+count threshold that is required by the linter for content validation.
+";
         let chapter = Chapter::new(
             "Test Chapter",
-            "# Test\n\nThis is a clean chapter.\n".to_string(),
+            content.to_string(),
             PathBuf::from("test.md"),
             Vec::new(),
         );

--- a/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
+++ b/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
@@ -409,9 +409,22 @@ fn test_fix_clean_file() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = temp_dir.path().join("clean.md");
 
+    // Content needs 50+ words to pass CONTENT003 (short chapter detection)
     fs::write(
         &test_file,
-        "# Clean Document\n\nThis file has no violations.\n\n```rust\nfn main() {}\n```\n",
+        "# Clean Document
+
+This file has no violations and contains enough content to pass all rules.
+We need to write several sentences here to make sure we have at least fifty
+words in total for the content quality checks to pass successfully.
+
+Let me add some more text to ensure we definitely pass the minimum word
+count threshold that is required by the linter for content validation.
+
+```rust
+fn main() {}
+```
+",
     )
     .unwrap();
 

--- a/crates/mdbook-lint-rulesets/src/content/content003.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content003.rs
@@ -1,0 +1,316 @@
+//! CONTENT003: Short chapter detection
+//!
+//! Flags chapters that are too short and might be stubs or incomplete.
+//! Short chapters can indicate work-in-progress content that needs expansion.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+
+/// Default minimum word count for a chapter
+const DEFAULT_MIN_WORDS: usize = 50;
+
+/// CONTENT003: Detects overly short chapters
+///
+/// This rule flags chapters that have fewer than a configurable minimum
+/// number of words (default: 50). Short chapters often indicate:
+/// - Stub content that needs expansion
+/// - Placeholder sections
+/// - Incomplete documentation
+#[derive(Clone)]
+pub struct CONTENT003 {
+    /// Minimum word count threshold
+    min_words: usize,
+    /// Whether to count words in code blocks
+    include_code_blocks: bool,
+}
+
+impl Default for CONTENT003 {
+    fn default() -> Self {
+        Self {
+            min_words: DEFAULT_MIN_WORDS,
+            include_code_blocks: false,
+        }
+    }
+}
+
+impl CONTENT003 {
+    /// Create with a custom minimum word count
+    #[allow(dead_code)]
+    pub fn with_min_words(min_words: usize) -> Self {
+        Self {
+            min_words,
+            include_code_blocks: false,
+        }
+    }
+
+    /// Set whether to include code blocks in word count
+    #[allow(dead_code)]
+    pub fn include_code_blocks(mut self, include: bool) -> Self {
+        self.include_code_blocks = include;
+        self
+    }
+
+    /// Count words in content, optionally excluding code blocks
+    fn count_words(&self, lines: &[String]) -> usize {
+        let mut word_count = 0;
+        let mut in_code_block = false;
+
+        for line in lines {
+            let trimmed = line.trim();
+
+            // Track fenced code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            // Skip code block content unless configured to include
+            if in_code_block && !self.include_code_blocks {
+                continue;
+            }
+
+            // Skip headings from word count (they're structural, not content)
+            if trimmed.starts_with('#') {
+                continue;
+            }
+
+            // Skip HTML comments
+            if trimmed.starts_with("<!--") {
+                continue;
+            }
+
+            // Skip mdBook directives
+            if trimmed.starts_with("{{#") {
+                continue;
+            }
+
+            // Count words in this line
+            word_count += trimmed.split_whitespace().count();
+        }
+
+        word_count
+    }
+}
+
+impl Rule for CONTENT003 {
+    fn id(&self) -> &'static str {
+        "CONTENT003"
+    }
+
+    fn name(&self) -> &'static str {
+        "no-short-chapters"
+    }
+
+    fn description(&self) -> &'static str {
+        "Chapters should have sufficient content (minimum word count)"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+
+        let word_count = self.count_words(&document.lines);
+
+        if word_count < self.min_words {
+            violations.push(self.create_violation(
+                format!(
+                    "Chapter has only {} words (minimum: {}). Consider expanding the content or marking as draft",
+                    word_count, self.min_words
+                ),
+                1,
+                1,
+                Severity::Warning,
+            ));
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_sufficient_content() {
+        // 50+ words of content
+        let content = "# Chapter Title
+
+This is a paragraph with enough content to pass the minimum word count threshold.
+We need to write several sentences here to make sure we have at least fifty words
+in total. Let me add some more text to ensure we definitely pass the check.
+Here is another sentence. And another one. Plus a few more words to be safe.";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_short_chapter() {
+        let content = "# Short Chapter
+
+This is too short.";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("words"));
+    }
+
+    #[test]
+    fn test_empty_chapter() {
+        let content = "# Empty Chapter";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("0 words"));
+    }
+
+    #[test]
+    fn test_custom_threshold() {
+        let content = "# Chapter
+
+This has about ten words of content here.";
+        let doc = create_test_document(content);
+
+        // Should fail with default (50 words)
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+
+        // Should pass with lower threshold
+        let rule = CONTENT003::with_min_words(5);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_code_blocks_excluded_by_default() {
+        let content = "# Chapter
+
+Short intro.
+
+```rust
+fn main() {
+    // This is a lot of code that adds many words
+    // but should not count toward the word total
+    // because code blocks are excluded by default
+    let x = 1;
+    let y = 2;
+    let z = x + y;
+    println!(\"Result: {}\", z);
+}
+```";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        // Should be short because code block words don't count
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_code_blocks_included_when_configured() {
+        let content = "# Chapter
+
+Short intro but lots of code comments.
+
+```rust
+// This is a very long comment that contains many words
+// and should be counted when we configure the rule to
+// include code blocks in the word count which brings
+// our total word count up significantly higher than
+// the minimum threshold of fifty words required
+fn main() {
+    println!(\"Hello\");
+}
+```";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default().include_code_blocks(true);
+        let violations = rule.check(&doc).unwrap();
+        // Should pass because code block words count
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_headings_not_counted() {
+        let content = "# This Heading Has Many Words In It
+
+## Another Long Heading With Words
+
+### Yet Another Heading
+
+#### And One More
+
+Short body.";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        // Should be short because headings don't count
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_mdbook_directives_not_counted() {
+        let content = "# Chapter
+
+{{#include file.rs}}
+{{#playground example.rs}}
+{{#title Some Title}}
+
+Short content.";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_just_at_threshold() {
+        // Exactly 50 words
+        let words: Vec<&str> = (0..50).map(|_| "word").collect();
+        let content = format!("# Chapter\n\n{}", words.join(" "));
+        let doc = create_test_document(&content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_just_below_threshold() {
+        // 49 words
+        let words: Vec<&str> = (0..49).map(|_| "word").collect();
+        let content = format!("# Chapter\n\n{}", words.join(" "));
+        let doc = create_test_document(&content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_html_comments_not_counted() {
+        let content = "# Chapter
+
+<!-- This is a long HTML comment with many words that should not be counted -->
+
+Short visible content.";
+        let doc = create_test_document(content);
+        let rule = CONTENT003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/content004.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content004.rs
@@ -1,0 +1,407 @@
+//! CONTENT004: Heading capitalization consistency
+//!
+//! Checks that headings use consistent capitalization style throughout
+//! the document (e.g., Title Case vs sentence case).
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to extract heading text from ATX headings
+static HEADING_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(#{1,6})\s+(.+?)(?:\s*#*)?$").unwrap());
+
+/// Common lowercase words in Title Case (articles, conjunctions, prepositions)
+const TITLE_CASE_EXCEPTIONS: &[&str] = &[
+    "a", "an", "the", "and", "but", "or", "nor", "for", "yet", "so", "at", "by", "in", "of", "on",
+    "to", "up", "as", "if", "is", "it", "vs", "via", "with",
+];
+
+/// Capitalization style for headings
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CapitalizationStyle {
+    /// Title Case: Most Words Are Capitalized
+    TitleCase,
+    /// Sentence case: Only first word and proper nouns capitalized
+    SentenceCase,
+    /// Consistent: Use whatever style the first heading uses
+    #[default]
+    Consistent,
+}
+
+/// CONTENT004: Checks heading capitalization consistency
+///
+/// This rule ensures headings use a consistent capitalization style.
+/// By default, it detects the style from the first heading and expects
+/// all subsequent headings to follow the same pattern.
+#[derive(Clone, Default)]
+pub struct CONTENT004 {
+    /// Required capitalization style
+    style: CapitalizationStyle,
+}
+
+impl CONTENT004 {
+    /// Create with a specific capitalization style
+    #[allow(dead_code)]
+    pub fn with_style(style: CapitalizationStyle) -> Self {
+        Self { style }
+    }
+
+    /// Extract heading text from a line
+    fn extract_heading(&self, line: &str) -> Option<(usize, String)> {
+        HEADING_REGEX.captures(line).map(|caps| {
+            let level = caps.get(1).unwrap().as_str().len();
+            let text = caps.get(2).unwrap().as_str().trim().to_string();
+            (level, text)
+        })
+    }
+
+    /// Check if a word is an acronym (all uppercase letters)
+    fn is_acronym(&self, word: &str) -> bool {
+        word.len() > 1
+            && word.chars().all(|c| c.is_uppercase() || !c.is_alphabetic())
+            && word.chars().any(|c| c.is_alphabetic())
+    }
+
+    /// Check if a word is a title case exception (article, preposition, etc.)
+    fn is_exception(&self, word: &str) -> bool {
+        TITLE_CASE_EXCEPTIONS.contains(&word.to_lowercase().as_str())
+    }
+
+    /// Get significant words (excluding acronyms and exceptions except first word)
+    fn get_significant_words<'a>(&self, text: &'a str) -> Vec<(usize, &'a str)> {
+        text.split_whitespace()
+            .enumerate()
+            .filter(|(i, word)| {
+                // First word is always significant
+                if *i == 0 {
+                    return true;
+                }
+                // Skip acronyms
+                if self.is_acronym(word) {
+                    return false;
+                }
+                // Skip exception words
+                if self.is_exception(word) {
+                    return false;
+                }
+                // Skip non-alphabetic words
+                if !word.chars().next().is_some_and(|c| c.is_alphabetic()) {
+                    return false;
+                }
+                true
+            })
+            .collect()
+    }
+
+    /// Check if a heading appears to be Title Case
+    fn is_title_case(&self, text: &str) -> bool {
+        let words = self.get_significant_words(text);
+        if words.is_empty() {
+            return true;
+        }
+
+        let capitalized = words
+            .iter()
+            .filter(|(_, word)| word.chars().next().is_some_and(|c| c.is_uppercase()))
+            .count();
+
+        // Consider title case if >= 60% of significant words are capitalized
+        capitalized as f64 / words.len() as f64 >= 0.6
+    }
+
+    /// Check if a heading appears to be sentence case
+    fn is_sentence_case(&self, text: &str) -> bool {
+        let words: Vec<&str> = text.split_whitespace().collect();
+        if words.is_empty() {
+            return true;
+        }
+
+        // First word should be capitalized
+        if !words[0].chars().next().is_some_and(|c| c.is_uppercase()) {
+            return false;
+        }
+
+        // Count non-first words that start with uppercase (excluding acronyms)
+        let mut uppercase_non_first = 0;
+        let mut checkable_non_first = 0;
+
+        for word in words.iter().skip(1) {
+            // Skip acronyms
+            if self.is_acronym(word) {
+                continue;
+            }
+            // Skip non-alphabetic
+            if !word.chars().next().is_some_and(|c| c.is_alphabetic()) {
+                continue;
+            }
+
+            checkable_non_first += 1;
+            if word.chars().next().is_some_and(|c| c.is_uppercase()) {
+                uppercase_non_first += 1;
+            }
+        }
+
+        // Allow some capitalization for proper nouns (~30% of remaining words)
+        checkable_non_first == 0 || uppercase_non_first as f64 / checkable_non_first as f64 <= 0.35
+    }
+
+    /// Detect the style of a heading
+    fn detect_style(&self, text: &str) -> CapitalizationStyle {
+        let is_title = self.is_title_case(text);
+        let is_sentence = self.is_sentence_case(text);
+
+        // If it looks like title case but not sentence case, it's title case
+        if is_title && !is_sentence {
+            CapitalizationStyle::TitleCase
+        } else {
+            // Default to sentence case (includes ambiguous cases)
+            CapitalizationStyle::SentenceCase
+        }
+    }
+}
+
+impl Rule for CONTENT004 {
+    fn id(&self) -> &'static str {
+        "CONTENT004"
+    }
+
+    fn name(&self) -> &'static str {
+        "heading-capitalization"
+    }
+
+    fn description(&self) -> &'static str {
+        "Headings should use consistent capitalization (Title Case or sentence case)"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut detected_style: Option<CapitalizationStyle> = None;
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let line_num = line_idx + 1;
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Extract heading
+            if let Some((_level, text)) = self.extract_heading(trimmed) {
+                // Skip very short headings (single word)
+                if text.split_whitespace().count() < 2 {
+                    continue;
+                }
+
+                let heading_style = self.detect_style(&text);
+
+                match self.style {
+                    CapitalizationStyle::Consistent => {
+                        if let Some(expected) = detected_style {
+                            if heading_style != expected {
+                                let expected_name = match expected {
+                                    CapitalizationStyle::TitleCase => "Title Case",
+                                    CapitalizationStyle::SentenceCase => "sentence case",
+                                    CapitalizationStyle::Consistent => unreachable!(),
+                                };
+                                violations.push(self.create_violation(
+                                    format!(
+                                        "Heading '{}' uses inconsistent capitalization (expected {})",
+                                        text, expected_name
+                                    ),
+                                    line_num,
+                                    1,
+                                    Severity::Warning,
+                                ));
+                            }
+                        } else {
+                            detected_style = Some(heading_style);
+                        }
+                    }
+                    CapitalizationStyle::TitleCase => {
+                        if !self.is_title_case(&text) {
+                            violations.push(self.create_violation(
+                                format!("Heading '{}' should use Title Case", text),
+                                line_num,
+                                1,
+                                Severity::Warning,
+                            ));
+                        }
+                    }
+                    CapitalizationStyle::SentenceCase => {
+                        if !self.is_sentence_case(&text) {
+                            violations.push(self.create_violation(
+                                format!("Heading '{}' should use sentence case", text),
+                                line_num,
+                                1,
+                                Severity::Warning,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_consistent_title_case() {
+        let content = "# Getting Started Guide
+
+## Installation Steps
+
+### Configuration Options";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_consistent_sentence_case() {
+        let content = "# Getting started guide
+
+## Installation steps
+
+### Configuration options";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_inconsistent_capitalization() {
+        let content = "# Getting Started Guide
+
+## installation steps
+
+### More Configuration Options";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("installation steps"));
+    }
+
+    #[test]
+    fn test_enforced_title_case() {
+        let content = "# Getting started guide
+
+## Installation Steps";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::with_style(CapitalizationStyle::TitleCase);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Getting started guide"));
+    }
+
+    #[test]
+    fn test_enforced_sentence_case() {
+        let content = "# Getting Started Guide
+
+## Installation steps";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::with_style(CapitalizationStyle::SentenceCase);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Getting Started Guide"));
+    }
+
+    #[test]
+    fn test_single_word_headings_ignored() {
+        let content = "# Introduction
+
+## Overview
+
+### Details";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_headings_in_code_blocks_ignored() {
+        let content = "# Main Title Here
+
+```markdown
+# This Is Not a Real Heading
+## neither is this
+```
+
+## Second Section Here";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_mixed_styles_detected() {
+        let content = "# User Guide Introduction
+
+## getting started quickly
+
+### Advanced Configuration";
+        let doc = create_test_document(content);
+        let rule = CONTENT004::default();
+        let violations = rule.check(&doc).unwrap();
+        // Should detect that "getting started quickly" doesn't match Title Case
+        assert!(!violations.is_empty());
+    }
+
+    #[test]
+    fn test_is_title_case() {
+        let rule = CONTENT004::default();
+        assert!(rule.is_title_case("Getting Started Guide"));
+        assert!(rule.is_title_case("The Quick Brown Fox"));
+        assert!(!rule.is_title_case("getting started guide"));
+    }
+
+    #[test]
+    fn test_is_sentence_case() {
+        let rule = CONTENT004::default();
+        assert!(rule.is_sentence_case("Getting started guide"));
+        assert!(rule.is_sentence_case("The quick brown fox"));
+        assert!(!rule.is_sentence_case("Getting Started Guide"));
+    }
+
+    #[test]
+    fn test_is_acronym() {
+        let rule = CONTENT004::default();
+        assert!(rule.is_acronym("API"));
+        assert!(rule.is_acronym("HTTP"));
+        assert!(rule.is_acronym("REST"));
+        assert!(!rule.is_acronym("Api"));
+        assert!(!rule.is_acronym("A")); // Single letter not acronym
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/content005.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content005.rs
@@ -1,0 +1,373 @@
+//! CONTENT005: Introductory paragraph before subheading
+//!
+//! Ensures chapters have introductory content before the first subheading.
+//! Jumping directly to subheadings without context can confuse readers.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to match ATX headings
+static HEADING_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(#{1,6})\s+.+").unwrap());
+
+/// Default minimum words for an introduction
+const DEFAULT_MIN_INTRO_WORDS: usize = 10;
+
+/// CONTENT005: Ensures chapters have introductory paragraphs
+///
+/// This rule checks that there is substantive content between the main
+/// heading (H1) and the first subheading (H2+). Chapters that jump
+/// directly into subheadings without introduction can be disorienting.
+#[derive(Clone)]
+pub struct CONTENT005 {
+    /// Minimum words required in the introduction
+    min_intro_words: usize,
+}
+
+impl Default for CONTENT005 {
+    fn default() -> Self {
+        Self {
+            min_intro_words: DEFAULT_MIN_INTRO_WORDS,
+        }
+    }
+}
+
+impl CONTENT005 {
+    /// Create with a custom minimum introduction word count
+    #[allow(dead_code)]
+    pub fn with_min_words(min_words: usize) -> Self {
+        Self {
+            min_intro_words: min_words,
+        }
+    }
+
+    /// Get the heading level from a line (1-6, or 0 if not a heading)
+    fn get_heading_level(&self, line: &str) -> usize {
+        let trimmed = line.trim();
+        if let Some(caps) = HEADING_REGEX.captures(trimmed) {
+            caps.get(1).map(|m| m.as_str().len()).unwrap_or(0)
+        } else {
+            0
+        }
+    }
+
+    /// Count words in a range of lines, excluding special elements
+    fn count_content_words(&self, lines: &[String]) -> usize {
+        let mut word_count = 0;
+        let mut in_code_block = false;
+
+        for line in lines {
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Skip headings
+            if trimmed.starts_with('#') {
+                continue;
+            }
+
+            // Skip HTML comments
+            if trimmed.starts_with("<!--") {
+                continue;
+            }
+
+            // Skip mdBook directives
+            if trimmed.starts_with("{{#") {
+                continue;
+            }
+
+            // Skip empty lines
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            word_count += trimmed.split_whitespace().count();
+        }
+
+        word_count
+    }
+}
+
+impl Rule for CONTENT005 {
+    fn id(&self) -> &'static str {
+        "CONTENT005"
+    }
+
+    fn name(&self) -> &'static str {
+        "intro-before-subheading"
+    }
+
+    fn description(&self) -> &'static str {
+        "Chapters should have introductory content before the first subheading"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut h1_line: Option<usize> = None;
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            let level = self.get_heading_level(trimmed);
+
+            // Track H1
+            if level == 1 && h1_line.is_none() {
+                h1_line = Some(line_idx);
+                continue;
+            }
+
+            // Check content before first subheading (H2+)
+            if level >= 2 {
+                if let Some(h1_idx) = h1_line {
+                    // Get content between H1 and this subheading
+                    let content_lines = &document.lines[h1_idx + 1..line_idx];
+                    let intro_words = self.count_content_words(content_lines);
+
+                    if intro_words < self.min_intro_words {
+                        let line_num = line_idx + 1;
+                        violations.push(self.create_violation(
+                            format!(
+                                "Subheading at line {} has insufficient introduction ({} words, minimum: {}). \
+                                 Add introductory content after the main heading",
+                                line_num, intro_words, self.min_intro_words
+                            ),
+                            line_num,
+                            1,
+                            Severity::Warning,
+                        ));
+                    }
+                }
+                // Only check the first subheading
+                break;
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_sufficient_introduction() {
+        let content = "# Chapter Title
+
+This chapter covers important topics that you need to understand.
+We will explore several key concepts in detail below.
+
+## First Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_no_introduction() {
+        let content = "# Chapter Title
+
+## First Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("0 words"));
+    }
+
+    #[test]
+    fn test_short_introduction() {
+        let content = "# Chapter Title
+
+Brief intro.
+
+## First Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("2 words"));
+    }
+
+    #[test]
+    fn test_custom_min_words() {
+        let content = "# Chapter Title
+
+Short intro here.
+
+## First Section";
+        let doc = create_test_document(content);
+
+        // Should fail with default (10 words)
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+
+        // Should pass with lower threshold
+        let rule = CONTENT005::with_min_words(3);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_no_h1_heading() {
+        let content = "## First Section
+
+Some content here.
+
+## Second Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        // No H1, so no check performed
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_no_subheadings() {
+        let content = "# Chapter Title
+
+This is a simple chapter with no subheadings.
+It just has regular paragraphs of content.";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_code_block_before_subheading() {
+        let content = "# Chapter Title
+
+```rust
+// This code block should not count as intro
+fn main() {}
+```
+
+## First Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        // Code blocks don't count toward intro
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_mdbook_directive_doesnt_count() {
+        let content = "# Chapter Title
+
+{{#include intro.md}}
+
+## First Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        // Directives don't count as intro content
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_only_first_subheading_checked() {
+        let content = "# Chapter Title
+
+This is a proper introduction with enough words to pass.
+
+## First Section
+
+## Second Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_h3_as_first_subheading() {
+        let content = "# Chapter Title
+
+### Directly to H3";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_heading_in_code_block_ignored() {
+        let content = "# Chapter Title
+
+This is the introduction with enough words here to pass the threshold.
+
+```markdown
+## This is not a real subheading
+```
+
+## Actual Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_html_comments_dont_count() {
+        let content = "# Chapter Title
+
+<!-- This is a long comment that has many words but should not count -->
+
+## First Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_exact_threshold() {
+        // Exactly 10 words
+        let content = "# Chapter Title
+
+One two three four five six seven eight nine ten.
+
+## First Section";
+        let doc = create_test_document(content);
+        let rule = CONTENT005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/content/mod.rs
@@ -5,6 +5,9 @@
 
 mod content001;
 mod content002;
+mod content003;
+mod content004;
+mod content005;
 
 use crate::{RuleProvider, RuleRegistry};
 
@@ -27,9 +30,18 @@ impl RuleProvider for ContentRuleProvider {
     fn register_rules(&self, registry: &mut RuleRegistry) {
         registry.register(Box::new(content001::CONTENT001::default()));
         registry.register(Box::new(content002::CONTENT002::default()));
+        registry.register(Box::new(content003::CONTENT003::default()));
+        registry.register(Box::new(content004::CONTENT004::default()));
+        registry.register(Box::new(content005::CONTENT005::default()));
     }
 
     fn rule_ids(&self) -> Vec<&'static str> {
-        vec!["CONTENT001", "CONTENT002"]
+        vec![
+            "CONTENT001",
+            "CONTENT002",
+            "CONTENT003",
+            "CONTENT004",
+            "CONTENT005",
+        ]
     }
 }


### PR DESCRIPTION
Add three more content quality rules from issue #16:

## New Rules

### CONTENT003: no-short-chapters
Flags chapters with fewer than 50 words (configurable). Short chapters often indicate:
- Stub content that needs expansion
- Placeholder sections
- Incomplete documentation

### CONTENT004: heading-capitalization
Checks that headings use consistent capitalization throughout the document:
- Detects first heading's style (Title Case or sentence case)
- Flags subsequent headings that don't match
- Can enforce a specific style via configuration
- Handles acronyms (API, HTTP) and title case exceptions (a, an, the, etc.)

### CONTENT005: intro-before-subheading
Ensures chapters have introductory content (10+ words, configurable) between the main H1 heading and the first subheading. Chapters that jump directly into subheadings without introduction can be disorienting.

## Test Updates
Updated existing tests to account for CONTENT003's minimum word requirement.

Partial progress on #16