### PR TITLE
feat: add content feature flag for CONTENT rules

### DIFF
--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/bin/debug_preprocessor.rs"
 [features]
 default = ["lsp"]
 lsp = ["tower-lsp", "tokio"]
+content = ["mdbook-lint-rulesets/content"]  # Enable content quality rules (CONTENT001-005)
 
 [dependencies]
 # Workspace dependencies

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -11,7 +11,9 @@ use mdbook_lint_core::{
     error::Result,
     rule::{RuleCategory, RuleStability},
 };
-use mdbook_lint_rulesets::{ContentRuleProvider, MdBookRuleProvider, StandardRuleProvider};
+#[cfg(feature = "content")]
+use mdbook_lint_rulesets::ContentRuleProvider;
+use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read};
@@ -733,14 +735,17 @@ fn run_cli_mode(
 
     if standard_only {
         registry.register_provider(Box::new(StandardRuleProvider))?;
+        #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
     } else {
-        // Default: use all rules (standard + mdBook + content)
+        // Default: use all rules (standard + mdBook + content if enabled)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
     }
 
@@ -1063,14 +1068,17 @@ fn run_rules_command(
 
     if standard_only {
         registry.register_provider(Box::new(StandardRuleProvider))?;
+        #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
     } else {
-        // Default: show all rules (standard + mdBook + content)
+        // Default: show all rules (standard + mdBook + content if enabled)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
     }
 
@@ -1254,6 +1262,7 @@ fn run_check_command(config_path: &PathBuf) -> Result<()> {
     let mut registry = PluginRegistry::new();
     registry.register_provider(Box::new(StandardRuleProvider))?;
     registry.register_provider(Box::new(MdBookRuleProvider))?;
+    #[cfg(feature = "content")]
     registry.register_provider(Box::new(ContentRuleProvider))?;
     let engine = registry.create_engine()?;
 
@@ -1448,6 +1457,7 @@ fn run_init_command(
         let mut registry = PluginRegistry::new();
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
         let engine = registry.create_engine()?;
 
@@ -1521,6 +1531,7 @@ fn get_all_available_rule_ids() -> Vec<String> {
     registry
         .register_provider(Box::new(MdBookRuleProvider))
         .unwrap();
+    #[cfg(feature = "content")]
     registry
         .register_provider(Box::new(ContentRuleProvider))
         .unwrap();
@@ -1719,6 +1730,7 @@ mod tests {
         all_registry
             .register_provider(Box::new(MdBookRuleProvider))
             .unwrap();
+        #[cfg(feature = "content")]
         all_registry
             .register_provider(Box::new(ContentRuleProvider))
             .unwrap();

--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -7,7 +7,9 @@ use mdbook_lint_core::RuleCategory;
 use mdbook_lint_core::{
     Document, LintEngine, MdBookLintError, PluginRegistry, Severity, Violation,
 };
-use mdbook_lint_rulesets::{ContentRuleProvider, MdBookRuleProvider, StandardRuleProvider};
+#[cfg(feature = "content")]
+use mdbook_lint_rulesets::ContentRuleProvider;
+use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use serde_json::Value;
 use std::io::{self, Read};
 use std::path::PathBuf;
@@ -30,6 +32,7 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
+        #[cfg(feature = "content")]
         registry
             .register_provider(Box::new(ContentRuleProvider))
             .expect("Failed to register content rules");
@@ -51,6 +54,7 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
+        #[cfg(feature = "content")]
         registry
             .register_provider(Box::new(ContentRuleProvider))
             .expect("Failed to register content rules");

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 default = ["standard", "mdbook"]
 standard = []  # Standard markdown rules (MD001-MD059)
 mdbook = ["dep:mdbook"]   # mdBook-specific rules (MDBOOK001-025)
+content = []  # Content quality rules (CONTENT001-005) - optional, off by default
 
 [dependencies]
 # Local workspace crates

--- a/crates/mdbook-lint-rulesets/src/lib.rs
+++ b/crates/mdbook-lint-rulesets/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! - `standard` (default): Standard markdown linting rules
 //! - `mdbook` (default): mdBook-specific linting rules
+//! - `content`: Content quality rules (CONTENT001-005) - optional, off by default
 //!
 //! # Rule Categories
 //!
@@ -130,6 +131,8 @@ pub mod mdbook;
 #[cfg(feature = "mdbook")]
 pub use mdbook::MdBookRuleProvider;
 
-// Content quality rules (always available, no heavy dependencies)
+// Content quality rules (optional, off by default)
+#[cfg(feature = "content")]
 pub mod content;
+#[cfg(feature = "content")]
 pub use content::ContentRuleProvider;


### PR DESCRIPTION
## Summary

Make the CONTENT rules (CONTENT001-005) optional via a feature flag. These rules are now off by default and can be enabled with:

```bash
cargo build --features content
```

Or in Cargo.toml:

```toml
[dependencies]
mdbook-lint = { version = "...", features = ["content"] }
```

## Rationale

The content rules are more opinionated than the standard markdown rules:
- CONTENT001: TODO/FIXME detection
- CONTENT002: Word count recommendations  
- CONTENT003: Short chapter detection
- CONTENT004: Heading capitalization
- CONTENT005: Draft marker detection

By making them opt-in, users get a cleaner default experience focused on markdown syntax validation. Users who want content quality checks can explicitly enable the feature.

## Changes

- Added `content` feature flag to `mdbook-lint-rulesets` crate
- Added `content` feature flag to `mdbook-lint` CLI crate (passes through to rulesets)
- All ContentRuleProvider registrations are now gated behind `#[cfg(feature = "content")]`
- Updated documentation to reflect the new feature

## Testing

- All 1142 tests pass with `--all-features`
- All 1073 tests pass without the content feature
- Verified build works with and without the feature