### PR TITLE
feat: add MDBOOK016 and MDBOOK017 rules

### DIFF
--- a/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
+++ b/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
@@ -410,6 +410,7 @@ fn test_fix_clean_file() {
     let test_file = temp_dir.path().join("clean.md");
 
     // Content needs 50+ words to pass CONTENT003 (short chapter detection)
+    // Use # prefix in rust code block to avoid MDBOOK017 warning
     fs::write(
         &test_file,
         "# Clean Document
@@ -422,7 +423,9 @@ Let me add some more text to ensure we definitely pass the minimum word
 count threshold that is required by the linter for content validation.
 
 ```rust
-fn main() {}
+# fn main() {
+let x = 42;
+# }
 ```
 ",
     )

--- a/crates/mdbook-lint-cli/tests/fixtures/markdown/mdbook_clean.md
+++ b/crates/mdbook-lint-cli/tests/fixtures/markdown/mdbook_clean.md
@@ -7,9 +7,9 @@ This document follows all mdBook linting rules and should produce no violations.
 All code blocks have appropriate language tags:
 
 ```rust
-fn main() {
-    println!("Hello, Rust!");
-}
+# fn main() {
+println!("Hello, Rust!");
+# }
 ```
 
 ```bash

--- a/crates/mdbook-lint-cli/tests/fixtures/mdbook/minimal_input.json
+++ b/crates/mdbook-lint-cli/tests/fixtures/mdbook/minimal_input.json
@@ -24,7 +24,7 @@
       {
         "Chapter": {
           "name": "Introduction",
-          "content": "# Introduction\n\nThis is a simple test chapter with proper formatting.\n\n## Getting Started\n\nEverything looks good here.\n\n```rust\nfn main() {\n    println!(\"Hello, world!\");\n}\n```\n\nThis should pass all linting rules.\n",
+          "content": "# Introduction\n\nThis is a simple test chapter with proper formatting.\n\n## Getting Started\n\nEverything looks good here.\n\n```rust\n# fn main() {\nprintln!(\"Hello, world!\");\n# }\n```\n\nThis should pass all linting rules.\n",
           "number": null,
           "sub_items": [],
           "path": "introduction.md",

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook016.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook016.rs
@@ -1,0 +1,379 @@
+//! MDBOOK016: Validate Rust code block attributes
+//!
+//! Validates that Rust code blocks use valid mdBook/rustdoc attributes
+//! like `ignore`, `should_panic`, `no_run`, `compile_fail`, etc.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Valid Rust code block attributes recognized by mdBook and rustdoc
+const VALID_RUST_ATTRIBUTES: &[&str] = &[
+    // mdBook attributes
+    "ignore",
+    "noplayground",
+    "noplaypen",
+    "mdbook-runnable",
+    "editable",
+    "hidelines",
+    // rustdoc attributes
+    "should_panic",
+    "no_run",
+    "compile_fail",
+    "edition2015",
+    "edition2018",
+    "edition2021",
+    "edition2024",
+    // Common valid identifiers
+    "rust",
+    "text",
+    "plain",
+];
+
+/// Regex to match code block opening with language tag
+static CODE_BLOCK_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^```(\S+)?").unwrap());
+
+/// MDBOOK016: Validates Rust code block attributes
+///
+/// This rule checks that Rust code blocks use valid attributes.
+/// Invalid attributes can cause unexpected behavior in mdBook builds
+/// or rustdoc testing.
+pub struct MDBOOK016;
+
+impl MDBOOK016 {
+    /// Parse attributes from a language tag like "rust,ignore,should_panic"
+    fn parse_attributes<'a>(&self, lang_tag: &'a str) -> Vec<&'a str> {
+        lang_tag.split(',').map(|s| s.trim()).collect()
+    }
+
+    /// Check if a tag indicates this is a Rust code block
+    fn is_rust_code_block(&self, lang_tag: &str) -> bool {
+        let first_part = lang_tag.split(',').next().unwrap_or("");
+        first_part == "rust" || first_part == "rs"
+    }
+
+    /// Validate a single attribute
+    fn validate_attribute(&self, attr: &str) -> Option<String> {
+        // Skip empty attributes
+        if attr.is_empty() {
+            return None;
+        }
+
+        // Skip the language identifier itself
+        if attr == "rust" || attr == "rs" {
+            return None;
+        }
+
+        // Check for hidelines=X pattern
+        if attr.starts_with("hidelines=") {
+            return None;
+        }
+
+        // Check if it's a valid attribute
+        if VALID_RUST_ATTRIBUTES.contains(&attr) {
+            return None;
+        }
+
+        // Check for common typos and suggest corrections
+        let suggestion = self.get_typo_suggestion(attr);
+        if let Some(suggested) = suggestion {
+            Some(format!(
+                "Unknown Rust code block attribute '{}'. Did you mean '{}'?",
+                attr, suggested
+            ))
+        } else {
+            Some(format!(
+                "Unknown Rust code block attribute '{}'. Valid attributes include: ignore, \
+                 should_panic, no_run, compile_fail, noplayground, editable",
+                attr
+            ))
+        }
+    }
+
+    /// Get suggestion for common typos
+    fn get_typo_suggestion(&self, attr: &str) -> Option<&'static str> {
+        match attr.to_lowercase().as_str() {
+            "shouldpanic" | "should-panic" | "shouldPanic" => Some("should_panic"),
+            "norun" | "no-run" | "noRun" => Some("no_run"),
+            "compilefail" | "compile-fail" | "compileFail" => Some("compile_fail"),
+            "ignored" | "ignor" => Some("ignore"),
+            "noplaypen" => Some("noplayground"),
+            "editible" | "edittable" => Some("editable"),
+            _ => None,
+        }
+    }
+}
+
+impl Rule for MDBOOK016 {
+    fn id(&self) -> &'static str {
+        "MDBOOK016"
+    }
+
+    fn name(&self) -> &'static str {
+        "rust-code-block-attributes"
+    }
+
+    fn description(&self) -> &'static str {
+        "Rust code blocks should use valid mdBook/rustdoc attributes"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::MdBook).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let line_num = line_idx + 1;
+            let trimmed = line.trim();
+
+            // Check for code block start
+            if let Some(caps) = CODE_BLOCK_REGEX.captures(trimmed) {
+                if in_code_block {
+                    // This is actually closing a code block
+                    in_code_block = false;
+                    continue;
+                }
+
+                in_code_block = true;
+
+                // Check if there's a language tag
+                if let Some(lang_match) = caps.get(1) {
+                    let lang_tag = lang_match.as_str();
+
+                    // Only validate Rust code blocks
+                    if self.is_rust_code_block(lang_tag) {
+                        let attrs = self.parse_attributes(lang_tag);
+
+                        for attr in attrs {
+                            if let Some(error_msg) = self.validate_attribute(attr) {
+                                violations.push(self.create_violation(
+                                    error_msg,
+                                    line_num,
+                                    1,
+                                    Severity::Warning,
+                                ));
+                            }
+                        }
+                    }
+                }
+            } else if trimmed == "```" || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_rust_attributes() {
+        let content = "# Code Examples
+
+```rust,ignore
+fn main() {}
+```
+
+```rust,should_panic
+fn main() { panic!(); }
+```
+
+```rust,no_run
+fn main() {}
+```
+
+```rust,compile_fail
+fn main() { invalid syntax }
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_invalid_attribute() {
+        let content = "# Code
+
+```rust,invalid_attr
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("invalid_attr"));
+    }
+
+    #[test]
+    fn test_typo_suggestion() {
+        let content = "# Code
+
+```rust,shouldpanic
+fn main() { panic!(); }
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("should_panic"));
+        assert!(violations[0].message.contains("Did you mean"));
+    }
+
+    #[test]
+    fn test_multiple_valid_attributes() {
+        let content = "# Code
+
+```rust,ignore,editable
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_non_rust_block_ignored() {
+        let content = "# Code
+
+```python,invalid_attr
+def main():
+    pass
+```
+
+```javascript,also_invalid
+console.log('hi');
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_plain_rust_block() {
+        let content = "# Code
+
+```rust
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_noplayground_attribute() {
+        let content = "# Code
+
+```rust,noplayground
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_edition_attributes() {
+        let content = "# Code
+
+```rust,edition2021
+fn main() {}
+```
+
+```rust,edition2018,ignore
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_hidelines_attribute() {
+        let content = "# Code
+
+```rust,hidelines=#
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_mixed_valid_invalid() {
+        let content = "# Code
+
+```rust,ignore,badattr,should_panic
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("badattr"));
+    }
+
+    #[test]
+    fn test_rs_alias() {
+        let content = "# Code
+
+```rs,ignore
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_typo_no_run() {
+        let content = "# Code
+
+```rust,norun
+fn main() {}
+```
+";
+        let doc = create_test_document(content);
+        let rule = MDBOOK016;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("no_run"));
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook017.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook017.rs
@@ -1,0 +1,339 @@
+//! MDBOOK017: Check for potentially missing hidden line prefixes in Rust code
+//!
+//! In mdBook, lines starting with `#` in Rust code blocks are hidden from
+//! readers but still compiled. This rule detects common patterns that might
+//! indicate missing `#` prefixes.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to match code block opening with rust language tag
+static RUST_CODE_BLOCK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^```(rust|rs)").unwrap());
+
+/// Patterns that typically should be hidden in documentation examples
+const BOILERPLATE_PATTERNS: &[&str] = &[
+    "use std::",
+    "use crate::",
+    "extern crate",
+    "fn main() {",
+    "fn main(){",
+    "pub fn main() {",
+    "async fn main() {",
+    "#![allow(",
+    "#![deny(",
+    "#![warn(",
+    "#![feature(",
+];
+
+/// MDBOOK017: Detects potentially missing hidden line prefixes
+///
+/// In mdBook Rust code blocks, lines prefixed with `#` are hidden from
+/// readers but still compiled. This rule flags common boilerplate patterns
+/// that are typically hidden but lack the `#` prefix.
+pub struct MDBOOK017;
+
+impl MDBOOK017 {
+    /// Check if a line looks like boilerplate that should be hidden
+    fn is_boilerplate(&self, line: &str) -> bool {
+        let trimmed = line.trim();
+        BOILERPLATE_PATTERNS
+            .iter()
+            .any(|pattern| trimmed.starts_with(pattern))
+    }
+
+    /// Check if a line is already hidden (starts with #)
+    fn is_hidden(&self, line: &str) -> bool {
+        let trimmed = line.trim();
+        trimmed.starts_with('#') && !trimmed.starts_with("#[") && !trimmed.starts_with("#!")
+    }
+
+    /// Check if a code block appears to use hidden lines
+    fn block_uses_hidden_lines(&self, lines: &[&str]) -> bool {
+        lines.iter().any(|line| self.is_hidden(line))
+    }
+}
+
+impl Rule for MDBOOK017 {
+    fn id(&self) -> &'static str {
+        "MDBOOK017"
+    }
+
+    fn name(&self) -> &'static str {
+        "hidden-code-prefix"
+    }
+
+    fn description(&self) -> &'static str {
+        "Rust code blocks should use # prefix to hide boilerplate from readers"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::MdBook).introduced_in("mdbook-lint v0.12.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut in_rust_block = false;
+        let mut block_lines: Vec<(usize, &str)> = Vec::new();
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let line_num = line_idx + 1;
+            let trimmed = line.trim();
+
+            // Check for Rust code block start
+            if RUST_CODE_BLOCK_REGEX.is_match(trimmed) {
+                in_rust_block = true;
+                block_lines.clear();
+                continue;
+            }
+
+            // Check for code block end
+            if in_rust_block && (trimmed == "```" || trimmed.starts_with("~~~")) {
+                // Analyze the collected block
+                let raw_lines: Vec<&str> = block_lines.iter().map(|(_, l)| *l).collect();
+
+                // Only flag if the block doesn't already use hidden lines
+                // If they're using hidden lines elsewhere, they probably know about the feature
+                if !self.block_uses_hidden_lines(&raw_lines) {
+                    for (bl_num, bl_content) in &block_lines {
+                        if self.is_boilerplate(bl_content) {
+                            let pattern = BOILERPLATE_PATTERNS
+                                .iter()
+                                .find(|p| bl_content.trim().starts_with(*p))
+                                .unwrap_or(&"boilerplate");
+
+                            violations.push(self.create_violation(
+                                format!(
+                                    "Consider hiding '{}' with # prefix to focus on the example's core logic",
+                                    pattern
+                                ),
+                                *bl_num,
+                                1,
+                                Severity::Info,
+                            ));
+                        }
+                    }
+                }
+
+                in_rust_block = false;
+                block_lines.clear();
+                continue;
+            }
+
+            // Collect lines inside Rust blocks
+            if in_rust_block {
+                block_lines.push((line_num, line.as_str()));
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_no_boilerplate() {
+        let content = r#"# Example
+
+```rust
+let x = 42;
+println!("{}", x);
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_unhidden_fn_main() {
+        let content = r#"# Example
+
+```rust
+fn main() {
+    let x = 42;
+    println!("{}", x);
+}
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_unhidden_use_statement() {
+        let content = r#"# Example
+
+```rust
+use std::collections::HashMap;
+
+let mut map = HashMap::new();
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("use std::"));
+    }
+
+    #[test]
+    fn test_already_hidden() {
+        let content = r#"# Example
+
+```rust
+# fn main() {
+let x = 42;
+println!("{}", x);
+# }
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_block_with_some_hidden() {
+        // If the block already uses hidden lines, don't flag unhidden boilerplate
+        // The author is clearly aware of the feature
+        let content = r#"# Example
+
+```rust
+# use std::io;
+fn main() {
+    println!("Hello");
+}
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_non_rust_block_ignored() {
+        let content = r#"# Example
+
+```python
+def main():
+    print("Hello")
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_extern_crate() {
+        let content = r#"# Example
+
+```rust
+extern crate serde;
+
+fn example() {}
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("extern crate"));
+    }
+
+    #[test]
+    fn test_lint_attributes() {
+        let content = r#"# Example
+
+```rust
+#![allow(dead_code)]
+fn unused() {}
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("#![allow("));
+    }
+
+    #[test]
+    fn test_multiple_boilerplate() {
+        let content = r#"# Example
+
+```rust
+use std::collections::HashMap;
+use std::io::Read;
+
+fn main() {
+    let map: HashMap<i32, i32> = HashMap::new();
+}
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        // Should flag both use statements and fn main
+        assert_eq!(violations.len(), 3);
+    }
+
+    #[test]
+    fn test_attribute_not_hidden_marker() {
+        // #[derive(...)] should NOT be considered a hidden line marker
+        let content = r#"# Example
+
+```rust
+#[derive(Debug)]
+struct Foo;
+
+fn main() {
+    println!("{:?}", Foo);
+}
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        // fn main should be flagged because #[derive] is not a hidden marker
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_rs_alias() {
+        let content = r#"# Example
+
+```rs
+fn main() {
+    println!("test");
+}
+```
+"#;
+        let doc = create_test_document(content);
+        let rule = MDBOOK017;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
@@ -15,6 +15,8 @@ mod mdbook009;
 mod mdbook010;
 mod mdbook011;
 mod mdbook012;
+mod mdbook016;
+mod mdbook017;
 mod mdbook021;
 mod mdbook022;
 mod mdbook023;
@@ -51,6 +53,8 @@ impl RuleProvider for MdBookRuleProvider {
         registry.register(Box::new(mdbook010::MDBOOK010));
         registry.register(Box::new(mdbook011::MDBOOK011));
         registry.register(Box::new(mdbook012::MDBOOK012));
+        registry.register(Box::new(mdbook016::MDBOOK016));
+        registry.register(Box::new(mdbook017::MDBOOK017));
         registry.register(Box::new(mdbook021::MDBOOK021));
         registry.register(Box::new(mdbook022::MDBOOK022::default()));
         registry.register(Box::new(mdbook023::MDBOOK023::default()));
@@ -71,6 +75,8 @@ impl RuleProvider for MdBookRuleProvider {
             "MDBOOK010",
             "MDBOOK011",
             "MDBOOK012",
+            "MDBOOK016",
+            "MDBOOK017",
             "MDBOOK021",
             "MDBOOK022",
             "MDBOOK023",


### PR DESCRIPTION
## Summary

Adds two new mdBook-specific rules for Rust code block validation:

### MDBOOK016 - rust-code-block-attributes
Validates Rust code block attributes to catch invalid or mistyped attributes.

**Valid attributes detected:**
- `ignore`, `noplayground`, `noplaypen`, `mdbook-runnable`, `editable`, `hidelines`
- `should_panic`, `no_run`, `compile_fail`
- `edition2015`, `edition2018`, `edition2021`, `edition2024`
- `rust`, `text`, `plain`

**Typo detection with suggestions:**
- `shouldpanic` / `should-panic` -> `should_panic`
- `norun` / `no-run` -> `no_run`
- `compilefail` / `compile-fail` -> `compile_fail`
- And more...

### MDBOOK017 - hidden-code-prefix
Detects boilerplate patterns in Rust code blocks that should be hidden with `#` prefix to focus readers on the essential code.

**Detected patterns:**
- `fn main() {` and variants
- `use std::`, `use crate::`
- `extern crate`
- Lint attributes (`#![allow(`, `#![deny(`, etc.)
- `#![feature(`

**Smart detection:**
- Only flags blocks that don't already use hidden lines
- Uses Info severity (non-blocking suggestion)
- Only applies to Rust/rs code blocks

Closes part of #16