### PR TITLE
fix: include dependency crate commits in changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -38,6 +38,9 @@ git_release_enable = true
 git_tag_enable = true
 changelog_update = true
 changelog_path = "CHANGELOG.md"
+# Include commits from dependency crates in the main changelog
+# Without this, commits that only touch rulesets or core won't appear
+changelog_include = ["mdbook-lint-core", "mdbook-lint-rulesets"]
 
 # Library packages don't create releases/tags (only published to crates.io)
 [[package]]


### PR DESCRIPTION
## Root Cause of Missing Changelog Entries

The v0.13.5 changelog was missing 9 PRs (#325, #326, #327, #329, #331, #332, #334, #335, #340). After investigation, I found the root cause:

**Problem**: Release-plz determines which commits belong to a package based on which files they changed. All the missing commits only touched files in `crates/mdbook-lint-rulesets/`, so they were attributed to that package - but `mdbook-lint-rulesets` has `changelog_update = false`.

**Solution**: Add `changelog_include` to the `mdbook-lint` package config to include commits from its dependency crates:

```toml
[[package]]
name = "mdbook-lint"
changelog_include = ["mdbook-lint-core", "mdbook-lint-rulesets"]
```

This ensures that commits touching only the core library or rulesets will still appear in the main changelog.

## References

- [release-plz changelog_include docs](https://release-plz.dev/docs/config)
- Related: #341 (manual changelog fix for v0.13.5)