### PR TITLE
feat: improve rules command output formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1276,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tabled",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1441,6 +1448,17 @@ dependencies = [
  "bstr",
  "normpath",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1643,6 +1661,28 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1999,6 +2039,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2090,15 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -2295,6 +2368,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode_categories"

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -36,6 +36,7 @@ clap = { workspace = true }
 mdbook = { workspace = true }
 walkdir = { workspace = true }
 rayon = "1.10"
+tabled = "0.20"
 
 # LSP server dependencies (optional)
 tower-lsp = { version = "0.20", optional = true }

--- a/crates/mdbook-lint-cli/tests/rules_command_tests.rs
+++ b/crates/mdbook-lint-cli/tests/rules_command_tests.rs
@@ -1,0 +1,182 @@
+//! Integration tests for the `rules` command
+//!
+//! Tests for rule listing functionality including different output formats,
+//! filtering options, and the --json shorthand flag.
+
+mod common;
+
+use common::cli_command;
+use predicates::str::contains;
+
+#[test]
+fn test_rules_command_default_output() {
+    let assert = cli_command().arg("rules").assert();
+
+    assert
+        .success()
+        .stdout(contains("MD001"))
+        .stdout(contains("heading-increment"))
+        .stdout(contains("MDBOOK001"));
+}
+
+#[test]
+fn test_rules_command_detailed_output() {
+    let assert = cli_command().arg("rules").arg("--detailed").assert();
+
+    // Detailed output should have table formatting with rounded borders
+    assert
+        .success()
+        .stdout(contains("Rule"))
+        .stdout(contains("Name"))
+        .stdout(contains("Description"))
+        .stdout(contains("Category"))
+        .stdout(contains("Status"))
+        .stdout(contains("Fix"))
+        .stdout(contains("MD001"))
+        .stdout(contains("heading-increment"));
+}
+
+#[test]
+fn test_rules_command_json_shorthand() {
+    let assert = cli_command().arg("rules").arg("--json").assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    // Should be valid JSON
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json output should be valid JSON");
+
+    // Should have expected structure
+    assert!(parsed.get("total_rules").is_some());
+    assert!(parsed.get("providers").is_some());
+
+    // Should have rules in providers
+    let providers = parsed.get("providers").unwrap().as_array().unwrap();
+    assert!(!providers.is_empty());
+
+    // First provider should have rules array
+    let first_provider = &providers[0];
+    assert!(first_provider.get("rules").is_some());
+}
+
+#[test]
+fn test_rules_command_format_json() {
+    let assert = cli_command()
+        .arg("rules")
+        .arg("--format")
+        .arg("json")
+        .assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    // Should be valid JSON (same as --json)
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--format json output should be valid JSON");
+
+    assert!(parsed.get("total_rules").is_some());
+}
+
+#[test]
+fn test_rules_command_json_and_format_json_equivalent() {
+    // Both --json and --format json should produce equivalent output
+    let json_flag_output = cli_command().arg("rules").arg("--json").assert();
+
+    let format_json_output = cli_command()
+        .arg("rules")
+        .arg("--format")
+        .arg("json")
+        .assert();
+
+    let json_stdout = String::from_utf8(json_flag_output.get_output().stdout.clone()).unwrap();
+    let format_stdout = String::from_utf8(format_json_output.get_output().stdout.clone()).unwrap();
+
+    // Parse both as JSON and compare structure (not exact match due to potential ordering)
+    let json_parsed: serde_json::Value = serde_json::from_str(&json_stdout).unwrap();
+    let format_parsed: serde_json::Value = serde_json::from_str(&format_stdout).unwrap();
+
+    assert_eq!(
+        json_parsed.get("total_rules"),
+        format_parsed.get("total_rules")
+    );
+}
+
+#[test]
+fn test_rules_command_standard_only() {
+    let assert = cli_command().arg("rules").arg("--standard-only").assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    // Should have standard rules
+    assert!(stdout.contains("MD001"));
+    assert!(stdout.contains("MD013"));
+
+    // Should NOT have mdBook rules
+    assert!(!stdout.contains("MDBOOK001"));
+    assert!(!stdout.contains("MDBOOK002"));
+}
+
+#[test]
+fn test_rules_command_mdbook_only() {
+    let assert = cli_command().arg("rules").arg("--mdbook-only").assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    // Should have mdBook rules
+    assert!(stdout.contains("MDBOOK001"));
+    assert!(stdout.contains("MDBOOK002"));
+
+    // Should NOT have standard rules
+    assert!(!stdout.contains("MD001"));
+    assert!(!stdout.contains("MD013"));
+}
+
+#[test]
+fn test_rules_command_category_filter() {
+    let assert = cli_command()
+        .arg("rules")
+        .arg("--category")
+        .arg("Structure")
+        .assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    // Should have structure-related rules
+    assert!(stdout.contains("MD001")); // heading-increment is Structure category
+
+    // The output should be filtered (fewer rules than total)
+    let line_count = stdout.lines().count();
+    assert!(line_count < 80); // Total rules is 78+, filtered should be much less
+}
+
+#[test]
+fn test_rules_command_detailed_with_json() {
+    // --json should take precedence over --detailed
+    let assert = cli_command()
+        .arg("rules")
+        .arg("--detailed")
+        .arg("--json")
+        .assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    // Should be JSON, not table format
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("Output should be valid JSON even with --detailed");
+
+    assert!(parsed.get("total_rules").is_some());
+}
+
+#[test]
+fn test_rules_command_help() {
+    let assert = cli_command().arg("rules").arg("--help").assert();
+
+    assert
+        .success()
+        .stdout(contains("--detailed"))
+        .stdout(contains("--json"))
+        .stdout(contains("--format"))
+        .stdout(contains("--standard-only"))
+        .stdout(contains("--mdbook-only"))
+        .stdout(contains("--category"))
+        .stdout(contains("--provider"));
+}


### PR DESCRIPTION
## Summary

Improves the `mdbook-lint rules` command output to be more readable and informative.

## Changes

### Default output (no flags)

Shows three columns: Rule ID, Name, and Description with deprecated markers:

```
Available rules:
  MD001       heading-increment                Heading levels should only increment by one lev...
  MD002       first-heading-h1                 First heading should be a top-level heading [deprecated]
  MD003       heading-style                    Heading style should be consistent throughout t...
```

### Detailed output (`--detailed`)

Shows a formatted table with rounded borders:

```
mdbook-lint Rules

╭────────────┬──────────────────────────────────┬────────────────────────────────────────────────────┬───────────────┬──────────────┬─────╮
│ Rule       │ Name                             │ Description                                        │ Category      │ Status       │ Fix │
├────────────┼──────────────────────────────────┼────────────────────────────────────────────────────┼───────────────┼──────────────┼─────┤
│ MD001      │ heading-increment                │ Heading levels should only increment by one lev... │ Structure     │ Stable       │ Yes │
│ MD002      │ first-heading-h1                 │ First heading should be a top-level heading        │ Structure     │ Deprecated   │ Yes │
```

### JSON shorthand (`--json`)

Added `--json` as a convenient shorthand for `--format json`:

```bash
mdbook-lint rules --json
# equivalent to: mdbook-lint rules --format json
```

## Dependencies

- Added `tabled` (0.20) for table formatting

## Tests

Added comprehensive integration tests for the rules command covering:
- Default output format
- Detailed table output
- JSON shorthand flag
- Filter options (--standard-only, --mdbook-only, --category)
- Help text verification

Closes #264