### PR TITLE
chore: add changelog configuration for release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -22,6 +22,37 @@ release_always = false
 # Explicit changelog setting (we don't use CHANGELOG.md)
 changelog_update = false
 
+# Changelog generation using git-cliff style configuration
+[changelog]
+# Body template for changelog entries
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first | trim }}\
+{% endfor %}
+{% endfor %}
+"""
+# Remove leading/trailing whitespace
+trim = true
+# Commit message parsers (conventional commits)
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+]
+# Sort commits oldest to newest
+sort_commits = "oldest"
+# Protect breaking changes from being filtered
+protect_breaking_commits = true
+
 # Main CLI package creates the GitHub release and tag
 [[package]]
 name = "mdbook-lint"


### PR DESCRIPTION
Configure git-cliff style changelog generation directly in release-plz.toml using the integrated `[changelog]` section.

## Changes

Added a `[changelog]` section to `release-plz.toml` that configures:
- Commit parsers for conventional commit types (feat, fix, docs, perf, refactor, style, test, chore)
- Grouping commits by type for cleaner release notes
- Skipping release chore commits to avoid noise
- Protecting breaking change commits from being filtered

This uses release-plz's native changelog configuration rather than a separate `cliff.toml` file, which is the recommended approach.

## Expected Result

When release-plz creates a release PR, the changelog should now be nicely formatted with commits grouped by type:

```
### Features
- Add new content rules

### Bug Fixes  
- Fix MD051 performance issue

### Documentation
- Update rule reference
```