### PR TITLE
feat: add ADR ruleset for Architecture Decision Records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 1.0.69",
  "toml",

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -19,6 +19,7 @@ default = ["standard", "mdbook", "content"]
 standard = []  # Standard markdown rules (MD001-MD059)
 mdbook = ["dep:mdbook"]   # mdBook-specific rules (MDBOOK001-025)
 content = []  # Content quality rules (CONTENT001-005)
+adr = ["dep:serde_yaml"]  # ADR (Architecture Decision Record) rules (ADR001-019)
 
 [dependencies]
 # Local workspace crates
@@ -35,6 +36,9 @@ comrak = { workspace = true }
 
 # mdBook integration (for mdbook rules)
 mdbook = { workspace = true, optional = true }
+
+# YAML parsing (for ADR rules)
+serde_yaml = { workspace = true, optional = true }
 
 # Utilities
 walkdir = { workspace = true }

--- a/crates/mdbook-lint-rulesets/src/adr/adr001.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr001.rs
@@ -1,0 +1,295 @@
+//! ADR001: ADR title format
+//!
+//! Validates that the ADR has a properly formatted title:
+//! - Nygard format: "# N. Title" or "# N - Title" (H1 with number prefix)
+//! - MADR format: Any H1 heading is acceptable
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document, is_nygard_title};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+
+/// ADR001: Validates ADR title format
+///
+/// For Nygard format ADRs, the title must follow the pattern "# N. Title"
+/// where N is the ADR number.
+///
+/// For MADR format ADRs, any H1 heading is acceptable.
+pub struct Adr001 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr001 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr001 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+}
+
+impl Rule for Adr001 {
+    fn id(&self) -> &'static str {
+        "ADR001"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-title-format"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR title should follow the appropriate format for its type"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        let format = self.effective_format(&document.content);
+
+        // Find the first H1 heading
+        let mut found_h1 = false;
+        let mut h1_line = 0;
+        let mut h1_text = String::new();
+
+        // Parse AST locally (we don't share with other rules)
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        for node in ast_node.descendants() {
+            if let NodeValue::Heading(heading) = &node.data.borrow().value
+                && heading.level == 1
+            {
+                found_h1 = true;
+                h1_line = node.data.borrow().sourcepos.start.line;
+
+                // Extract heading text
+                for child in node.children() {
+                    if let NodeValue::Text(text) = &child.data.borrow().value {
+                        h1_text.push_str(text);
+                    }
+                }
+                break;
+            }
+        }
+
+        if !found_h1 {
+            violations.push(self.create_violation(
+                format!(
+                    "ADR is missing a title (H1 heading). {} format ADRs should have {}",
+                    format,
+                    if format == AdrFormat::Nygard {
+                        "a title like '# 1. Record architecture decisions'"
+                    } else {
+                        "an H1 heading"
+                    }
+                ),
+                1,
+                1,
+                Severity::Error,
+            ));
+            return Ok(violations);
+        }
+
+        // For Nygard format, check the title pattern
+        if format == AdrFormat::Nygard {
+            // Get the original line to check the pattern
+            if let Some(line) = document.lines.get(h1_line.saturating_sub(1))
+                && !is_nygard_title(line)
+            {
+                violations.push(self.create_violation(
+                    format!(
+                        "Nygard format ADR title should follow pattern '# N. Title' (e.g., '# 1. Record architecture decisions'), found: '{}'",
+                        line.trim()
+                    ),
+                    h1_line,
+                    1,
+                    Severity::Error,
+                ));
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        // Use a path that matches ADR directory detection
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_title() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid Nygard title"
+        );
+    }
+
+    #[test]
+    fn test_valid_nygard_title_with_dash() {
+        let content = r#"# 1 - Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid Nygard title with dash"
+        );
+    }
+
+    #[test]
+    fn test_invalid_nygard_title_no_number() {
+        let content = r#"# Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("pattern"));
+    }
+
+    #[test]
+    fn test_missing_title() {
+        let content = r#"Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing a title"));
+    }
+
+    #[test]
+    fn test_valid_madr_title() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid MADR title"
+        );
+    }
+
+    #[test]
+    fn test_madr_missing_title() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+## Context and Problem Statement
+
+We need to select a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing a title"));
+    }
+
+    #[test]
+    fn test_force_nygard_format() {
+        // Even with frontmatter-like content, if we force Nygard format,
+        // it should check for Nygard title pattern
+        let content = r#"# Use PostgreSQL
+
+Some content
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::with_format(AdrFormat::Nygard);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("pattern"));
+    }
+
+    #[test]
+    fn test_large_adr_number() {
+        let content = r#"# 9999. Very late decision
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr001::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr002.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr002.rs
@@ -1,0 +1,364 @@
+//! ADR002: Required status
+//!
+//! Validates that the ADR has a status defined:
+//! - Nygard format: "## Status" section with status value
+//! - MADR format: `status` field in YAML frontmatter
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use crate::adr::frontmatter::parse_frontmatter;
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to match a "## Status" heading (case-insensitive)
+static STATUS_HEADING_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^##\s+status\s*$").expect("Invalid regex"));
+
+/// ADR002: Validates that ADR has a status
+///
+/// For Nygard format ADRs, there must be a "## Status" section.
+/// For MADR format ADRs, there must be a `status` field in the frontmatter.
+pub struct Adr002 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr002 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr002 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+}
+
+impl Rule for Adr002 {
+    fn id(&self) -> &'static str {
+        "ADR002"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-required-status"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR must have a status defined"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        let format = self.effective_format(&document.content);
+
+        match format {
+            AdrFormat::Madr4 => {
+                // Check for status in frontmatter
+                match parse_frontmatter(&document.content) {
+                    Some(result) => {
+                        if let Some(ref error) = result.error {
+                            // Frontmatter parsing failed
+                            violations.push(self.create_violation(
+                                format!("Cannot check status: {}", error),
+                                result.start_line,
+                                1,
+                                Severity::Warning,
+                            ));
+                        } else if let Some(ref fm) = result.frontmatter {
+                            if fm.status.is_none() {
+                                violations.push(
+                                    self.create_violation(
+                                        "MADR format ADR is missing 'status' field in frontmatter"
+                                            .to_string(),
+                                        result.start_line,
+                                        1,
+                                        Severity::Error,
+                                    ),
+                                );
+                            }
+                        } else {
+                            // Frontmatter exists but couldn't be parsed
+                            violations.push(
+                                self.create_violation(
+                                    "MADR format ADR is missing 'status' field in frontmatter"
+                                        .to_string(),
+                                    result.start_line,
+                                    1,
+                                    Severity::Error,
+                                ),
+                            );
+                        }
+                    }
+                    None => {
+                        // No frontmatter at all, but we detected MADR format
+                        // This shouldn't happen with proper format detection
+                        violations.push(
+                            self.create_violation(
+                                "MADR format ADR is missing frontmatter with 'status' field"
+                                    .to_string(),
+                                1,
+                                1,
+                                Severity::Error,
+                            ),
+                        );
+                    }
+                }
+            }
+            AdrFormat::Nygard | AdrFormat::Auto => {
+                // Check for ## Status section
+                let mut found_status_section = false;
+
+                // Parse AST locally (we don't share with other rules)
+                let arena = comrak::Arena::new();
+                let ast_node = document.parse_ast(&arena);
+
+                for node in ast_node.descendants() {
+                    if let NodeValue::Heading(heading) = &node.data.borrow().value
+                        && heading.level == 2
+                    {
+                        // Extract heading text
+                        let mut heading_text = String::new();
+                        for child in node.children() {
+                            if let NodeValue::Text(text) = &child.data.borrow().value {
+                                heading_text.push_str(text);
+                            }
+                        }
+
+                        if heading_text.trim().eq_ignore_ascii_case("status") {
+                            found_status_section = true;
+                            break;
+                        }
+                    }
+                }
+
+                // Fallback: check lines directly
+                if !found_status_section {
+                    for line in document.lines.iter() {
+                        if STATUS_HEADING_REGEX.is_match(line) {
+                            found_status_section = true;
+                            break;
+                        }
+                    }
+                }
+
+                if !found_status_section {
+                    violations.push(self.create_violation(
+                        "Nygard format ADR is missing '## Status' section".to_string(),
+                        1,
+                        1,
+                        Severity::Error,
+                    ));
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        // Use a path that matches ADR directory detection
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_status() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid Nygard status"
+        );
+    }
+
+    #[test]
+    fn test_missing_nygard_status() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Context
+
+We need a language.
+
+## Decision
+
+Use Rust.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("missing '## Status' section")
+        );
+    }
+
+    #[test]
+    fn test_valid_madr_status() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid MADR status"
+        );
+    }
+
+    #[test]
+    fn test_missing_madr_status() {
+        let content = r#"---
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing 'status' field"));
+    }
+
+    #[test]
+    fn test_status_case_insensitive() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## STATUS
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Status section should be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_empty_frontmatter() {
+        let content = r#"---
+---
+
+# Title
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing 'status' field"));
+    }
+
+    #[test]
+    fn test_force_nygard_format() {
+        // Even with frontmatter, if we force Nygard format,
+        // it should check for ## Status section
+        let content = r#"---
+status: accepted
+---
+
+# Title
+
+## Context
+
+Content
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::with_format(AdrFormat::Nygard);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("missing '## Status' section")
+        );
+    }
+
+    #[test]
+    fn test_status_with_extra_whitespace() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+##   Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr002::default();
+        let violations = rule.check(&doc).unwrap();
+        // The regex allows for whitespace after "Status"
+        // but the AST-based check is more strict
+        // This tests the fallback regex pattern
+        assert!(violations.is_empty() || violations.len() == 1);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr003.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr003.rs
@@ -1,0 +1,379 @@
+//! ADR003: Required date
+//!
+//! Validates that the ADR has a date defined:
+//! - Nygard format: "Date:" line after the title
+//! - MADR format: `date` field in YAML frontmatter
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use crate::adr::frontmatter::parse_frontmatter;
+use comrak::nodes::AstNode;
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to match a "Date:" line (case-insensitive)
+static DATE_LINE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^date\s*:\s*(.+)$").expect("Invalid regex"));
+
+/// ADR003: Validates that ADR has a date
+///
+/// For Nygard format ADRs, there must be a "Date:" line.
+/// For MADR format ADRs, there must be a `date` field in the frontmatter.
+pub struct Adr003 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr003 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr003 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+}
+
+impl Rule for Adr003 {
+    fn id(&self) -> &'static str {
+        "ADR003"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-required-date"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR must have a date defined"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        let format = self.effective_format(&document.content);
+
+        match format {
+            AdrFormat::Madr4 => {
+                // Check for date in frontmatter
+                match parse_frontmatter(&document.content) {
+                    Some(result) => {
+                        if let Some(ref error) = result.error {
+                            // Frontmatter parsing failed
+                            violations.push(self.create_violation(
+                                format!("Cannot check date: {}", error),
+                                result.start_line,
+                                1,
+                                Severity::Warning,
+                            ));
+                        } else if let Some(ref fm) = result.frontmatter {
+                            if fm.date.is_none() {
+                                violations.push(
+                                    self.create_violation(
+                                        "MADR format ADR is missing 'date' field in frontmatter"
+                                            .to_string(),
+                                        result.start_line,
+                                        1,
+                                        Severity::Error,
+                                    ),
+                                );
+                            }
+                        } else {
+                            // Frontmatter exists but couldn't be parsed
+                            violations.push(
+                                self.create_violation(
+                                    "MADR format ADR is missing 'date' field in frontmatter"
+                                        .to_string(),
+                                    result.start_line,
+                                    1,
+                                    Severity::Error,
+                                ),
+                            );
+                        }
+                    }
+                    None => {
+                        // No frontmatter at all, but we detected MADR format
+                        violations.push(self.create_violation(
+                            "MADR format ADR is missing frontmatter with 'date' field".to_string(),
+                            1,
+                            1,
+                            Severity::Error,
+                        ));
+                    }
+                }
+            }
+            AdrFormat::Nygard | AdrFormat::Auto => {
+                // Check for Date: line in the document body (not in frontmatter)
+                let mut found_date = false;
+
+                // Skip frontmatter lines if present
+                let skip_lines = parse_frontmatter(&document.content)
+                    .map(|r| r.end_line)
+                    .unwrap_or(0);
+
+                for line in document.lines.iter().skip(skip_lines) {
+                    if DATE_LINE_REGEX.is_match(line) {
+                        found_date = true;
+                        break;
+                    }
+                }
+
+                if !found_date {
+                    violations.push(self.create_violation(
+                        "Nygard format ADR is missing 'Date:' line".to_string(),
+                        1,
+                        1,
+                        Severity::Error,
+                    ));
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        // Use a path that matches ADR directory detection
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_date() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid Nygard date"
+        );
+    }
+
+    #[test]
+    fn test_missing_nygard_date() {
+        let content = r#"# 1. Use Rust for implementation
+
+## Status
+
+Accepted
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing 'Date:' line"));
+    }
+
+    #[test]
+    fn test_valid_madr_date() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid MADR date"
+        );
+    }
+
+    #[test]
+    fn test_missing_madr_date() {
+        let content = r#"---
+status: accepted
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing 'date' field"));
+    }
+
+    #[test]
+    fn test_date_case_insensitive() {
+        let content = r#"# 1. Use Rust
+
+DATE: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Date line should be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_date_without_space() {
+        let content = r#"# 1. Use Rust
+
+Date:2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Date line should work without space after colon"
+        );
+    }
+
+    #[test]
+    fn test_date_with_extra_whitespace() {
+        let content = r#"# 1. Use Rust
+
+Date:    2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Date line should work with extra whitespace"
+        );
+    }
+
+    #[test]
+    fn test_empty_frontmatter_missing_date() {
+        let content = r#"---
+status: accepted
+---
+
+# Title
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing 'date' field"));
+    }
+
+    #[test]
+    fn test_force_nygard_format() {
+        // Even with frontmatter, if we force Nygard format,
+        // it should check for Date: line
+        let content = r#"---
+date: 2024-01-15
+---
+
+# Title
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr003::with_format(AdrFormat::Nygard);
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("missing 'Date:' line"));
+    }
+
+    #[test]
+    fn test_date_in_different_formats() {
+        // Various date formats should be accepted
+        let dates = vec![
+            "2024-01-15",
+            "January 15, 2024",
+            "2024/01/15",
+            "15-01-2024",
+            "2024.01.15",
+        ];
+
+        for date in dates {
+            let content = format!(
+                r#"# 1. Use Rust
+
+Date: {}
+
+## Status
+
+Accepted
+"#,
+                date
+            );
+            let doc = create_test_document(&content);
+            let rule = Adr003::default();
+            let violations = rule.check(&doc).unwrap();
+            assert!(
+                violations.is_empty(),
+                "Date format '{}' should be accepted",
+                date
+            );
+        }
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/format.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/format.rs
@@ -1,0 +1,256 @@
+//! ADR format detection utilities
+//!
+//! Provides functionality to detect whether an ADR follows the Nygard format
+//! or the MADR 4.0 format.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// The format of an Architecture Decision Record
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AdrFormat {
+    /// Nygard format: Plain markdown with "Date:" line and sections like Status, Context, Decision
+    Nygard,
+    /// MADR 4.0 format: YAML frontmatter with status/date fields
+    Madr4,
+    /// Auto-detect format based on content
+    #[default]
+    Auto,
+}
+
+impl std::fmt::Display for AdrFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdrFormat::Nygard => write!(f, "nygard"),
+            AdrFormat::Madr4 => write!(f, "madr"),
+            AdrFormat::Auto => write!(f, "auto"),
+        }
+    }
+}
+
+impl std::str::FromStr for AdrFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "nygard" => Ok(AdrFormat::Nygard),
+            "madr" | "madr4" => Ok(AdrFormat::Madr4),
+            "auto" => Ok(AdrFormat::Auto),
+            _ => Err(format!("Unknown ADR format: {}", s)),
+        }
+    }
+}
+
+/// Regex for detecting Nygard-style title: "# N. Title" or "# N - Title"
+static NYGARD_TITLE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^#\s+(\d+)[.\-\s]+\s*(.+)$").expect("Invalid regex"));
+
+/// Detect the ADR format based on content
+///
+/// Returns `AdrFormat::Madr4` if YAML frontmatter is present (starts with `---`),
+/// otherwise returns `AdrFormat::Nygard`.
+pub fn detect_format(content: &str) -> AdrFormat {
+    let trimmed = content.trim_start();
+
+    // MADR 4.0 uses YAML frontmatter
+    if trimmed.starts_with("---") {
+        return AdrFormat::Madr4;
+    }
+
+    // Default to Nygard format for plain markdown
+    AdrFormat::Nygard
+}
+
+/// Check if a document looks like an ADR based on content or path
+///
+/// Returns true if the document appears to be an Architecture Decision Record:
+/// - Has YAML frontmatter with a `status` field (MADR)
+/// - Has a numbered title like "# 1. Title" (Nygard)
+/// - Has a path containing "adr" or "adrs" directory
+pub fn is_adr_document(content: &str, file_path: Option<&std::path::Path>) -> bool {
+    // Check if in an ADR directory (handle both absolute and relative paths)
+    if let Some(path) = file_path {
+        let path_str = path.to_string_lossy().to_lowercase();
+        // Check for ADR directory anywhere in path, including at start for relative paths
+        if path_str.contains("/adr/")
+            || path_str.contains("/adrs/")
+            || path_str.contains("\\adr\\")
+            || path_str.contains("\\adrs\\")
+            || path_str.starts_with("adr/")
+            || path_str.starts_with("adrs/")
+            || path_str.starts_with("adr\\")
+            || path_str.starts_with("adrs\\")
+        {
+            return true;
+        }
+    }
+
+    // Check for MADR frontmatter with status field
+    let trimmed = content.trim_start();
+    if let Some(after_open) = trimmed.strip_prefix("---") {
+        // Simple check for status in frontmatter
+        if let Some(end) = after_open.find("---") {
+            let frontmatter = &after_open[..end];
+            if frontmatter.lines().any(|line| {
+                let line = line.trim();
+                line.starts_with("status:") || line.starts_with("status :")
+            }) {
+                return true;
+            }
+        }
+    }
+
+    // Check for Nygard-style numbered title
+    for line in content.lines().take(5) {
+        if is_nygard_title(line) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Extract the ADR number from a Nygard-style title
+///
+/// Nygard titles follow the pattern "# N. Title" or "# N - Title"
+pub fn extract_nygard_number(title_line: &str) -> Option<u32> {
+    NYGARD_TITLE_REGEX
+        .captures(title_line)
+        .and_then(|caps| caps.get(1))
+        .and_then(|m| m.as_str().parse().ok())
+}
+
+/// Extract the title text from a Nygard-style title line
+///
+/// Returns the title without the number prefix
+pub fn extract_nygard_title(title_line: &str) -> Option<&str> {
+    NYGARD_TITLE_REGEX
+        .captures(title_line)
+        .and_then(|caps| caps.get(2))
+        .map(|m| m.as_str().trim())
+}
+
+/// Check if a line matches the Nygard title format
+pub fn is_nygard_title(line: &str) -> bool {
+    NYGARD_TITLE_REGEX.is_match(line)
+}
+
+/// Parsed information from an ADR document
+#[derive(Debug, Clone)]
+pub struct ParsedAdr {
+    /// Detected format
+    pub format: AdrFormat,
+    /// ADR number (if extractable from title or filename)
+    pub number: Option<u32>,
+    /// Title text (without number prefix for Nygard)
+    pub title: Option<String>,
+    /// Status value
+    pub status: Option<String>,
+    /// Date value
+    pub date: Option<String>,
+    /// Line number where the H1 title is found (1-indexed)
+    pub title_line: Option<usize>,
+    /// Line number where status section/field is found (1-indexed)
+    pub status_line: Option<usize>,
+    /// Line number where date is found (1-indexed)
+    pub date_line: Option<usize>,
+}
+
+impl ParsedAdr {
+    /// Create a new empty ParsedAdr
+    pub fn new(format: AdrFormat) -> Self {
+        Self {
+            format,
+            number: None,
+            title: None,
+            status: None,
+            date: None,
+            title_line: None,
+            status_line: None,
+            date_line: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_format_madr() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+"#;
+        assert_eq!(detect_format(content), AdrFormat::Madr4);
+    }
+
+    #[test]
+    fn test_detect_format_nygard() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        assert_eq!(detect_format(content), AdrFormat::Nygard);
+    }
+
+    #[test]
+    fn test_detect_format_with_leading_whitespace() {
+        // Leading whitespace should be ignored
+        let content = "   \n\n---\nstatus: accepted\n---\n";
+        assert_eq!(detect_format(content), AdrFormat::Madr4);
+    }
+
+    #[test]
+    fn test_extract_nygard_number() {
+        assert_eq!(extract_nygard_number("# 1. Use Rust"), Some(1));
+        assert_eq!(extract_nygard_number("# 42. Some Decision"), Some(42));
+        assert_eq!(extract_nygard_number("# 1 - Use Rust"), Some(1));
+        assert_eq!(extract_nygard_number("# Use Rust"), None);
+        assert_eq!(extract_nygard_number("## 1. Section"), None);
+    }
+
+    #[test]
+    fn test_extract_nygard_title() {
+        assert_eq!(extract_nygard_title("# 1. Use Rust"), Some("Use Rust"));
+        assert_eq!(
+            extract_nygard_title("# 42. Some Decision"),
+            Some("Some Decision")
+        );
+        assert_eq!(extract_nygard_title("# 1 - Use Rust"), Some("Use Rust"));
+        assert_eq!(extract_nygard_title("# Use Rust"), None);
+    }
+
+    #[test]
+    fn test_is_nygard_title() {
+        assert!(is_nygard_title("# 1. Use Rust"));
+        assert!(is_nygard_title("# 42. Some Decision"));
+        assert!(is_nygard_title("# 1 - Use Rust"));
+        assert!(!is_nygard_title("# Use Rust"));
+        assert!(!is_nygard_title("## 1. Section"));
+    }
+
+    #[test]
+    fn test_format_from_str() {
+        assert_eq!("nygard".parse::<AdrFormat>().unwrap(), AdrFormat::Nygard);
+        assert_eq!("madr".parse::<AdrFormat>().unwrap(), AdrFormat::Madr4);
+        assert_eq!("madr4".parse::<AdrFormat>().unwrap(), AdrFormat::Madr4);
+        assert_eq!("auto".parse::<AdrFormat>().unwrap(), AdrFormat::Auto);
+        assert_eq!("NYGARD".parse::<AdrFormat>().unwrap(), AdrFormat::Nygard);
+        assert!("unknown".parse::<AdrFormat>().is_err());
+    }
+
+    #[test]
+    fn test_format_display() {
+        assert_eq!(format!("{}", AdrFormat::Nygard), "nygard");
+        assert_eq!(format!("{}", AdrFormat::Madr4), "madr");
+        assert_eq!(format!("{}", AdrFormat::Auto), "auto");
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/frontmatter.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/frontmatter.rs
@@ -1,0 +1,285 @@
+//! YAML frontmatter parsing for MADR 4.0 format
+//!
+//! MADR 4.0 ADRs use YAML frontmatter to store metadata like status and date.
+
+use serde::Deserialize;
+
+/// MADR 4.0 frontmatter fields
+///
+/// Example:
+/// ```yaml
+/// ---
+/// status: accepted
+/// date: 2024-01-15
+/// decision-makers:
+///   - Alice Smith
+///   - Bob Jones
+/// consulted:
+///   - Security Team
+/// informed:
+///   - Engineering Team
+/// ---
+/// ```
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct AdrFrontmatter {
+    /// ADR status (e.g., "proposed", "accepted", "deprecated", "superseded")
+    pub status: Option<String>,
+
+    /// Date of the decision (typically YYYY-MM-DD format)
+    pub date: Option<String>,
+
+    /// List of decision makers
+    #[serde(rename = "decision-makers", alias = "deciders")]
+    pub decision_makers: Option<Vec<String>>,
+
+    /// List of people/teams consulted
+    pub consulted: Option<Vec<String>>,
+
+    /// List of people/teams to be informed
+    pub informed: Option<Vec<String>>,
+}
+
+/// Result of parsing frontmatter from a document
+#[derive(Debug, Clone)]
+pub struct FrontmatterResult {
+    /// The parsed frontmatter (if valid YAML)
+    pub frontmatter: Option<AdrFrontmatter>,
+
+    /// The line number where the opening `---` is found (1-indexed)
+    pub start_line: usize,
+
+    /// The line number where the closing `---` is found (1-indexed)
+    pub end_line: usize,
+
+    /// Raw YAML content between the delimiters
+    pub raw_yaml: String,
+
+    /// Any parsing error message
+    pub error: Option<String>,
+}
+
+/// Parse YAML frontmatter from document content
+///
+/// Returns `None` if no frontmatter is present (document doesn't start with `---`)
+pub fn parse_frontmatter(content: &str) -> Option<FrontmatterResult> {
+    let trimmed = content.trim_start();
+
+    // Must start with ---
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+
+    // Calculate the offset for line numbering (accounting for trimmed whitespace)
+    let leading_lines = content
+        .chars()
+        .take(content.len() - trimmed.len())
+        .filter(|&c| c == '\n')
+        .count();
+
+    let lines: Vec<&str> = trimmed.lines().collect();
+
+    // Find the closing ---
+    let mut end_idx = None;
+    for (idx, line) in lines.iter().enumerate().skip(1) {
+        if line.trim() == "---" {
+            end_idx = Some(idx);
+            break;
+        }
+    }
+
+    let end_idx = match end_idx {
+        Some(idx) => idx,
+        None => {
+            // No closing delimiter found
+            return Some(FrontmatterResult {
+                frontmatter: None,
+                start_line: leading_lines + 1,
+                end_line: leading_lines + 1,
+                raw_yaml: String::new(),
+                error: Some("No closing '---' delimiter found for frontmatter".to_string()),
+            });
+        }
+    };
+
+    // Extract the YAML content
+    let yaml_content: String = lines[1..end_idx].join("\n");
+
+    // Try to parse the YAML
+    let (frontmatter, error) = match serde_yaml::from_str::<AdrFrontmatter>(&yaml_content) {
+        Ok(fm) => (Some(fm), None),
+        Err(e) => (
+            None,
+            Some(format!("Failed to parse YAML frontmatter: {}", e)),
+        ),
+    };
+
+    Some(FrontmatterResult {
+        frontmatter,
+        start_line: leading_lines + 1,
+        end_line: leading_lines + end_idx + 1,
+        raw_yaml: yaml_content,
+        error,
+    })
+}
+
+/// Extract the body content (everything after the frontmatter)
+pub fn extract_body(content: &str) -> &str {
+    let trimmed = content.trim_start();
+
+    if !trimmed.starts_with("---") {
+        return content;
+    }
+
+    // Find the closing ---
+    let lines: Vec<&str> = trimmed.lines().collect();
+    for (idx, line) in lines.iter().enumerate().skip(1) {
+        if line.trim() == "---" {
+            // Return everything after the closing delimiter
+            let body_start = lines[..=idx].join("\n").len() + 1; // +1 for newline
+            if body_start < trimmed.len() {
+                return &trimmed[body_start..];
+            } else {
+                return "";
+            }
+        }
+    }
+
+    // No closing delimiter, return entire content
+    content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_frontmatter() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+decision-makers:
+  - Alice Smith
+---
+
+# Title
+"#;
+
+        let result = parse_frontmatter(content).unwrap();
+        assert!(result.frontmatter.is_some());
+        assert!(result.error.is_none());
+
+        let fm = result.frontmatter.unwrap();
+        assert_eq!(fm.status, Some("accepted".to_string()));
+        assert_eq!(fm.date, Some("2024-01-15".to_string()));
+        assert_eq!(fm.decision_makers, Some(vec!["Alice Smith".to_string()]));
+
+        assert_eq!(result.start_line, 1);
+        assert_eq!(result.end_line, 6);
+    }
+
+    #[test]
+    fn test_parse_frontmatter_no_frontmatter() {
+        let content = "# Title\n\nSome content";
+        assert!(parse_frontmatter(content).is_none());
+    }
+
+    #[test]
+    fn test_parse_frontmatter_unclosed() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+
+# Title
+"#;
+
+        let result = parse_frontmatter(content).unwrap();
+        assert!(result.frontmatter.is_none());
+        assert!(result.error.is_some());
+        assert!(result.error.unwrap().contains("No closing"));
+    }
+
+    #[test]
+    fn test_parse_frontmatter_with_leading_whitespace() {
+        let content = "\n\n---\nstatus: accepted\n---\n\n# Title";
+
+        let result = parse_frontmatter(content).unwrap();
+        assert!(result.frontmatter.is_some());
+        assert_eq!(result.start_line, 3);
+        assert_eq!(result.end_line, 5);
+    }
+
+    #[test]
+    fn test_parse_empty_frontmatter() {
+        let content = "---\n---\n\n# Title";
+
+        let result = parse_frontmatter(content).unwrap();
+        assert!(result.frontmatter.is_some());
+        let fm = result.frontmatter.unwrap();
+        assert!(fm.status.is_none());
+        assert!(fm.date.is_none());
+    }
+
+    #[test]
+    fn test_extract_body() {
+        let content = r#"---
+status: accepted
+---
+
+# Title
+
+Body content here.
+"#;
+
+        let body = extract_body(content);
+        assert!(body.contains("# Title"));
+        assert!(body.contains("Body content here."));
+        assert!(!body.contains("status:"));
+    }
+
+    #[test]
+    fn test_extract_body_no_frontmatter() {
+        let content = "# Title\n\nBody content";
+        assert_eq!(extract_body(content), content);
+    }
+
+    #[test]
+    fn test_deciders_alias() {
+        let content = r#"---
+status: accepted
+deciders:
+  - Alice Smith
+---
+"#;
+
+        let result = parse_frontmatter(content).unwrap();
+        let fm = result.frontmatter.unwrap();
+        assert_eq!(fm.decision_makers, Some(vec!["Alice Smith".to_string()]));
+    }
+
+    #[test]
+    fn test_all_optional_fields() {
+        let content = r#"---
+status: proposed
+date: 2024-01-20
+decision-makers:
+  - Alice
+  - Bob
+consulted:
+  - Security Team
+informed:
+  - Engineering
+---
+"#;
+
+        let result = parse_frontmatter(content).unwrap();
+        let fm = result.frontmatter.unwrap();
+        assert_eq!(fm.status, Some("proposed".to_string()));
+        assert_eq!(fm.date, Some("2024-01-20".to_string()));
+        assert_eq!(
+            fm.decision_makers,
+            Some(vec!["Alice".to_string(), "Bob".to_string()])
+        );
+        assert_eq!(fm.consulted, Some(vec!["Security Team".to_string()]));
+        assert_eq!(fm.informed, Some(vec!["Engineering".to_string()]));
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/mod.rs
@@ -1,0 +1,279 @@
+//! ADR (Architecture Decision Record) linting rules
+//!
+//! This module provides rules for validating Architecture Decision Records (ADRs)
+//! against both the Nygard format and MADR 4.0 format.
+//!
+//! # Supported Formats
+//!
+//! ## Nygard Format
+//!
+//! The original ADR format proposed by Michael Nygard in his blog post
+//! "Documenting Architecture Decisions". Key characteristics:
+//!
+//! - Title: `# N. Title` (e.g., `# 1. Record architecture decisions`)
+//! - Date: `Date: YYYY-MM-DD` line after the title
+//! - Status: `## Status` section with status value
+//! - Required sections: Context, Decision, Consequences
+//!
+//! Example:
+//! ```markdown
+//! # 1. Record architecture decisions
+//!
+//! Date: 2024-01-15
+//!
+//! ## Status
+//!
+//! Accepted
+//!
+//! ## Context
+//!
+//! We need to record the architectural decisions made on this project.
+//!
+//! ## Decision
+//!
+//! We will use Architecture Decision Records, as described by Michael Nygard.
+//!
+//! ## Consequences
+//!
+//! See Michael Nygard's article for more details.
+//! ```
+//!
+//! ## MADR 4.0 Format
+//!
+//! Markdown Any Decision Records (MADR) version 4.0 uses YAML frontmatter
+//! for metadata and a slightly different structure. Key characteristics:
+//!
+//! - YAML frontmatter with `status` and `date` fields
+//! - Simple H1 title (no number prefix required)
+//! - Different section names (Context and Problem Statement, Decision Outcome)
+//!
+//! Example:
+//! ```markdown
+//! ---
+//! status: accepted
+//! date: 2024-01-15
+//! decision-makers:
+//!   - Alice Smith
+//! ---
+//!
+//! # Use PostgreSQL for persistence
+//!
+//! ## Context and Problem Statement
+//!
+//! We need to select a database for the application.
+//!
+//! ## Decision Outcome
+//!
+//! Chosen option: PostgreSQL.
+//! ```
+//!
+//! # Available Rules
+//!
+//! | Rule | Name | Description |
+//! |------|------|-------------|
+//! | ADR001 | adr-title-format | Title follows appropriate format for ADR type |
+//! | ADR002 | adr-required-status | Status is defined (section or frontmatter) |
+//! | ADR003 | adr-required-date | Date is defined (line or frontmatter) |
+//!
+//! # Configuration
+//!
+//! Rules can be configured in your `.mdbook-lint.toml`:
+//!
+//! ```toml
+//! # Provider-level format setting (affects all ADR rules)
+//! [ADR]
+//! format = "auto"  # "auto", "nygard", or "madr"
+//! ```
+
+pub mod format;
+pub mod frontmatter;
+
+mod adr001;
+mod adr002;
+mod adr003;
+
+use crate::{RuleProvider, RuleRegistry};
+
+pub use adr001::Adr001;
+pub use adr002::Adr002;
+pub use adr003::Adr003;
+pub use format::AdrFormat;
+pub use frontmatter::AdrFrontmatter;
+
+/// Provider for ADR (Architecture Decision Record) rules
+///
+/// This provider registers rules for validating ADRs against both the
+/// Nygard format and MADR 4.0 format. Format detection is automatic
+/// by default but can be configured.
+pub struct AdrRuleProvider;
+
+impl RuleProvider for AdrRuleProvider {
+    fn provider_id(&self) -> &'static str {
+        "adr"
+    }
+
+    fn description(&self) -> &'static str {
+        "Architecture Decision Record linting rules (ADR001-ADR019)"
+    }
+
+    fn version(&self) -> &'static str {
+        "0.1.0"
+    }
+
+    fn register_rules(&self, registry: &mut RuleRegistry) {
+        registry.register(Box::new(Adr001::default()));
+        registry.register(Box::new(Adr002::default()));
+        registry.register(Box::new(Adr003::default()));
+    }
+
+    fn rule_ids(&self) -> Vec<&'static str> {
+        vec!["ADR001", "ADR002", "ADR003"]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdbook_lint_core::Document;
+    use mdbook_lint_core::rule::Rule;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        // Use a path that matches ADR directory detection
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_provider_metadata() {
+        let provider = AdrRuleProvider;
+        assert_eq!(provider.provider_id(), "adr");
+        assert!(provider.description().contains("ADR"));
+        assert_eq!(provider.version(), "0.1.0");
+    }
+
+    #[test]
+    fn test_provider_rule_ids() {
+        let provider = AdrRuleProvider;
+        let ids = provider.rule_ids();
+        assert!(ids.contains(&"ADR001"));
+        assert!(ids.contains(&"ADR002"));
+        assert!(ids.contains(&"ADR003"));
+    }
+
+    #[test]
+    fn test_valid_nygard_adr() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to choose a programming language.
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+Team will need Rust training.
+"#;
+        let doc = create_test_document(content);
+
+        let rule1 = Adr001::default();
+        let rule2 = Adr002::default();
+        let rule3 = Adr003::default();
+
+        assert!(rule1.check(&doc).unwrap().is_empty());
+        assert!(rule2.check(&doc).unwrap().is_empty());
+        assert!(rule3.check(&doc).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_valid_madr_adr() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+decision-makers:
+  - Alice Smith
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+
+        let rule1 = Adr001::default();
+        let rule2 = Adr002::default();
+        let rule3 = Adr003::default();
+
+        assert!(rule1.check(&doc).unwrap().is_empty());
+        assert!(rule2.check(&doc).unwrap().is_empty());
+        assert!(rule3.check(&doc).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_invalid_nygard_adr_all_rules_fail() {
+        // Missing number in title, no status section, no date
+        let content = r#"# Use Rust
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+
+        let rule1 = Adr001::default();
+        let rule2 = Adr002::default();
+        let rule3 = Adr003::default();
+
+        assert!(!rule1.check(&doc).unwrap().is_empty(), "ADR001 should fail");
+        assert!(!rule2.check(&doc).unwrap().is_empty(), "ADR002 should fail");
+        assert!(!rule3.check(&doc).unwrap().is_empty(), "ADR003 should fail");
+    }
+
+    #[test]
+    fn test_invalid_madr_adr_missing_fields() {
+        // Frontmatter present but missing status and date
+        let content = r#"---
+decision-makers:
+  - Alice
+---
+
+# Title
+
+## Context
+
+Content.
+"#;
+        let doc = create_test_document(content);
+
+        let rule1 = Adr001::default();
+        let rule2 = Adr002::default();
+        let rule3 = Adr003::default();
+
+        assert!(
+            rule1.check(&doc).unwrap().is_empty(),
+            "ADR001 should pass (title exists)"
+        );
+        assert!(
+            !rule2.check(&doc).unwrap().is_empty(),
+            "ADR002 should fail (no status)"
+        );
+        assert!(
+            !rule3.check(&doc).unwrap().is_empty(),
+            "ADR003 should fail (no date)"
+        );
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/lib.rs
+++ b/crates/mdbook-lint-rulesets/src/lib.rs
@@ -137,3 +137,9 @@ pub use mdbook::MdBookRuleProvider;
 pub mod content;
 #[cfg(feature = "content")]
 pub use content::ContentRuleProvider;
+
+// ADR (Architecture Decision Record) rules (optional, off by default)
+#[cfg(feature = "adr")]
+pub mod adr;
+#[cfg(feature = "adr")]
+pub use adr::AdrRuleProvider;


### PR DESCRIPTION
## Summary

- Add new optional `adr` feature with rules for linting Architecture Decision Records
- ADR001: Validates title format (Nygard numbered titles or MADR H1)
- ADR002: Ensures status is defined (## Status section or frontmatter)
- ADR003: Ensures date is defined (Date: line or frontmatter)
- Auto-detects Nygard vs MADR 4.0 format based on content
- Only runs on files that appear to be ADRs (in `adr/`/`adrs/` directories or with ADR markers)

## Note

CLI integration will be added in a follow-on PR after this crate is published to crates.io (avoids chicken-and-egg dependency issue with the release check).

## Test plan

- [x] Unit tests for all three rules with both formats
- [x] Integration tests pass (ADR rules don't interfere with non-ADR files)
- [x] `cargo clippy` and `cargo fmt` pass