### PR TITLE
feat: add content feature flag for CONTENT rules

### DIFF
--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -11,7 +11,7 @@ use mdbook_lint_core::{
     error::Result,
     rule::{RuleCategory, RuleStability},
 };
-use mdbook_lint_rulesets::{ContentRuleProvider, MdBookRuleProvider, StandardRuleProvider};
+use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read};
@@ -733,15 +733,12 @@ fn run_cli_mode(
 
     if standard_only {
         registry.register_provider(Box::new(StandardRuleProvider))?;
-        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
-        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else {
-        // Default: use all rules (standard + mdBook + content)
+        // Default: use all rules (standard + mdBook)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
-        registry.register_provider(Box::new(ContentRuleProvider))?;
     }
 
     let engine = registry.create_engine_with_config(Some(&config.core))?;
@@ -1063,15 +1060,12 @@ fn run_rules_command(
 
     if standard_only {
         registry.register_provider(Box::new(StandardRuleProvider))?;
-        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
-        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else {
-        // Default: show all rules (standard + mdBook + content)
+        // Default: show all rules (standard + mdBook)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
-        registry.register_provider(Box::new(ContentRuleProvider))?;
     }
 
     let engine = registry.create_engine()?;
@@ -1254,7 +1248,6 @@ fn run_check_command(config_path: &PathBuf) -> Result<()> {
     let mut registry = PluginRegistry::new();
     registry.register_provider(Box::new(StandardRuleProvider))?;
     registry.register_provider(Box::new(MdBookRuleProvider))?;
-    registry.register_provider(Box::new(ContentRuleProvider))?;
     let engine = registry.create_engine()?;
 
     let available_rules: std::collections::HashSet<String> = engine
@@ -1448,7 +1441,6 @@ fn run_init_command(
         let mut registry = PluginRegistry::new();
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
-        registry.register_provider(Box::new(ContentRuleProvider))?;
         let engine = registry.create_engine()?;
 
         let mut config = Config::default();
@@ -1520,9 +1512,6 @@ fn get_all_available_rule_ids() -> Vec<String> {
         .unwrap();
     registry
         .register_provider(Box::new(MdBookRuleProvider))
-        .unwrap();
-    registry
-        .register_provider(Box::new(ContentRuleProvider))
         .unwrap();
 
     // Create engine to get available rules
@@ -1718,9 +1707,6 @@ mod tests {
             .unwrap();
         all_registry
             .register_provider(Box::new(MdBookRuleProvider))
-            .unwrap();
-        all_registry
-            .register_provider(Box::new(ContentRuleProvider))
             .unwrap();
         let all_engine = all_registry.create_engine().unwrap();
         let all_rules = all_engine.available_rules().len();

--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::RuleCategory;
 use mdbook_lint_core::{
     Document, LintEngine, MdBookLintError, PluginRegistry, Severity, Violation,
 };
-use mdbook_lint_rulesets::{ContentRuleProvider, MdBookRuleProvider, StandardRuleProvider};
+use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use serde_json::Value;
 use std::io::{self, Read};
 use std::path::PathBuf;
@@ -30,9 +30,6 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
-        registry
-            .register_provider(Box::new(ContentRuleProvider))
-            .expect("Failed to register content rules");
         let engine = registry.create_engine().expect("Failed to create engine");
 
         Self {
@@ -51,9 +48,6 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
-        registry
-            .register_provider(Box::new(ContentRuleProvider))
-            .expect("Failed to register content rules");
         let engine = registry.create_engine().expect("Failed to create engine");
 
         Self { config, engine }

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 default = ["standard", "mdbook"]
 standard = []  # Standard markdown rules (MD001-MD059)
 mdbook = ["dep:mdbook"]   # mdBook-specific rules (MDBOOK001-025)
+content = []  # Content quality rules (CONTENT001-005) - optional, off by default
 
 [dependencies]
 # Local workspace crates

--- a/crates/mdbook-lint-rulesets/src/lib.rs
+++ b/crates/mdbook-lint-rulesets/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! - `standard` (default): Standard markdown linting rules
 //! - `mdbook` (default): mdBook-specific linting rules
+//! - `content`: Content quality rules (CONTENT001-005) - optional, off by default
 //!
 //! # Rule Categories
 //!
@@ -130,6 +131,8 @@ pub mod mdbook;
 #[cfg(feature = "mdbook")]
 pub use mdbook::MdBookRuleProvider;
 
-// Content quality rules (always available, no heavy dependencies)
+// Content quality rules (optional, off by default)
+#[cfg(feature = "content")]
 pub mod content;
+#[cfg(feature = "content")]
 pub use content::ContentRuleProvider;


### PR DESCRIPTION
## Summary

Make the CONTENT rules (CONTENT001-005) optional via a feature flag in the rulesets crate. These rules are now off by default.

## Changes

- Added `content` feature flag to `mdbook-lint-rulesets` crate
- Content module and `ContentRuleProvider` are now behind `#[cfg(feature = "content")]`
- Removed `ContentRuleProvider` from CLI (will be re-added in follow-up PR after this is released)
- Updated documentation to reflect the new feature

## Usage

To enable content rules:

```bash
cargo build -p mdbook-lint-rulesets --features content
```

## Rationale

The content rules are more opinionated than the standard markdown rules:
- CONTENT001: TODO/FIXME detection
- CONTENT002: Word count recommendations  
- CONTENT003: Short chapter detection
- CONTENT004: Heading capitalization
- CONTENT005: Draft marker detection

By making them opt-in, users get a cleaner default experience focused on markdown syntax validation.

## Follow-up

After this is merged and released to crates.io, a follow-up PR will add a CLI `--features content` passthrough so users can opt-in via the CLI crate as well.