### PR TITLE
docs: fix preprocessor naming from mdbook-lint to lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ mdbook-lint --version
 Add to your `book.toml`:
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 ```
 
 Then run `mdbook build` as usual. The linter will automatically check all your markdown files and report issues during the build process.

--- a/docs/src/api-documentation.md
+++ b/docs/src/api-documentation.md
@@ -254,7 +254,7 @@ cargo doc --no-deps --open
 
 ```toml
 # book.toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = true
 ```
 

--- a/docs/src/ci-vs-preprocessor.md
+++ b/docs/src/ci-vs-preprocessor.md
@@ -38,7 +38,7 @@ The standalone CLI gives you more control, better error handling, and avoids con
 **Setup in `book.toml`:**
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = false  # Set to true for strict mode
 disabled-rules = ["MD013", "MD033"]
 
@@ -219,7 +219,7 @@ jobs:
 
 ```toml
 # book.toml - for local development feedback only
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = false
 ```
 
@@ -237,7 +237,7 @@ Use standalone CLI in CI for control and reliability, with optional preprocessor
 
 ```toml
 # book.toml - local development uses preprocessor (optional)
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = false
 ```
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -188,11 +188,11 @@ Configuration is resolved in the following order (later overrides earlier):
 When used as an mdBook preprocessor, configuration can be specified in `book.toml`:
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = true
 disabled-rules = ["MD025"]
 
-[preprocessor.mdbook-lint.MD013]
+[preprocessor.lint.MD013]
 line-length = 100
 ```
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -58,7 +58,7 @@ To integrate mdbook-lint with your mdBook project:
 1. **Add to book.toml**:
 
    ```toml
-   [preprocessor.mdbook-lint]
+   [preprocessor.lint]
    ```
 
 2. **Build your book**:

--- a/docs/src/mdbook-integration.md
+++ b/docs/src/mdbook-integration.md
@@ -50,7 +50,7 @@ Expand-Archive mdbook-lint.zip -DestinationPath .
 Add mdbook-lint to your `book.toml`:
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 ```
 
 This enables mdbook-lint with default settings. It will:
@@ -77,7 +77,7 @@ mdbook test
 ### Complete Configuration Example
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 # Control build behavior
 fail-on-warnings = false  # Set to true to fail builds on any violation
 
@@ -97,7 +97,7 @@ exclude = ["src/drafts/**", "src/archive/**"]  # Exclude these files
 output = "concise"  # Options: "concise", "detailed", "json"
 
 # Rule-specific configuration
-[preprocessor.mdbook-lint.rules]
+[preprocessor.lint.rules]
 # Configure individual rules
 MD013 = { line_length = 100 }
 MD024 = { siblings_only = true }
@@ -134,7 +134,7 @@ MD024 = { siblings_only = true }
 Rules are organized into categories for easier management:
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 # Disable all whitespace-related rules
 disabled-categories = ["whitespace"]
 
@@ -158,7 +158,7 @@ Define different rule sets for different environments:
 
 ```toml
 # Development: Lenient settings
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = false
 disabled-rules = ["MD013", "MD033", "MD041"]
 
@@ -301,7 +301,7 @@ jobs:
 2. Check `book.toml` has the preprocessor section:
 
    ```toml
-   [preprocessor.mdbook-lint]
+   [preprocessor.lint]
    ```
 
 3. Run with verbose output:
@@ -368,7 +368,7 @@ mdbook build 2>&1 | grep -A 5 "mdbook-lint"
 1. Exclude unnecessary files:
 
    ```toml
-   [preprocessor.mdbook-lint]
+   [preprocessor.lint]
    exclude = ["src/generated/**", "src/vendor/**"]
    ```
 
@@ -395,7 +395,7 @@ mdbook build 2>&1 | grep -A 5 "mdbook-lint"
 **Local `book.toml`**:
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = false
 disabled-rules = ["MD013"]  # Allow long lines locally
 ```
@@ -416,7 +416,7 @@ disabled-rules = ["MD013"]  # Allow long lines locally
 
 ```toml
 # Strict rules for main content
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 include = ["src/chapters/**"]
 fail-on-warnings = true
 
@@ -434,7 +434,7 @@ Start lenient and gradually enable more rules:
 
 ```toml
 # Phase 1: Critical rules only
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 enabled-rules = ["MDBOOK001", "MDBOOK002", "MDBOOK003", "MD040", "MD041"]
 
 # Phase 2: Add formatting rules

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -172,7 +172,7 @@ echo "1. Checking mdbook-lint installation..."
 which mdbook-lint || echo "ERROR: mdbook-lint not found in PATH"
 
 echo "2. Checking book.toml..."
-grep -A5 "preprocessor.mdbook-lint" book.toml || echo "ERROR: Preprocessor not configured"
+grep -A5 "preprocessor.lint" book.toml || echo "ERROR: Preprocessor not configured"
 
 echo "3. Testing preprocessor directly..."
 echo '{"root":"","config":{},"renderer":"html","mdbook_version":"0.4.0"}' | mdbook-lint preprocessor
@@ -210,7 +210,7 @@ grep ERROR mdbook-lint-debug.log
 
 ```toml
 # book.toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 before = ["links"]  # Run before links preprocessor
 after = ["index"]   # Run after index preprocessor
 
@@ -240,7 +240,7 @@ after = ["mdbook-lint"]  # Ensure mdbook-lint runs first
 
 2. **Disable expensive rules**:
    ```toml
-   [preprocessor.mdbook-lint]
+   [preprocessor.lint]
 # Line length and link checking are expensive
 
    disabled-rules = ["MD013", "MD053", "MDBOOK002"]
@@ -250,7 +250,7 @@ after = ["mdbook-lint"]  # Ensure mdbook-lint runs first
 
    ```toml
 
-   [preprocessor.mdbook-lint]
+   [preprocessor.lint]
 
 ## Only lint main content
 
@@ -429,7 +429,7 @@ cat > book.toml << EOF
 title = "Test"
 authors = ["Test"]
 
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 fail-on-warnings = true
 EOF
 
@@ -520,7 +520,7 @@ If these solutions don't resolve your issue:
 **Fix**: Use absolute paths or paths relative to book root:
 
 ```toml
-[preprocessor.mdbook-lint]
+[preprocessor.lint]
 include = ["src/**/*.md"]  # Relative to book root
 exclude = ["/tmp/**"]       # Absolute path
 ```


### PR DESCRIPTION
mdBook automatically prepends `mdbook-` to preprocessor names, so `[preprocessor.lint]` invokes the `mdbook-lint` command. Using `[preprocessor.mdbook-lint]` would incorrectly try to invoke `mdbook-mdbook-lint`.

This fixes the same issue across all documentation files (7 files, 24 occurrences).

Closes #313 - this PR supersedes that one by fixing all occurrences, not just one.

Thanks to @iampi31415 for reporting!