### PR TITLE
typo: mdbook-lint should be just lint.

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -58,7 +58,7 @@ To integrate mdbook-lint with your mdBook project:
 1. **Add to book.toml**:
 
    ```toml
-   [preprocessor.mdbook-lint]
+   [preprocessor.lint]
    ```
 
 2. **Build your book**:


### PR DESCRIPTION
[I was getting: ](https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html#provide-your-own-command)

>  WARN The command `mdbook-mdbook-lint` for preprocessor `mdbook-lint` was not found, but is marked as optional.

Comment: It'd be really neat if line-length could be fix automatically.