### PR TITLE
docs: add mdbook explanation and version compatibility documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@
 [![Build Status](https://github.com/joshrotenberg/mdbook-lint/workflows/CI/badge.svg)](<https://github.com/joshrotenberg/mdbook-lint/actions>)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](<https://github.com/joshrotenberg/mdbook-lint#license>)
 
-A fast, configurable linter designed for mdBook projects. Works as both an mdBook preprocessor and standalone CLI tool.
+A fast, configurable linter designed for [mdBook](https://rust-lang.github.io/mdBook/) projects. Works as both an mdBook preprocessor and standalone CLI tool.
 
 **[Documentation](https://joshrotenberg.github.io/mdbook-lint/)** | **[Getting Started](https://joshrotenberg.github.io/mdbook-lint/getting-started.html)**
+
+## What is mdBook?
+
+[mdBook](https://rust-lang.github.io/mdBook/) is a command-line tool for creating books from Markdown files. It's widely used in the Rust ecosystem for documentation, including [The Rust Programming Language](https://doc.rust-lang.org/book/) book, and is popular for technical documentation projects of all kinds. mdBook renders Markdown into a clean, searchable HTML book format with navigation, search, and syntax highlighting.
+
+mdbook-lint helps ensure your mdBook documentation maintains consistent quality by catching common issues before they reach readers.
 
 ## Installation
 
@@ -159,6 +165,12 @@ jobs:
       - name: Lint markdown files
         run: ./mdbook-lint lint --fail-on-warnings docs/
 ```
+
+## Compatibility
+
+mdbook-lint supports mdBook versions 0.4.x and 0.5.x. The tool automatically detects and handles differences in mdBook's JSON protocol between versions, so it works seamlessly regardless of which mdBook version you have installed.
+
+For detailed compatibility information, see the [Compatibility Guide](https://joshrotenberg.github.io/mdbook-lint/compatibility.html).
 
 ## Contributing
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
 - [CLI Usage](./cli-usage.md)
 - [mdBook Integration](./mdbook-integration.md)
 - [CI vs Preprocessor](./ci-vs-preprocessor.md)
+- [Compatibility](./compatibility.md)
 - [Troubleshooting](./troubleshooting.md)
 
 # Reference

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -1,0 +1,87 @@
+# Compatibility
+
+mdbook-lint is designed to work seamlessly across different versions of mdBook and various environments.
+
+## mdBook Version Support
+
+mdbook-lint supports both mdBook 0.4.x and 0.5.x series.
+
+### Supported Versions
+
+| mdBook Version | Status | Notes |
+|----------------|--------|-------|
+| 0.4.40+ | Supported | Fully tested |
+| 0.5.0 | Supported | JSON format changes handled automatically |
+| 0.5.1+ | Supported | Latest recommended |
+
+### Automatic Version Detection
+
+When running as an mdBook preprocessor, mdbook-lint automatically detects the mdBook version and handles protocol differences transparently. You don't need to configure anything differently based on your mdBook version.
+
+### mdBook 0.5.x Changes
+
+mdBook 0.5.0 introduced breaking changes to the preprocessor JSON protocol:
+
+- The `sections` field was renamed to `items` in book chapter structures
+- The `__non_exhaustive` marker field was removed
+
+mdbook-lint automatically normalizes these differences, so your configuration and usage remain the same regardless of which mdBook version you use.
+
+## Platform Support
+
+mdbook-lint provides prebuilt binaries for all major platforms:
+
+| Platform | Architecture | Binary |
+|----------|--------------|--------|
+| Linux | x86_64 (glibc) | `mdbook-lint-linux-x86_64` |
+| Linux | x86_64 (musl) | `mdbook-lint-linux-x86_64-musl` |
+| macOS | Intel (x86_64) | `mdbook-lint-macos-x86_64` |
+| macOS | Apple Silicon (aarch64) | `mdbook-lint-macos-aarch64` |
+| Windows | x86_64 | `mdbook-lint-windows-x86_64.exe` |
+
+### Minimum Rust Version
+
+If building from source, mdbook-lint requires:
+
+- **Rust Edition**: 2024
+- **Minimum Supported Rust Version (MSRV)**: 1.85.0
+
+## Configuration Compatibility
+
+### markdownlint Compatibility
+
+mdbook-lint aims for compatibility with [markdownlint](https://github.com/DavidAnson/markdownlint) rule definitions. Standard rules (MD001-MD060) follow the same semantics as markdownlint where applicable.
+
+Configuration differences:
+
+- mdbook-lint uses TOML configuration by default (`.mdbook-lint.toml`)
+- YAML and JSON configuration formats are also supported
+- Rule configuration options may have slightly different names
+
+### CI Environment Support
+
+mdbook-lint works in all major CI environments:
+
+- GitHub Actions
+- GitLab CI
+- CircleCI
+- Jenkins
+- Azure Pipelines
+
+See [CI vs Preprocessor](./ci-vs-preprocessor.md) for guidance on choosing the right integration approach.
+
+## Continuous Compatibility Testing
+
+mdbook-lint runs automated compatibility tests against multiple mdBook versions on a weekly schedule. These tests verify that the preprocessor integration works correctly across all supported mdBook versions.
+
+You can view the test results in the [mdBook Compatibility workflow](https://github.com/joshrotenberg/mdbook-lint/actions/workflows/mdbook-compatibility.yml) on GitHub.
+
+## Reporting Compatibility Issues
+
+If you encounter compatibility issues with a specific mdBook version or platform, please [open an issue](https://github.com/joshrotenberg/mdbook-lint/issues) with:
+
+1. Your mdBook version (`mdbook --version`)
+2. Your mdbook-lint version (`mdbook-lint --version`)
+3. Your operating system and architecture
+4. The error message or unexpected behavior
+5. A minimal example that reproduces the issue


### PR DESCRIPTION
This PR improves documentation for newcomers and documents version compatibility:

## Changes

### README.md
- Added 'What is mdBook?' section explaining what mdBook is and linking to the official docs
- Added link to The Rust Programming Language book as a real-world example
- Added Compatibility section with link to detailed documentation

### New: docs/src/compatibility.md
- Documents mdBook 0.4.x and 0.5.x support
- Explains automatic version detection and JSON protocol normalization
- Provides platform support matrix (Linux, macOS, Windows)
- Documents MSRV (Rust 1.85.0, Edition 2024)
- Notes markdownlint compatibility
- Lists supported CI environments
- Links to the weekly mdBook compatibility workflow

### docs/src/SUMMARY.md
- Added Compatibility page to the User Guide section

## Testing
- All cargo tests pass
- Clippy passes with no warnings
- mdbook build succeeds