### PR TITLE
docs: add preprocessor to keywords and description

### DIFF
--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-lint"
-description = "A fast markdown linter for mdBook"
-keywords = ["markdown", "linter", "mdbook", "documentation"]
+description = "A fast markdown linter and preprocessor for mdBook"
+keywords = ["markdown", "linter", "mdbook", "preprocessor", "documentation"]
 categories = ["command-line-utilities", "development-tools"]
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Add 'preprocessor' keyword and update description to mention preprocessor functionality.

This helps users discover mdbook-lint when searching for mdBook preprocessors on crates.io via `cargo search mdbook-preprocessor`.