### PR TITLE
feat: add visual line length mode to MD013

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -234,6 +234,7 @@
 # MD013 - Line length
 # [MD013]
 # line_length = 80  # Maximum line length
+# length_mode = "strict"  # Options: "strict" (count all chars), "visual" (exclude URLs)
 # code_blocks = true  # Check code blocks
 # tables = true  # Check tables
 # headings = true  # Check headings

--- a/docs/src/rules-reference.md
+++ b/docs/src/rules-reference.md
@@ -245,6 +245,7 @@ Many rules support customization through configuration files. Common patterns:
 ```toml
 [MD013]
 line_length = 120      # Default: 80
+length_mode = "visual" # "strict" (default) or "visual" (excludes URLs from count)
 code_blocks = false    # Ignore code blocks
 tables = false         # Ignore tables  
 headings = false       # Ignore headings


### PR DESCRIPTION
## Summary

Adds a new `length_mode` configuration option to MD013 that excludes URLs from line length calculation, reducing false positives for lines containing long URLs.

## Changes

- Add `LengthMode` enum with `Strict` (default) and `Visual` modes
- `Visual` mode excludes URLs (http:// and https://) from line length calculation
- Add `length-mode` / `length_mode` configuration option
- Update example config and documentation

## Configuration

```toml
[MD013]
line_length = 80
length_mode = "visual"  # excludes URLs from count
```

## Motivation

Lines containing long URLs often exceed line length limits through no fault of the author - URLs cannot be wrapped without breaking them. The visual mode provides a more practical line length check that focuses on the actual readable content.

This brings mdbook-lint closer to parity with rumdl's default behavior and significantly reduces MD013 violations on real-world projects like the Rust Book.

Closes #270