### PR TITLE
feat: add fix subcommand for easier auto-fix discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,14 @@ Then run `mdbook build` as usual. The linter will automatically check all your m
 # Lint files
 mdbook-lint lint README.md src/*.md
 
-# Auto-fix violations where possible
-mdbook-lint lint --fix src/*.md
+# Auto-fix violations (using the fix subcommand)
+mdbook-lint fix src/*.md
 
 # Preview what would be fixed
-mdbook-lint lint --fix --dry-run src/*.md
+mdbook-lint fix --dry-run src/*.md
+
+# Alternative: use lint with --fix flag
+mdbook-lint lint --fix src/*.md
 
 # Show available rules
 mdbook-lint rules


### PR DESCRIPTION
This PR adds a dedicated `fix` subcommand to make auto-fix functionality more discoverable.

## Problem

Users looking at `mdbook-lint --help` couldn't easily discover how to auto-fix issues. The `--fix` flag was buried in the `lint` subcommand options.

## Solution

Add a `fix` subcommand that is a shorthand for `lint --fix`:

```bash
# Before: had to know about the --fix flag
mdbook-lint lint --fix src/*.md

# After: obvious from help output
mdbook-lint fix src/*.md
```

## New Help Output

```
Commands:
  preprocessor  Run as mdBook preprocessor
  lint          Lint markdown files directly
  fix           Automatically fix issues in markdown files (shorthand for \`lint --fix\`)
  rules         List available rules by category
  ...
```

## Features

The `fix` subcommand supports:
- `--dry-run` - Preview fixes without applying
- `--unsafe` - Include potentially unsafe fixes  
- `--no-backup` - Skip backup file creation
- `--disable` / `--enable` - Filter rules
- `--config` - Use custom configuration
- `--standard-only` / `--mdbook-only` - Filter rule sets

## Testing

- All 1205 tests pass
- Clippy passes with no warnings
- Manually tested `fix --dry-run` works correctly