### PR TITLE
feat: add per-rule auto-fix configuration

### DIFF
--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -844,8 +844,10 @@ fn run_cli_mode(
 
     if apply_fixes {
         for (file_path, violations) in &violations_by_file {
-            let fixable_violations: Vec<_> =
-                violations.iter().filter(|v| v.fix.is_some()).collect();
+            let fixable_violations: Vec<_> = violations
+                .iter()
+                .filter(|v| v.fix.is_some() && config.should_auto_fix_rule(&v.rule_id))
+                .collect();
 
             if !fixable_violations.is_empty() {
                 let path = PathBuf::from(file_path);


### PR DESCRIPTION
## Summary

Adds ability to enable/disable auto-fix on a per-rule basis, allowing users to control which rules have their fixes applied when using `--fix`.

## Configuration

### Global Setting
```toml
# Disable all auto-fixes by default
auto-fix = false
```

### Per-Rule Override
```toml
# Global setting
auto-fix = true

# Disable auto-fix for specific rules
[MD001]
auto-fix = false

[MD024]
auto-fix = false
```

## Example Use Cases

### Conservative: Only fix whitespace issues
```toml
auto-fix = false  # Disable all fixes by default

[MD009]  # Trailing spaces
auto-fix = true

[MD010]  # Hard tabs
auto-fix = true

[MD012]  # Multiple blank lines
auto-fix = true
```

### Aggressive: Fix everything except structural changes
```toml
auto-fix = true  # Enable all fixes by default

[MD001]  # Heading increment
auto-fix = false

[MD024]  # Duplicate headings
auto-fix = false

[MD025]  # Multiple H1s
auto-fix = false
```

## Implementation

- Added `auto-fix` field to core config (default: `true`)
- Added `should_auto_fix_rule()` method to check per-rule settings
- Updated fix application logic to respect configuration
- Added comprehensive tests for all configuration scenarios

Closes #214