### PR TITLE
feat: add five new content quality rules

### DIFF
--- a/crates/mdbook-lint-rulesets/src/content/content006.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content006.rs
@@ -1,0 +1,380 @@
+//! CONTENT006: No broken internal links
+//!
+//! Ensures that internal anchor links (e.g., `[link](#section-name)`) point to
+//! valid headings within the same document.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+/// Regex to match ATX headings and capture the text
+static HEADING_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^#{1,6}\s+(.+?)(?:\s*#*)?$").unwrap());
+
+/// Regex to match internal anchor links [text](#anchor)
+static INTERNAL_LINK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[([^\]]*)\]\(#([^)]+)\)").unwrap());
+
+/// CONTENT006: Detects broken internal anchor links
+///
+/// This rule checks that all internal anchor links (`#anchor-name`) reference
+/// valid headings in the document. Broken internal links lead to poor UX.
+#[derive(Default, Clone)]
+pub struct CONTENT006;
+
+impl CONTENT006 {
+    /// Generate an anchor ID from heading text (GitHub-style)
+    ///
+    /// Rules:
+    /// - Convert to lowercase
+    /// - Replace spaces with hyphens
+    /// - Remove special characters except hyphens and underscores
+    /// - Remove leading/trailing hyphens
+    fn generate_anchor(heading_text: &str) -> String {
+        let mut anchor = String::new();
+        let text = heading_text.trim();
+
+        for ch in text.chars() {
+            if ch.is_alphanumeric() {
+                anchor.push(ch.to_ascii_lowercase());
+            } else if ch == ' ' || ch == '-' || ch == '_' {
+                // Avoid multiple consecutive hyphens
+                if !anchor.ends_with('-') {
+                    anchor.push('-');
+                }
+            }
+            // Skip other special characters
+        }
+
+        // Remove trailing hyphens
+        while anchor.ends_with('-') {
+            anchor.pop();
+        }
+
+        // Remove leading hyphens
+        while anchor.starts_with('-') {
+            anchor.remove(0);
+        }
+
+        anchor
+    }
+
+    /// Extract all valid anchors from the document (from headings)
+    fn extract_anchors(&self, document: &Document) -> HashSet<String> {
+        let mut anchors = HashSet::new();
+        let mut in_code_block = false;
+
+        for line in &document.lines {
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Extract heading text and generate anchor
+            if let Some(caps) = HEADING_REGEX.captures(trimmed)
+                && let Some(heading_text) = caps.get(1)
+            {
+                let anchor = Self::generate_anchor(heading_text.as_str());
+                if !anchor.is_empty() {
+                    anchors.insert(anchor);
+                }
+            }
+        }
+
+        anchors
+    }
+
+    /// Find suggestions for a broken anchor
+    fn find_similar_anchor<'a>(
+        &self,
+        broken_anchor: &str,
+        valid_anchors: &'a HashSet<String>,
+    ) -> Option<&'a String> {
+        let broken_lower = broken_anchor.to_lowercase();
+
+        // First try exact case-insensitive match
+        for anchor in valid_anchors {
+            if anchor.to_lowercase() == broken_lower {
+                return Some(anchor);
+            }
+        }
+
+        // Try to find anchors that contain the broken one or vice versa
+        valid_anchors
+            .iter()
+            .find(|anchor| anchor.contains(&broken_lower) || broken_lower.contains(anchor.as_str()))
+    }
+}
+
+impl Rule for CONTENT006 {
+    fn id(&self) -> &'static str {
+        "CONTENT006"
+    }
+
+    fn name(&self) -> &'static str {
+        "no-broken-internal-links"
+    }
+
+    fn description(&self) -> &'static str {
+        "Internal anchor links should reference valid headings in the document"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let valid_anchors = self.extract_anchors(document);
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Find all internal links in the line
+            for caps in INTERNAL_LINK_REGEX.captures_iter(line) {
+                let anchor = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+                let link_text = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+
+                // Check if this anchor exists
+                if !valid_anchors.contains(anchor) {
+                    let line_num = line_idx + 1;
+                    let col = caps.get(0).map(|m| m.start() + 1).unwrap_or(1);
+
+                    let mut message = format!(
+                        "Broken internal link: '#{anchor}' does not match any heading in this document"
+                    );
+
+                    // Add suggestion if we find a similar anchor
+                    if let Some(suggestion) = self.find_similar_anchor(anchor, &valid_anchors) {
+                        message.push_str(&format!(". Did you mean '#{suggestion}'?"));
+                    }
+
+                    // Add context about what the link text was
+                    if !link_text.is_empty() {
+                        message.push_str(&format!(" (link text: '{link_text}')"));
+                    }
+
+                    violations.push(self.create_violation(
+                        message,
+                        line_num,
+                        col,
+                        Severity::Warning,
+                    ));
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_generate_anchor() {
+        assert_eq!(CONTENT006::generate_anchor("Hello World"), "hello-world");
+        assert_eq!(
+            CONTENT006::generate_anchor("Getting Started"),
+            "getting-started"
+        );
+        assert_eq!(CONTENT006::generate_anchor("What's New?"), "whats-new");
+        assert_eq!(CONTENT006::generate_anchor("Section 1.2.3"), "section-123");
+        assert_eq!(
+            CONTENT006::generate_anchor("C++ Programming"),
+            "c-programming"
+        );
+        assert_eq!(CONTENT006::generate_anchor("  Spaces  "), "spaces");
+    }
+
+    #[test]
+    fn test_valid_internal_link() {
+        let content = "# Getting Started
+
+See [the introduction](#getting-started) for more info.
+
+## Installation
+
+Check [installation](#installation) instructions.";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_broken_internal_link() {
+        let content = "# Getting Started
+
+See [broken link](#nonexistent-section) for more info.";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("nonexistent-section"));
+    }
+
+    #[test]
+    fn test_multiple_broken_links() {
+        let content = "# Title
+
+[link1](#bad1) and [link2](#bad2)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn test_case_sensitive_anchors() {
+        let content = "# Hello World
+
+[link](#Hello-World)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        // Anchor is hello-world (lowercase), but link uses Hello-World
+        assert_eq!(violations.len(), 1);
+        // Should suggest the correct anchor
+        assert!(violations[0].message.contains("hello-world"));
+    }
+
+    #[test]
+    fn test_links_in_code_blocks_ignored() {
+        let content = "# Title
+
+```markdown
+[example](#nonexistent)
+```";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_external_links_ignored() {
+        let content = "# Title
+
+[external](https://example.com)
+[relative](./other-file.md)
+[with anchor](./other-file.md#section)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        // Only internal anchor links (#...) are checked
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_special_characters_in_heading() {
+        let content = "# What's New in 2024?
+
+[link](#whats-new-in-2024)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_heading_with_code() {
+        let content = "# The `main` Function
+
+[link](#the-main-function)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_nested_headings() {
+        let content = "# Chapter 1
+
+## Section 1.1
+
+### Subsection 1.1.1
+
+[to chapter](#chapter-1)
+[to section](#section-11)
+[to subsection](#subsection-111)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_suggestion_for_partial_match() {
+        let content = "# Installation Guide
+
+See [instructions](#installation) for details.";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        // Should suggest the correct anchor (installation is contained in installation-guide)
+        assert!(violations[0].message.contains("installation-guide"));
+    }
+
+    #[test]
+    fn test_empty_link_text() {
+        let content = "# Title
+
+[](#nonexistent)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        // Should not include "link text:" for empty text
+        assert!(!violations[0].message.contains("link text:"));
+    }
+
+    #[test]
+    fn test_headings_in_code_blocks_not_anchors() {
+        let content = "# Real Heading
+
+```markdown
+# Fake Heading
+```
+
+[link](#fake-heading)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        // #fake-heading is not a valid anchor (heading is in code block)
+        assert_eq!(violations.len(), 1);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/content007.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content007.rs
@@ -1,0 +1,396 @@
+//! CONTENT007: Consistent terminology
+//!
+//! Detects inconsistent use of terms within a document. For example, using both
+//! "config" and "configuration", or "setup" and "set up" inconsistently.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use std::collections::HashMap;
+
+/// Common term variants that should be used consistently
+/// Each group contains terms that are variants of each other
+const DEFAULT_TERM_GROUPS: &[&[&str]] = &[
+    &["config", "configuration"],
+    &["setup", "set up", "set-up"],
+    &["login", "log in", "log-in"],
+    &["signup", "sign up", "sign-up"],
+    &["email", "e-mail"],
+    &["filename", "file name", "file-name"],
+    &["username", "user name", "user-name"],
+    &["database", "data base"],
+    &["website", "web site", "web-site"],
+    &["checkbox", "check box", "check-box"],
+    &["dropdown", "drop down", "drop-down"],
+    &["frontend", "front end", "front-end"],
+    &["backend", "back end", "back-end"],
+    &["ok", "okay"],
+    &["grey", "gray"],
+    &["cancelled", "canceled"],
+    &["colour", "color"],
+    &["behaviour", "behavior"],
+    &["licence", "license"],
+    &["synchronise", "synchronize"],
+    &["analyse", "analyze"],
+];
+
+/// CONTENT007: Detects inconsistent terminology usage
+///
+/// This rule identifies when different variants of the same term are used
+/// within a document, which can confuse readers and appear unprofessional.
+#[derive(Clone)]
+pub struct CONTENT007 {
+    /// Term groups to check for consistency
+    term_groups: Vec<Vec<String>>,
+    /// Minimum occurrences to trigger a warning
+    min_occurrences: usize,
+}
+
+impl Default for CONTENT007 {
+    fn default() -> Self {
+        let term_groups = DEFAULT_TERM_GROUPS
+            .iter()
+            .map(|group| group.iter().map(|s| (*s).to_string()).collect())
+            .collect();
+
+        Self {
+            term_groups,
+            min_occurrences: 1,
+        }
+    }
+}
+
+impl CONTENT007 {
+    /// Create with custom term groups
+    #[allow(dead_code)]
+    pub fn with_term_groups(term_groups: Vec<Vec<String>>) -> Self {
+        Self {
+            term_groups,
+            min_occurrences: 1,
+        }
+    }
+
+    /// Find all occurrences of terms in the document
+    fn find_term_occurrences(
+        &self,
+        document: &Document,
+    ) -> HashMap<usize, Vec<(String, usize, usize)>> {
+        // Map from term_group_index -> list of (term, line, column)
+        let mut occurrences: HashMap<usize, Vec<(String, usize, usize)>> = HashMap::new();
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            // Track code blocks - skip code content
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Skip inline code spans for matching
+            let line_lower = line.to_lowercase();
+
+            for (group_idx, group) in self.term_groups.iter().enumerate() {
+                for term in group {
+                    let term_lower = term.to_lowercase();
+
+                    // Find all occurrences of this term
+                    let mut search_start = 0;
+                    while let Some(pos) = line_lower[search_start..].find(&term_lower) {
+                        let actual_pos = search_start + pos;
+
+                        // Check word boundaries
+                        let before_ok = actual_pos == 0
+                            || !line_lower[..actual_pos]
+                                .chars()
+                                .last()
+                                .map(|c| c.is_alphanumeric())
+                                .unwrap_or(false);
+
+                        let after_pos = actual_pos + term_lower.len();
+                        let after_ok = after_pos >= line_lower.len()
+                            || !line_lower[after_pos..]
+                                .chars()
+                                .next()
+                                .map(|c| c.is_alphanumeric())
+                                .unwrap_or(false);
+
+                        if before_ok && after_ok {
+                            // Check if this is inside inline code
+                            let before_text = &line[..actual_pos];
+                            let backtick_count = before_text.matches('`').count();
+                            if backtick_count % 2 == 0 {
+                                // Not inside inline code
+                                occurrences.entry(group_idx).or_default().push((
+                                    term.clone(),
+                                    line_idx + 1,
+                                    actual_pos + 1,
+                                ));
+                            }
+                        }
+
+                        search_start = actual_pos + 1;
+                    }
+                }
+            }
+        }
+
+        occurrences
+    }
+}
+
+impl Rule for CONTENT007 {
+    fn id(&self) -> &'static str {
+        "CONTENT007"
+    }
+
+    fn name(&self) -> &'static str {
+        "consistent-terminology"
+    }
+
+    fn description(&self) -> &'static str {
+        "Terms should be used consistently throughout a document"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let occurrences = self.find_term_occurrences(document);
+
+        for (group_idx, term_occurrences) in occurrences {
+            // Count how many of each term variant is used
+            let mut term_counts: HashMap<&str, Vec<(usize, usize)>> = HashMap::new();
+            for (term, line, col) in &term_occurrences {
+                term_counts
+                    .entry(term.as_str())
+                    .or_default()
+                    .push((*line, *col));
+            }
+
+            // Only flag if multiple variants are used
+            if term_counts.len() > 1 {
+                // Find the most common variant
+                let most_common = term_counts
+                    .iter()
+                    .max_by_key(|(_, locs)| locs.len())
+                    .map(|(term, _)| *term)
+                    .unwrap_or("");
+
+                // Report violations for less common variants
+                for (term, locations) in &term_counts {
+                    if *term != most_common && locations.len() >= self.min_occurrences {
+                        let group = &self.term_groups[group_idx];
+                        for (line, col) in locations {
+                            violations.push(self.create_violation(
+                                format!(
+                                    "Inconsistent terminology: '{}' used here, but '{}' is used more frequently. \
+                                     Consider using '{}' consistently (variants: {})",
+                                    term,
+                                    most_common,
+                                    most_common,
+                                    group.join(", ")
+                                ),
+                                *line,
+                                *col,
+                                Severity::Info,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Sort violations by line number
+        violations.sort_by_key(|v| (v.line, v.column));
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_consistent_config() {
+        let content = "# Settings
+
+The config file is located in the config directory.
+Edit the config to change settings.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // All uses are "config" - consistent
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_inconsistent_config() {
+        let content = "# Settings
+
+The config file is in the config directory.
+Edit the configuration to change settings.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "config" appears twice, "configuration" once - should flag "configuration"
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("configuration"));
+        assert!(violations[0].message.contains("config"));
+    }
+
+    #[test]
+    fn test_inconsistent_setup() {
+        let content = "# Setup Guide
+
+First, set up your environment.
+The setup process takes a few minutes.
+After setup, run the application.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "setup" appears 3 times (heading + 2 body), "set up" once
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("set up"));
+    }
+
+    #[test]
+    fn test_code_blocks_ignored() {
+        let content = "# Configuration
+
+Use configuration files.
+
+```
+config = load_config()
+```
+
+The configuration is loaded.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "config" in code block should be ignored
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_inline_code_ignored() {
+        let content = "# Configuration
+
+The `config` variable holds the configuration.
+Update the configuration as needed.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "config" in inline code should be ignored
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_word_boundaries() {
+        let content = "# Reconfiguration
+
+This is about reconfiguration.
+The configuration must be valid.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "reconfiguration" should not match "config"
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let content = "# Setup
+
+Setup is important.
+The SETUP guide is here.
+Let's set up the system.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "Setup", "SETUP" count as same; "set up" is different
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_british_american_spelling() {
+        let content = "# Color Settings
+
+The color scheme is customizable.
+You can change the colour of any element.
+The colour picker is easy to use.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "colour" appears twice, "color" twice - should flag one
+        assert!(!violations.is_empty());
+    }
+
+    #[test]
+    fn test_email_variations() {
+        let content = "# Contact
+
+Send an email to support.
+Your e-mail will be answered within 24 hours.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_no_term_groups_match() {
+        let content = "# Introduction
+
+This is a simple document with no conflicting terms.
+It just has regular content.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_custom_term_groups() {
+        let content = "# API Reference
+
+Use the API to fetch data.
+The interface provides methods.";
+        let term_groups = vec![vec!["api".to_string(), "interface".to_string()]];
+        let rule = CONTENT007::with_term_groups(term_groups);
+        let doc = create_test_document(content);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_frontend_backend() {
+        let content = "# Architecture
+
+The frontend handles user interaction.
+The front-end is built with React.
+The backend processes requests.";
+        let doc = create_test_document(content);
+        let rule = CONTENT007::default();
+        let violations = rule.check(&doc).unwrap();
+        // "frontend" vs "front-end"
+        assert_eq!(violations.len(), 1);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/content009.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content009.rs
@@ -1,0 +1,226 @@
+//! CONTENT009: No excessive heading nesting
+//!
+//! Warns when heading nesting goes too deep (e.g., beyond h4), which can
+//! indicate overly complex document structure that's hard to navigate.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to match ATX headings
+static HEADING_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(#{1,6})\s+.+").unwrap());
+
+/// Default maximum heading depth
+const DEFAULT_MAX_DEPTH: usize = 4;
+
+/// CONTENT009: Detects excessive heading nesting
+///
+/// Deep heading hierarchies (h5, h6) often indicate that content should be
+/// restructured into separate documents or that the hierarchy is too granular.
+#[derive(Clone)]
+pub struct CONTENT009 {
+    /// Maximum allowed heading depth (1-6)
+    max_depth: usize,
+}
+
+impl Default for CONTENT009 {
+    fn default() -> Self {
+        Self {
+            max_depth: DEFAULT_MAX_DEPTH,
+        }
+    }
+}
+
+impl CONTENT009 {
+    /// Create with a custom maximum depth
+    #[allow(dead_code)]
+    pub fn with_max_depth(max_depth: usize) -> Self {
+        Self {
+            max_depth: max_depth.clamp(1, 6),
+        }
+    }
+}
+
+impl Rule for CONTENT009 {
+    fn id(&self) -> &'static str {
+        "CONTENT009"
+    }
+
+    fn name(&self) -> &'static str {
+        "no-excessive-nesting"
+    }
+
+    fn description(&self) -> &'static str {
+        "Heading nesting should not be too deep (default max: h4)"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Check for headings
+            if let Some(caps) = HEADING_REGEX.captures(trimmed)
+                && let Some(hashes) = caps.get(1)
+            {
+                let depth = hashes.as_str().len();
+
+                if depth > self.max_depth {
+                    let line_num = line_idx + 1;
+                    violations.push(self.create_violation(
+                        format!(
+                            "Heading level h{} exceeds maximum depth of h{}. \
+                             Consider restructuring to reduce nesting or splitting into separate documents",
+                            depth, self.max_depth
+                        ),
+                        line_num,
+                        1,
+                        Severity::Warning,
+                    ));
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_normal_nesting() {
+        let content = "# Chapter
+
+## Section
+
+### Subsection
+
+#### Details";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_excessive_h5() {
+        let content = "# Chapter
+
+## Section
+
+### Subsection
+
+#### Details
+
+##### Too Deep";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("h5"));
+    }
+
+    #[test]
+    fn test_excessive_h6() {
+        let content = "# Chapter
+
+###### Way Too Deep";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("h6"));
+    }
+
+    #[test]
+    fn test_multiple_violations() {
+        let content = "# Chapter
+
+##### Deep 1
+
+###### Deep 2";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn test_custom_max_depth() {
+        let content = "# Chapter
+
+## Section
+
+### Too Deep for Custom";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::with_max_depth(2);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("h3"));
+    }
+
+    #[test]
+    fn test_max_depth_h6() {
+        let content = "# Chapter
+
+###### This is fine";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::with_max_depth(6);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_headings_in_code_blocks_ignored() {
+        let content = "# Chapter
+
+```markdown
+##### This is in a code block
+###### This too
+```";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_no_headings() {
+        let content = "Just some text without any headings.
+
+More paragraphs here.";
+        let doc = create_test_document(content);
+        let rule = CONTENT009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/content010.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content010.rs
@@ -1,0 +1,245 @@
+//! CONTENT010: Link text quality
+//!
+//! Flags generic or unhelpful link text like "click here", "this link", "here",
+//! etc. Links should have descriptive text that makes sense out of context.
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to match markdown links [text](url)
+static LINK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[([^\]]*)\]\([^)]+\)").unwrap());
+
+/// Generic link text patterns to flag
+const GENERIC_LINK_TEXT: &[&str] = &[
+    "click here",
+    "here",
+    "this link",
+    "this page",
+    "this article",
+    "this",
+    "link",
+    "read more",
+    "more",
+    "learn more",
+    "see more",
+    "more info",
+    "more information",
+    "details",
+    "info",
+];
+
+/// CONTENT010: Detects poor quality link text
+///
+/// Good link text should be descriptive and make sense out of context.
+/// Screen readers often present links as a list, so "click here" or "here"
+/// provides no useful information.
+#[derive(Default, Clone)]
+pub struct CONTENT010;
+
+impl Rule for CONTENT010 {
+    fn id(&self) -> &'static str {
+        "CONTENT010"
+    }
+
+    fn name(&self) -> &'static str {
+        "link-text-quality"
+    }
+
+    fn description(&self) -> &'static str {
+        "Link text should be descriptive, not generic like 'click here' or 'here'"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Find all links in the line
+            for caps in LINK_REGEX.captures_iter(line) {
+                if let Some(text_match) = caps.get(1) {
+                    let link_text = text_match.as_str().trim();
+                    let link_text_lower = link_text.to_lowercase();
+
+                    // Check against generic patterns
+                    for &generic in GENERIC_LINK_TEXT {
+                        if link_text_lower == generic {
+                            let line_num = line_idx + 1;
+                            let col = text_match.start() + 1;
+
+                            violations.push(self.create_violation(
+                                format!(
+                                    "Generic link text '{}' is not descriptive. \
+                                     Use meaningful text that describes the link destination",
+                                    link_text
+                                ),
+                                line_num,
+                                col,
+                                Severity::Warning,
+                            ));
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_good_link_text() {
+        let content = "Check out the [installation guide](./install.md) for details.
+
+See the [API documentation](https://docs.example.com) for more info.";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_click_here() {
+        let content = "[Click here](https://example.com) to learn more.";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Click here"));
+    }
+
+    #[test]
+    fn test_here_alone() {
+        let content = "For more information, see [here](./docs.md).";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_this_link() {
+        let content = "Follow [this link](https://example.com) for details.";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_read_more() {
+        let content = "[Read more](./article.md)";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_learn_more() {
+        let content = "[Learn more](https://docs.example.com)";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_violations() {
+        let content = "See [here](./a.md) and [click here](./b.md) for more.";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let content = "[HERE](./doc.md) and [CLICK HERE](./other.md)";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn test_links_in_code_blocks_ignored() {
+        let content = "```markdown
+[click here](https://example.com)
+```";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_partial_match_not_flagged() {
+        let content = "Read [more about configuration](./config.md) here.";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        // "more about configuration" contains "more" but is not exactly "more"
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_this_alone() {
+        let content = "See [this](./example.md) for an example.";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_info() {
+        let content = "[Info](./help.md)";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_details() {
+        let content = "For [details](./spec.md), see the specification.";
+        let doc = create_test_document(content);
+        let rule = CONTENT010;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/content011.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content011.rs
@@ -1,0 +1,235 @@
+//! CONTENT011: No future tense in documentation
+//!
+//! Documentation should use present tense ("This function returns...")
+//! instead of future tense ("This function will return...").
+
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Patterns that indicate future tense usage in documentation
+/// These are common "will + verb" patterns
+static FUTURE_TENSE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    vec![
+        // Common documentation patterns with "will"
+        Regex::new(r"\bwill\s+(?:be|have|return|throw|create|generate|produce|output|display|show|print|log|emit|trigger|fire|call|invoke|execute|run|start|stop|open|close|read|write|load|save|send|receive|get|set|add|remove|delete|update|change|modify|process|handle|validate|check|verify|parse|convert|transform|format|render|build|compile|install|download|upload|fetch|request|respond)\b").unwrap(),
+        // "is going to" patterns
+        Regex::new(r"\bis\s+going\s+to\s+\w+").unwrap(),
+        // "are going to" patterns
+        Regex::new(r"\bare\s+going\s+to\s+\w+").unwrap(),
+    ]
+});
+
+/// CONTENT011: Detects future tense in documentation
+///
+/// Technical documentation should describe what things DO, not what they
+/// WILL DO. Present tense is clearer and more direct.
+#[derive(Default, Clone)]
+pub struct CONTENT011;
+
+impl Rule for CONTENT011 {
+    fn id(&self) -> &'static str {
+        "CONTENT011"
+    }
+
+    fn name(&self) -> &'static str {
+        "no-future-tense"
+    }
+
+    fn description(&self) -> &'static str {
+        "Documentation should use present tense instead of future tense"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        let mut violations = Vec::new();
+        let mut in_code_block = false;
+
+        for (line_idx, line) in document.lines.iter().enumerate() {
+            let trimmed = line.trim();
+
+            // Track code blocks
+            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+                in_code_block = !in_code_block;
+                continue;
+            }
+
+            if in_code_block {
+                continue;
+            }
+
+            // Skip lines that are likely not documentation prose
+            // (headings are OK, we check the content)
+            if trimmed.starts_with("<!--") || trimmed.starts_with("{{#") {
+                continue;
+            }
+
+            let line_lower = line.to_lowercase();
+
+            // Check for future tense patterns
+            for pattern in FUTURE_TENSE_PATTERNS.iter() {
+                if let Some(m) = pattern.find(&line_lower) {
+                    // Find the actual position in the original line
+                    let line_num = line_idx + 1;
+                    let col = m.start() + 1;
+                    let matched_text = &line[m.start()..m.end()];
+
+                    // Suggest present tense alternative
+                    let suggestion = matched_text
+                        .to_lowercase()
+                        .replace("will be", "is")
+                        .replace("will have", "has")
+                        .replace("will ", "")
+                        .replace("is going to ", "")
+                        .replace("are going to ", "");
+
+                    violations.push(self.create_violation(
+                        format!(
+                            "Future tense '{}' found. Consider using present tense: '{}'",
+                            matched_text.trim(),
+                            suggestion.trim()
+                        ),
+                        line_num,
+                        col,
+                        Severity::Info,
+                    ));
+                    // Only report one violation per line to avoid noise
+                    break;
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("test.md")).unwrap()
+    }
+
+    #[test]
+    fn test_present_tense() {
+        let content = "# Function Reference
+
+This function returns an integer.
+The method creates a new instance.
+It throws an error if invalid.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_will_return() {
+        let content = "This function will return an integer.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("will return"));
+    }
+
+    #[test]
+    fn test_will_be() {
+        let content = "The value will be updated.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("is"));
+    }
+
+    #[test]
+    fn test_will_throw() {
+        let content = "This will throw an exception if the input is invalid.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_is_going_to() {
+        let content = "This method is going to create a new file.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_are_going_to() {
+        let content = "These functions are going to process the data.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_code_blocks_ignored() {
+        let content = "```rust
+// This function will return a value
+fn example() -> i32 { 42 }
+```";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_violations() {
+        let content = "This will return a value.
+
+That will throw an error.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn test_will_in_other_context() {
+        let content = "The user's free will is respected.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        // "free will" should not trigger
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let content = "This WILL RETURN a value.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn test_various_verbs() {
+        let content = "It will create, will generate, will produce output.";
+        let doc = create_test_document(content);
+        let rule = CONTENT011;
+        let violations = rule.check(&doc).unwrap();
+        // Should only report once per line
+        assert_eq!(violations.len(), 1);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/content/mod.rs
@@ -8,6 +8,11 @@ mod content002;
 mod content003;
 mod content004;
 mod content005;
+mod content006;
+mod content007;
+mod content009;
+mod content010;
+mod content011;
 
 use crate::{RuleProvider, RuleRegistry};
 
@@ -33,6 +38,11 @@ impl RuleProvider for ContentRuleProvider {
         registry.register(Box::new(content003::CONTENT003::default()));
         registry.register(Box::new(content004::CONTENT004::default()));
         registry.register(Box::new(content005::CONTENT005::default()));
+        registry.register(Box::new(content006::CONTENT006));
+        registry.register(Box::new(content007::CONTENT007::default()));
+        registry.register(Box::new(content009::CONTENT009::default()));
+        registry.register(Box::new(content010::CONTENT010));
+        registry.register(Box::new(content011::CONTENT011));
     }
 
     fn rule_ids(&self) -> Vec<&'static str> {
@@ -42,6 +52,11 @@ impl RuleProvider for ContentRuleProvider {
             "CONTENT003",
             "CONTENT004",
             "CONTENT005",
+            "CONTENT006",
+            "CONTENT007",
+            "CONTENT009",
+            "CONTENT010",
+            "CONTENT011",
         ]
     }
 }


### PR DESCRIPTION
This PR adds five new content quality rules:

## New Rules

### CONTENT006: no-broken-internal-links
Validates that internal anchor links (e.g., `[link](#section-name)`) point to valid headings within the same document. Generates GitHub-style anchors from heading text and provides suggestions for similar anchors when a broken link is detected.

### CONTENT007: consistent-terminology
Detects inconsistent use of terms within a document. For example, using both "config" and "configuration", or "setup" and "set up" inconsistently. Includes common term variants for:
- config/configuration
- setup/set up/set-up
- login/log in/log-in
- email/e-mail
- frontend/front end/front-end
- And many more...

### CONTENT009: no-excessive-nesting
Warns when heading nesting goes too deep (beyond h4 by default). Deep heading hierarchies often indicate content should be restructured or split into separate documents. The maximum depth is configurable.

### CONTENT010: link-text-quality
Flags generic or unhelpful link text like "click here", "here", "this link", "read more", etc. Good link text should be descriptive and make sense out of context, which is important for accessibility (screen readers often present links as a list).

### CONTENT011: no-future-tense
Encourages present tense in documentation ("This function returns...") instead of future tense ("This function will return..."). Present tense is clearer and more direct in technical documentation.

## Testing
- All new rules have comprehensive unit tests
- Clippy passes with no warnings
- All existing tests continue to pass