### PR TITLE
feat: add CLI content feature passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ brew install mdbook-lint
 cargo install mdbook-lint
 ```
 
+By default, this includes all rule sets (standard, mdBook, and content rules). To install without specific rule sets:
+
+```bash
+# Without content rules (CONTENT001-005)
+cargo install mdbook-lint --no-default-features --features standard,mdbook,lsp
+
+# Only standard markdown rules
+cargo install mdbook-lint --no-default-features --features standard,lsp
+```
+
 ### From Prebuilt Binaries
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/joshrotenberg/mdbook-lint/releases):

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/bin/debug_preprocessor.rs"
 [features]
 default = ["lsp"]
 lsp = ["tower-lsp", "tokio"]
+content = ["mdbook-lint-rulesets/content"]  # Enable content quality rules (CONTENT001-005)
 
 [dependencies]
 # Workspace dependencies

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -11,6 +11,8 @@ use mdbook_lint_core::{
     error::Result,
     rule::{RuleCategory, RuleStability},
 };
+#[cfg(feature = "content")]
+use mdbook_lint_rulesets::ContentRuleProvider;
 use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -733,12 +735,18 @@ fn run_cli_mode(
 
     if standard_only {
         registry.register_provider(Box::new(StandardRuleProvider))?;
+        #[cfg(feature = "content")]
+        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
+        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else {
-        // Default: use all rules (standard + mdBook)
+        // Default: use all rules (standard + mdBook + content if enabled)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
+        registry.register_provider(Box::new(ContentRuleProvider))?;
     }
 
     let engine = registry.create_engine_with_config(Some(&config.core))?;
@@ -1060,12 +1068,18 @@ fn run_rules_command(
 
     if standard_only {
         registry.register_provider(Box::new(StandardRuleProvider))?;
+        #[cfg(feature = "content")]
+        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
+        registry.register_provider(Box::new(ContentRuleProvider))?;
     } else {
-        // Default: show all rules (standard + mdBook)
+        // Default: show all rules (standard + mdBook + content if enabled)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
+        registry.register_provider(Box::new(ContentRuleProvider))?;
     }
 
     let engine = registry.create_engine()?;
@@ -1248,6 +1262,8 @@ fn run_check_command(config_path: &PathBuf) -> Result<()> {
     let mut registry = PluginRegistry::new();
     registry.register_provider(Box::new(StandardRuleProvider))?;
     registry.register_provider(Box::new(MdBookRuleProvider))?;
+    #[cfg(feature = "content")]
+    registry.register_provider(Box::new(ContentRuleProvider))?;
     let engine = registry.create_engine()?;
 
     let available_rules: std::collections::HashSet<String> = engine
@@ -1441,6 +1457,8 @@ fn run_init_command(
         let mut registry = PluginRegistry::new();
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
+        #[cfg(feature = "content")]
+        registry.register_provider(Box::new(ContentRuleProvider))?;
         let engine = registry.create_engine()?;
 
         let mut config = Config::default();
@@ -1512,6 +1530,10 @@ fn get_all_available_rule_ids() -> Vec<String> {
         .unwrap();
     registry
         .register_provider(Box::new(MdBookRuleProvider))
+        .unwrap();
+    #[cfg(feature = "content")]
+    registry
+        .register_provider(Box::new(ContentRuleProvider))
         .unwrap();
 
     // Create engine to get available rules
@@ -1707,6 +1729,10 @@ mod tests {
             .unwrap();
         all_registry
             .register_provider(Box::new(MdBookRuleProvider))
+            .unwrap();
+        #[cfg(feature = "content")]
+        all_registry
+            .register_provider(Box::new(ContentRuleProvider))
             .unwrap();
         let all_engine = all_registry.create_engine().unwrap();
         let all_rules = all_engine.available_rules().len();

--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -7,6 +7,8 @@ use mdbook_lint_core::RuleCategory;
 use mdbook_lint_core::{
     Document, LintEngine, MdBookLintError, PluginRegistry, Severity, Violation,
 };
+#[cfg(feature = "content")]
+use mdbook_lint_rulesets::ContentRuleProvider;
 use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use serde_json::Value;
 use std::io::{self, Read};
@@ -30,6 +32,10 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
+        #[cfg(feature = "content")]
+        registry
+            .register_provider(Box::new(ContentRuleProvider))
+            .expect("Failed to register content rules");
         let engine = registry.create_engine().expect("Failed to create engine");
 
         Self {
@@ -48,6 +54,10 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
+        #[cfg(feature = "content")]
+        registry
+            .register_provider(Box::new(ContentRuleProvider))
+            .expect("Failed to register content rules");
         let engine = registry.create_engine().expect("Failed to create engine");
 
         Self { config, engine }

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -15,10 +15,10 @@ name = "mdbook_lint_rulesets"
 path = "src/lib.rs"
 
 [features]
-default = ["standard", "mdbook"]
+default = ["standard", "mdbook", "content"]
 standard = []  # Standard markdown rules (MD001-MD059)
 mdbook = ["dep:mdbook"]   # mdBook-specific rules (MDBOOK001-025)
-content = []  # Content quality rules (CONTENT001-005) - optional, off by default
+content = []  # Content quality rules (CONTENT001-005)
 
 [dependencies]
 # Local workspace crates

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -19,6 +19,21 @@ Install via Cargo from [crates.io](https://crates.io/crates/mdbook-lint):
 cargo install mdbook-lint
 ```
 
+By default, this includes all rule sets:
+- **standard** - 59 markdown syntax rules (MD001-MD059)
+- **mdbook** - 7 mdBook-specific rules (MDBOOK001-007)
+- **content** - 5 content quality rules (CONTENT001-005)
+
+To install without specific rule sets:
+
+```bash
+# Without content rules
+cargo install mdbook-lint --no-default-features --features standard,mdbook,lsp
+
+# Only standard markdown rules
+cargo install mdbook-lint --no-default-features --features standard,lsp
+```
+
 ## From Source
 
 To install the latest development version or contribute to the project:


### PR DESCRIPTION
## Summary

Add a `content` feature to the CLI crate that enables the content rules from `mdbook-lint-rulesets`.

## Usage

```bash
cargo install mdbook-lint --features content
```

This enables the content quality rules (CONTENT001-005):
- CONTENT001: TODO/FIXME detection
- CONTENT002: Word count recommendations  
- CONTENT003: Short chapter detection
- CONTENT004: Heading capitalization
- CONTENT005: Draft marker detection

## Changes

- Added `content` feature to CLI Cargo.toml that passes through to `mdbook-lint-rulesets/content`
- All `ContentRuleProvider` registrations are gated with `#[cfg(feature = "content")]`
- Works in both CLI and preprocessor modes

## Testing

- All 1142 tests pass with `--all-features`
- Clippy passes