### PR TITLE
docs: update rule counts to 83 (10 content rules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cargo install mdbook-lint
 By default, this includes all rule sets (standard, mdBook, and content rules). To install without specific rule sets:
 
 ```bash
-# Without content rules (CONTENT001-005)
+# Without content rules (CONTENT001-011)
 cargo install mdbook-lint --no-default-features --features standard,mdbook,lsp
 
 # Only standard markdown rules
@@ -55,7 +55,7 @@ mdbook-lint --version
 ## Features
 
 - **Native mdBook integration** - Seamless preprocessor integration
-- **78 linting rules** - 55 standard markdown + 18 mdBook-specific + 5 content rules  
+- **83 linting rules** - 55 standard markdown + 18 mdBook-specific + 10 content rules  
 - **Auto-fix support** - Automatically fix common issues with 41 rules
 - **Fast performance** - Lint entire books in seconds
 - **Configurable** - Disable rules, set custom parameters
@@ -126,14 +126,14 @@ mdbook-lint init --include-all
 
 **Configuration examples:**
 
-- [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all 78 rules documented
+- [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all 83 rules documented
 - [docs/.mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/docs/.mdbook-lint.toml) - Real-world example used by this project's documentation
 
 ## Rules
 
 - **55 standard rules** (MD001-MD060) - All the usual markdown linting
 - **18 mdBook rules** (MDBOOK001-MDBOOK025) - mdBook-specific checks
-- **5 content rules** (CONTENT001-CONTENT005) - Content quality checks
+- **10 content rules** (CONTENT001-CONTENT011) - Content quality checks including TODO detection, placeholder text, terminology consistency, link quality, and more
 
 Run `mdbook-lint rules --detailed` to see all available rules.
 

--- a/docs/src/api-documentation.md
+++ b/docs/src/api-documentation.md
@@ -76,7 +76,7 @@ It provides:
 
 - **55 standard markdown rules** (MD001-MD060) based on the markdownlint specification
 - **18 mdBook-specific rules** (MDBOOK001-MDBOOK025) for mdBook project validation
-- **5 content rules** (CONTENT001-CONTENT005) for content quality checks
+- **10 content rules** (CONTENT001-CONTENT011) for content quality checks
 - **Automatic fix support** for many rules to correct issues automatically
 - **Configurable rules** with sensible defaults
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -290,7 +290,7 @@ Use the `init` command to generate a configuration file:
 # Generate minimal configuration
 mdbook-lint init
 
-# Generate comprehensive configuration with all 78 rules documented
+# Generate comprehensive configuration with all 83 rules documented
 mdbook-lint init --include-all
 
 # Generate in a different format

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -22,7 +22,7 @@ cargo install mdbook-lint
 By default, this includes all rule sets:
 - **standard** - 55 markdown syntax rules (MD001-MD060)
 - **mdbook** - 18 mdBook-specific rules (MDBOOK001-MDBOOK025)
-- **content** - 5 content quality rules (CONTENT001-CONTENT005)
+- **content** - 10 content quality rules (CONTENT001-CONTENT011)
 
 To install without specific rule sets:
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -9,7 +9,7 @@ mdbook-lint is a command-line tool and mdBook preprocessor that helps you mainta
 ## Key Features
 
 - **Fast Performance**: Built in Rust for speed and efficiency
-- **Comprehensive Rule Set**: 55 standard markdown rules, 18 mdBook-specific rules, and 5 content rules (78 total)
+- **Comprehensive Rule Set**: 55 standard markdown rules, 18 mdBook-specific rules, and 10 content rules (83 total)
 - **Flexible Integration**: Works as a standalone CLI tool or as an mdBook preprocessor
 - **Configurable**: Customize rules and behavior through configuration files
 - **Zero Dependencies**: Self-contained binary with no external dependencies

--- a/docs/src/rules-reference.md
+++ b/docs/src/rules-reference.md
@@ -1,13 +1,13 @@
 # Rules Reference
 
-This page provides a comprehensive reference for all **78 linting rules** available in mdbook-lint.
+This page provides a comprehensive reference for all **83 linting rules** available in mdbook-lint.
 
 ## Quick Navigation
 
-- [Complete Rule List](#complete-rule-list) - All 78 rules at a glance
+- [Complete Rule List](#complete-rule-list) - All 83 rules at a glance
 - [Standard Markdown Rules (MD001-MD060)](#standard-markdown-rules) - 55 standard rules
 - [mdBook-Specific Rules](#mdbook-specific-rules) - 18 mdBook rules
-- [Content Rules](#content-rules) - 5 content rules
+- [Content Rules](#content-rules) - 10 content rules
 - [Auto-Fix Rules](#auto-fix-rules) - Rules with automatic fixes
 - [Rule Configuration](#rule-configuration) - How to customize rules
 
@@ -96,7 +96,7 @@ This page provides a comprehensive reference for all **78 linting rules** availa
 | [MDBOOK023](#mdbook023) | Chapter title consistency | | Book structure |
 | [MDBOOK025](#mdbook025) | SUMMARY.md heading structure | | Table of contents |
 
-### Content Rules (5 rules)
+### Content Rules (10 rules)
 
 | Rule | Name | Auto-fix | Purpose |
 |------|------|----------|---------|
@@ -105,6 +105,11 @@ This page provides a comprehensive reference for all **78 linting rules** availa
 | [CONTENT003](#content003) | Minimum chapter length | | Content quality |
 | [CONTENT004](#content004) | Heading capitalization | | Style consistency |
 | [CONTENT005](#content005) | Intro before subheading | | Content structure |
+| [CONTENT006](#content006) | No broken internal links | | Link integrity |
+| [CONTENT007](#content007) | Consistent terminology | | Content quality |
+| [CONTENT009](#content009) | No excessive nesting | | Document structure |
+| [CONTENT010](#content010) | Link text quality | | Accessibility |
+| [CONTENT011](#content011) | No future tense | | Documentation style |
 
 *✓ indicates automatic fix support*
 


### PR DESCRIPTION
Updates all documentation to reflect the new content rules added in #296:

**Files updated:**
- README.md
- docs/src/introduction.md
- docs/src/installation.md
- docs/src/api-documentation.md
- docs/src/configuration.md
- docs/src/rules-reference.md

**Changes:**
- 78 rules -> 83 rules
- 5 content rules -> 10 content rules
- Added CONTENT006-011 to the rules reference table