### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release-plz:


### PR DESCRIPTION
Allows manually triggering the release workflow to retry failed publishes.

This will let us manually trigger the v0.12.1 release after the packaging fix.