### PR TITLE
feat: add verbose and quiet CLI flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ toml = "0.5"
 comrak = "0.21"
 
 # CLI
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "color"] }
 
 # mdBook integration
 mdbook = { version = "0.4", default-features = false }

--- a/crates/mdbook-lint-cli/src/config.rs
+++ b/crates/mdbook-lint-cli/src/config.rs
@@ -596,7 +596,6 @@ impl Config {
             for config_name in CONFIG_NAMES {
                 let config_path = current.join(config_name);
                 if config_path.exists() && config_path.is_file() {
-                    eprintln!("DEBUG: Found config at {}", config_path.display());
                     return Some(config_path);
                 }
             }

--- a/crates/mdbook-lint-cli/src/output.rs
+++ b/crates/mdbook-lint-cli/src/output.rs
@@ -130,6 +130,16 @@ fn build_underline(source_line: &str, caret_pos: usize, rule_name: &str) -> Stri
     )
 }
 
+/// Print verbose status message (like cargo's "Compiling" messages)
+pub fn print_status(label: &str, message: &str) {
+    let styles = OutputStyles::default();
+    println!(
+        "{success}{:>12}{success:#} {message}",
+        label,
+        success = styles.success
+    );
+}
+
 /// Determine how many characters to underline
 fn determine_underline_length(source_line: &str, start_pos: usize) -> usize {
     let chars: Vec<char> = source_line.chars().collect();
@@ -154,14 +164,21 @@ fn determine_underline_length(source_line: &str, start_pos: usize) -> usize {
 }
 
 /// Print summary line
-pub fn print_summary(total_violations: usize, error_count: usize, warning_count: usize) {
+pub fn print_summary(
+    total_violations: usize,
+    error_count: usize,
+    warning_count: usize,
+    quiet: bool,
+) {
     let styles = OutputStyles::default();
 
     if total_violations == 0 {
-        println!(
-            "{success}No issues found{success:#}",
-            success = styles.success
-        );
+        if !quiet {
+            println!(
+                "{success}No issues found{success:#}",
+                success = styles.success
+            );
+        }
     } else {
         let mut parts = Vec::new();
 

--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -81,7 +81,6 @@ impl MdBookLint {
             // Start search from the book root directory
             let book_root = &ctx.root;
             if let Some(discovered_path) = Config::discover_config(Some(book_root)) {
-                eprintln!("Using config: {}", discovered_path.display());
                 self.config = Config::from_file(&discovered_path)?;
             }
         }


### PR DESCRIPTION
## Summary

Adds cargo-style `-v/--verbose` and `-q/--quiet` global flags to the CLI.

## Changes

- **`-v/--verbose`**: Shows additional information like the config file path being used
- **`-q/--quiet`**: Suppresses informational messages like "No issues found" (errors/warnings still shown)
- Removes leftover debug output from config discovery and preprocessor
- Adds `print_status()` helper for cargo-style status messages (right-aligned green label)

## Example Usage

```bash
# Normal output
$ mdbook-lint lint README.md
No issues found

# Quiet mode - no output when clean
$ mdbook-lint lint -q README.md

# Verbose mode - shows config path
$ mdbook-lint lint -v README.md
      Config /path/to/.mdbook-lint.toml
No issues found
```

## Motivation

Follows cargo's CLI patterns for consistent UX. The verbose flag is useful for debugging config discovery, and the quiet flag is useful in CI/scripts where you only want output on errors.