### PR TITLE
fix: MD052 no longer flags GitHub-style admonitions as undefined references

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md052.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md052.rs
@@ -48,7 +48,17 @@ impl MD052 {
     /// Create a new MD052 rule instance
     pub fn new() -> Self {
         Self {
-            ignored_labels: vec!["x".to_string()], // Default ignores checkbox syntax
+            // Default ignores:
+            // - "x" for checkbox syntax
+            // - GitHub-style admonition labels (supported by mdBook 0.5+)
+            ignored_labels: vec![
+                "x".to_string(),
+                "!note".to_string(),
+                "!tip".to_string(),
+                "!important".to_string(),
+                "!warning".to_string(),
+                "!caution".to_string(),
+            ],
             shortcut_syntax: false,
         }
     }
@@ -714,6 +724,37 @@ mod tests {
 "#;
 
         assert_no_violations(MD052::new(), content); // 'x' is ignored by default
+    }
+
+    #[test]
+    fn test_admonitions_ignored() {
+        // GitHub-style admonitions (supported by mdBook 0.5+) should not trigger violations
+        let content = r#"> [!NOTE]
+> This is a note
+
+> [!TIP]
+> This is a tip
+
+> [!IMPORTANT]
+> This is important
+
+> [!WARNING]
+> This is a warning
+
+> [!CAUTION]
+> This is a caution
+"#;
+
+        assert_no_violations(MD052::new(), content);
+    }
+
+    #[test]
+    fn test_admonitions_case_insensitive() {
+        let content = r#"> [!Note]
+> Mixed case should work too
+"#;
+
+        assert_no_violations(MD052::new(), content);
     }
 
     #[test]


### PR DESCRIPTION
GitHub-style admonitions like `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, and `[!CAUTION]` are now ignored by default in MD052. These are supported by mdBook 0.5+ and should not be flagged as undefined reference links.

## Changes
- Added admonition labels to the default ignored labels list in MD052
- Added tests for admonition syntax (including case-insensitive matching)

## Before
```
error[MD052]: Reference link uses undefined label '!NOTE'
  --> file.md:1:3
     |
   1 | > [!NOTE]
     |   ^^^^^^^ reference-links-images
```

## After
No violation - admonitions are recognized and ignored.

Closes #314

Thanks to @iampi31415 for reporting!