### PR TITLE
feat: add ADR rules batch 2 (ADR004-ADR009)

### DIFF
--- a/crates/mdbook-lint-rulesets/src/adr/adr004.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr004.rs
@@ -1,0 +1,268 @@
+//! ADR004: Required context section
+//!
+//! Validates that the ADR has a context section:
+//! - Nygard format: "## Context" section
+//! - MADR format: "## Context and Problem Statement" section
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+
+/// ADR004: Validates that ADR has a context section
+///
+/// For Nygard format ADRs, there must be a "## Context" section.
+/// For MADR format ADRs, there must be a "## Context and Problem Statement" section.
+pub struct Adr004 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr004 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr004 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+}
+
+impl Rule for Adr004 {
+    fn id(&self) -> &'static str {
+        "ADR004"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-required-context"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR must have a context section"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+        let format = self.effective_format(&document.content);
+
+        // Parse AST locally
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        let mut found_context = false;
+
+        for node in ast_node.descendants() {
+            if let NodeValue::Heading(heading) = &node.data.borrow().value
+                && heading.level == 2
+            {
+                // Extract heading text
+                let mut heading_text = String::new();
+                for child in node.children() {
+                    if let NodeValue::Text(text) = &child.data.borrow().value {
+                        heading_text.push_str(text);
+                    }
+                }
+
+                let heading_lower = heading_text.trim().to_lowercase();
+
+                match format {
+                    AdrFormat::Nygard | AdrFormat::Auto => {
+                        if heading_lower == "context" {
+                            found_context = true;
+                            break;
+                        }
+                    }
+                    AdrFormat::Madr4 => {
+                        if heading_lower == "context and problem statement" {
+                            found_context = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !found_context {
+            let expected = match format {
+                AdrFormat::Madr4 => "## Context and Problem Statement",
+                _ => "## Context",
+            };
+            violations.push(self.create_violation(
+                format!("ADR is missing '{}' section", expected),
+                1,
+                1,
+                Severity::Error,
+            ));
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        // Use a path that matches ADR directory detection
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_context() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to choose a programming language.
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+Team needs Rust training.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid Nygard context"
+        );
+    }
+
+    #[test]
+    fn test_missing_nygard_context() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+Team needs Rust training.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("## Context"));
+    }
+
+    #[test]
+    fn test_valid_madr_context() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid MADR context"
+        );
+    }
+
+    #[test]
+    fn test_missing_madr_context() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("Context and Problem Statement")
+        );
+    }
+
+    #[test]
+    fn test_context_case_insensitive() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## CONTEXT
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr004::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Context section should be case-insensitive"
+        );
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr005.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr005.rs
@@ -1,0 +1,234 @@
+//! ADR005: Required decision section
+//!
+//! Validates that the ADR has a decision section:
+//! - Nygard format: "## Decision" section
+//! - MADR format: "## Decision Outcome" section
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+
+/// ADR005: Validates that ADR has a decision section
+///
+/// For Nygard format ADRs, there must be a "## Decision" section.
+/// For MADR format ADRs, there must be a "## Decision Outcome" section.
+pub struct Adr005 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr005 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr005 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+}
+
+impl Rule for Adr005 {
+    fn id(&self) -> &'static str {
+        "ADR005"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-required-decision"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR must have a decision section"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+        let format = self.effective_format(&document.content);
+
+        // Parse AST locally
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        let mut found_decision = false;
+
+        for node in ast_node.descendants() {
+            if let NodeValue::Heading(heading) = &node.data.borrow().value
+                && heading.level == 2
+            {
+                // Extract heading text
+                let mut heading_text = String::new();
+                for child in node.children() {
+                    if let NodeValue::Text(text) = &child.data.borrow().value {
+                        heading_text.push_str(text);
+                    }
+                }
+
+                let heading_lower = heading_text.trim().to_lowercase();
+
+                match format {
+                    AdrFormat::Nygard | AdrFormat::Auto => {
+                        if heading_lower == "decision" {
+                            found_decision = true;
+                            break;
+                        }
+                    }
+                    AdrFormat::Madr4 => {
+                        if heading_lower == "decision outcome" {
+                            found_decision = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !found_decision {
+            let expected = match format {
+                AdrFormat::Madr4 => "## Decision Outcome",
+                _ => "## Decision",
+            };
+            violations.push(self.create_violation(
+                format!("ADR is missing '{}' section", expected),
+                1,
+                1,
+                Severity::Error,
+            ));
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_decision() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to choose a programming language.
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+Team needs Rust training.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_missing_nygard_decision() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to choose a programming language.
+
+## Consequences
+
+Team needs Rust training.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("## Decision"));
+    }
+
+    #[test]
+    fn test_valid_madr_decision() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_missing_madr_decision() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr005::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Decision Outcome"));
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr006.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr006.rs
@@ -1,0 +1,234 @@
+//! ADR006: Required consequences section
+//!
+//! Validates that Nygard format ADRs have a consequences section.
+//! MADR format does not require a consequences section.
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+
+/// ADR006: Validates that Nygard format ADR has a consequences section
+///
+/// For Nygard format ADRs, there must be a "## Consequences" section.
+/// MADR format ADRs do not require this section.
+pub struct Adr006 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr006 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr006 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+}
+
+impl Rule for Adr006 {
+    fn id(&self) -> &'static str {
+        "ADR006"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-required-consequences"
+    }
+
+    fn description(&self) -> &'static str {
+        "Nygard format ADR must have a consequences section"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let format = self.effective_format(&document.content);
+
+        // MADR format does not require a consequences section
+        if format == AdrFormat::Madr4 {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        // Parse AST locally
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        let mut found_consequences = false;
+
+        for node in ast_node.descendants() {
+            if let NodeValue::Heading(heading) = &node.data.borrow().value
+                && heading.level == 2
+            {
+                // Extract heading text
+                let mut heading_text = String::new();
+                for child in node.children() {
+                    if let NodeValue::Text(text) = &child.data.borrow().value {
+                        heading_text.push_str(text);
+                    }
+                }
+
+                if heading_text.trim().eq_ignore_ascii_case("consequences") {
+                    found_consequences = true;
+                    break;
+                }
+            }
+        }
+
+        if !found_consequences {
+            violations.push(self.create_violation(
+                "Nygard format ADR is missing '## Consequences' section".to_string(),
+                1,
+                1,
+                Severity::Error,
+            ));
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_consequences() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to choose a programming language.
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+Team needs Rust training.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr006::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_missing_nygard_consequences() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to choose a programming language.
+
+## Decision
+
+We will use Rust.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr006::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("## Consequences"));
+    }
+
+    #[test]
+    fn test_madr_no_consequences_required() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr006::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "MADR format should not require consequences section"
+        );
+    }
+
+    #[test]
+    fn test_consequences_case_insensitive() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need a language.
+
+## Decision
+
+Use Rust.
+
+## CONSEQUENCES
+
+Training needed.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr006::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr007.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr007.rs
@@ -1,0 +1,383 @@
+//! ADR007: Valid status values
+//!
+//! Validates that the ADR status is one of the recognized values:
+//! - proposed, accepted, deprecated, superseded (standard)
+//! - rejected, draft (common additions)
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use crate::adr::frontmatter::parse_frontmatter;
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Default valid status values
+const DEFAULT_VALID_STATUSES: &[&str] = &[
+    "proposed",
+    "accepted",
+    "deprecated",
+    "superseded",
+    "rejected",
+    "draft",
+];
+
+/// Regex to extract status value from a line following "## Status" heading
+static STATUS_VALUE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*(\w+(?:\s+\w+)*)\s*$").expect("Invalid regex"));
+
+/// ADR007: Validates that ADR has a valid status value
+pub struct Adr007 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+    /// Valid status values (lowercase for comparison)
+    valid_statuses: Vec<String>,
+}
+
+impl Default for Adr007 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+            valid_statuses: DEFAULT_VALID_STATUSES
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+}
+
+impl Adr007 {
+    /// Create a new rule with custom valid statuses
+    #[allow(dead_code)]
+    pub fn with_statuses(statuses: Vec<String>) -> Self {
+        Self {
+            format: AdrFormat::Auto,
+            valid_statuses: statuses.into_iter().map(|s| s.to_lowercase()).collect(),
+        }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+
+    /// Check if a status value is valid
+    fn is_valid_status(&self, status: &str) -> bool {
+        let status_lower = status.to_lowercase();
+        self.valid_statuses
+            .iter()
+            .any(|v| v.eq_ignore_ascii_case(&status_lower))
+    }
+}
+
+impl Rule for Adr007 {
+    fn id(&self) -> &'static str {
+        "ADR007"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-valid-status"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR status must be a recognized value"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+        let format = self.effective_format(&document.content);
+
+        match format {
+            AdrFormat::Madr4 => {
+                // Check status in frontmatter
+                if let Some(result) = parse_frontmatter(&document.content)
+                    && let Some(ref fm) = result.frontmatter
+                    && let Some(ref status) = fm.status
+                    && !self.is_valid_status(status)
+                {
+                    violations.push(self.create_violation(
+                        format!(
+                            "Invalid status '{}'. Valid values: {}",
+                            status,
+                            self.valid_statuses.join(", ")
+                        ),
+                        result.start_line,
+                        1,
+                        Severity::Warning,
+                    ));
+                }
+            }
+            AdrFormat::Nygard | AdrFormat::Auto => {
+                // Find ## Status section and extract the value
+                let arena = comrak::Arena::new();
+                let ast_node = document.parse_ast(&arena);
+
+                let mut in_status_section = false;
+
+                for node in ast_node.descendants() {
+                    if let NodeValue::Heading(heading) = &node.data.borrow().value {
+                        if heading.level == 2 {
+                            // Extract heading text
+                            let mut heading_text = String::new();
+                            for child in node.children() {
+                                if let NodeValue::Text(text) = &child.data.borrow().value {
+                                    heading_text.push_str(text);
+                                }
+                            }
+
+                            if heading_text.trim().eq_ignore_ascii_case("status") {
+                                in_status_section = true;
+                            } else if in_status_section {
+                                // Hit another H2, stop looking
+                                break;
+                            }
+                        }
+                    } else if in_status_section
+                        && let NodeValue::Paragraph = &node.data.borrow().value
+                    {
+                        // Extract paragraph text
+                        let mut para_text = String::new();
+                        for child in node.children() {
+                            if let NodeValue::Text(text) = &child.data.borrow().value {
+                                para_text.push_str(text);
+                            }
+                        }
+
+                        if let Some(caps) = STATUS_VALUE_REGEX.captures(para_text.trim())
+                            && let Some(status_match) = caps.get(1)
+                        {
+                            let status = status_match.as_str();
+                            if !self.is_valid_status(status) {
+                                violations.push(self.create_violation(
+                                    format!(
+                                        "Invalid status '{}'. Valid values: {}",
+                                        status,
+                                        self.valid_statuses.join(", ")
+                                    ),
+                                    node.data.borrow().sourcepos.start.line,
+                                    1,
+                                    Severity::Warning,
+                                ));
+                            }
+                        }
+                        break;
+                    }
+                }
+
+                // Handle case where status section exists but no value found
+                // This is handled by ADR002, so we don't report here
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_status_accepted() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_valid_nygard_status_proposed() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Proposed
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_nygard_status() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+WIP
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Invalid status"));
+        assert!(violations[0].message.contains("WIP"));
+    }
+
+    #[test]
+    fn test_valid_madr_status() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_madr_status() {
+        let content = r#"---
+status: approved
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Invalid status"));
+        assert!(violations[0].message.contains("approved"));
+    }
+
+    #[test]
+    fn test_status_case_insensitive() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+ACCEPTED
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "Status should be case-insensitive");
+    }
+
+    #[test]
+    fn test_custom_valid_statuses() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+approved
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::with_statuses(vec!["approved".to_string(), "denied".to_string()]);
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_deprecated_status() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Deprecated
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_superseded_status() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Superseded
+
+## Context
+
+We need a language.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr007::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr008.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr008.rs
@@ -1,0 +1,280 @@
+//! ADR008: Date format validation
+//!
+//! Validates that the ADR date follows ISO 8601 format (YYYY-MM-DD).
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use crate::adr::frontmatter::parse_frontmatter;
+use comrak::nodes::AstNode;
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex for ISO 8601 date format (YYYY-MM-DD)
+static ISO_DATE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\d{4}-\d{2}-\d{2}$").expect("Invalid regex"));
+
+/// Regex to extract date from "Date:" line
+static DATE_LINE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^date\s*:\s*(.+)$").expect("Invalid regex"));
+
+/// ADR008: Validates that ADR date follows ISO 8601 format
+pub struct Adr008 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr008 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr008 {
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+
+    /// Check if a date string is in ISO 8601 format
+    fn is_iso_date(date: &str) -> bool {
+        let date = date.trim();
+        if !ISO_DATE_REGEX.is_match(date) {
+            return false;
+        }
+
+        // Also validate that it's a reasonable date
+        let parts: Vec<&str> = date.split('-').collect();
+        if parts.len() != 3 {
+            return false;
+        }
+
+        if let (Ok(year), Ok(month), Ok(day)) = (
+            parts[0].parse::<u32>(),
+            parts[1].parse::<u32>(),
+            parts[2].parse::<u32>(),
+        ) {
+            // Basic validation
+            (1900..=2100).contains(&year) && (1..=12).contains(&month) && (1..=31).contains(&day)
+        } else {
+            false
+        }
+    }
+}
+
+impl Rule for Adr008 {
+    fn id(&self) -> &'static str {
+        "ADR008"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-date-format"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR date should follow ISO 8601 format (YYYY-MM-DD)"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+        let format = self.effective_format(&document.content);
+
+        match format {
+            AdrFormat::Madr4 => {
+                // Check date in frontmatter
+                if let Some(result) = parse_frontmatter(&document.content)
+                    && let Some(ref fm) = result.frontmatter
+                    && let Some(ref date) = fm.date
+                    && !Self::is_iso_date(date)
+                {
+                    violations.push(self.create_violation(
+                        format!("Date '{}' is not in ISO 8601 format (YYYY-MM-DD)", date),
+                        result.start_line,
+                        1,
+                        Severity::Warning,
+                    ));
+                }
+            }
+            AdrFormat::Nygard | AdrFormat::Auto => {
+                // Skip frontmatter lines if present
+                let skip_lines = parse_frontmatter(&document.content)
+                    .map(|r| r.end_line)
+                    .unwrap_or(0);
+
+                // Find Date: line
+                for (idx, line) in document.lines.iter().enumerate().skip(skip_lines) {
+                    if let Some(caps) = DATE_LINE_REGEX.captures(line) {
+                        if let Some(date_match) = caps.get(1) {
+                            let date = date_match.as_str().trim();
+                            if !Self::is_iso_date(date) {
+                                violations.push(self.create_violation(
+                                    format!(
+                                        "Date '{}' is not in ISO 8601 format (YYYY-MM-DD)",
+                                        date
+                                    ),
+                                    idx + 1,
+                                    1,
+                                    Severity::Warning,
+                                ));
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_iso_date_nygard() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr008::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_date_format_us() {
+        let content = r#"# 1. Use Rust
+
+Date: 01/15/2024
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr008::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("not in ISO 8601 format"));
+    }
+
+    #[test]
+    fn test_invalid_date_format_text() {
+        let content = r#"# 1. Use Rust
+
+Date: January 15, 2024
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr008::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("not in ISO 8601 format"));
+    }
+
+    #[test]
+    fn test_valid_iso_date_madr() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr008::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_date_format_madr() {
+        let content = r#"---
+status: accepted
+date: 15-01-2024
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr008::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("not in ISO 8601 format"));
+    }
+
+    #[test]
+    fn test_is_iso_date() {
+        assert!(Adr008::is_iso_date("2024-01-15"));
+        assert!(Adr008::is_iso_date("2024-12-31"));
+        assert!(Adr008::is_iso_date("1999-01-01"));
+        assert!(!Adr008::is_iso_date("01-15-2024"));
+        assert!(!Adr008::is_iso_date("2024/01/15"));
+        assert!(!Adr008::is_iso_date("January 15, 2024"));
+        assert!(!Adr008::is_iso_date("2024-13-01")); // Invalid month
+        assert!(!Adr008::is_iso_date("2024-00-01")); // Invalid month
+        assert!(!Adr008::is_iso_date("2024-01-32")); // Invalid day
+        assert!(!Adr008::is_iso_date("2024-01-00")); // Invalid day
+    }
+
+    #[test]
+    fn test_date_with_whitespace() {
+        let content = r#"# 1. Use Rust
+
+Date:   2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr008::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Should handle whitespace around date"
+        );
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr009.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr009.rs
@@ -1,0 +1,278 @@
+//! ADR009: Filename matches ADR number
+//!
+//! Validates that the filename matches the ADR number in the title.
+//! Expected format: NNNN-title-slug.md (e.g., 0001-use-rust.md)
+
+use crate::adr::format::{AdrFormat, detect_format, extract_nygard_number, is_adr_document};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to extract number from filename (e.g., "0001-use-rust.md" -> 1)
+static FILENAME_NUMBER_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\d+)[-_]").expect("Invalid regex"));
+
+/// ADR009: Validates that filename matches ADR number
+pub struct Adr009 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr009 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr009 {
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+
+    /// Extract the number from a filename
+    fn extract_filename_number(filename: &str) -> Option<u32> {
+        FILENAME_NUMBER_REGEX
+            .captures(filename)
+            .and_then(|caps| caps.get(1))
+            .and_then(|m| m.as_str().parse().ok())
+    }
+}
+
+impl Rule for Adr009 {
+    fn id(&self) -> &'static str {
+        "ADR009"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-filename-matches-number"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR filename should match the ADR number in the title"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let format = self.effective_format(&document.content);
+
+        // This rule only applies to Nygard format (which has numbered titles)
+        if format == AdrFormat::Madr4 {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        // Get filename
+        let filename = document
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+
+        // Extract number from filename
+        let filename_number = Self::extract_filename_number(filename);
+
+        // Find H1 heading and extract number from title
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        let mut title_number: Option<u32> = None;
+        let mut title_line = 1;
+
+        for node in ast_node.descendants() {
+            if let NodeValue::Heading(heading) = &node.data.borrow().value
+                && heading.level == 1
+            {
+                title_line = node.data.borrow().sourcepos.start.line;
+
+                // Get the original line to extract number
+                if let Some(line) = document.lines.get(title_line.saturating_sub(1)) {
+                    title_number = extract_nygard_number(line);
+                }
+                break;
+            }
+        }
+
+        // Compare numbers
+        match (filename_number, title_number) {
+            (Some(fn_num), Some(t_num)) if fn_num != t_num => {
+                violations.push(self.create_violation(
+                    format!(
+                        "Filename number ({:04}) does not match title number ({})",
+                        fn_num, t_num
+                    ),
+                    title_line,
+                    1,
+                    Severity::Warning,
+                ));
+            }
+            (None, Some(t_num)) => {
+                violations.push(self.create_violation(
+                    format!(
+                        "Filename '{}' does not start with ADR number. Expected format: {:04}-*.md",
+                        filename, t_num
+                    ),
+                    1,
+                    1,
+                    Severity::Warning,
+                ));
+            }
+            _ => {
+                // No title number (handled by ADR001) or numbers match
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document_with_path(content: &str, path: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from(path)).unwrap()
+    }
+
+    #[test]
+    fn test_matching_number() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document_with_path(content, "adr/0001-use-rust.md");
+        let rule = Adr009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_mismatched_number() {
+        let content = r#"# 2. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document_with_path(content, "adr/0001-use-rust.md");
+        let rule = Adr009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("does not match"));
+    }
+
+    #[test]
+    fn test_filename_without_number() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document_with_path(content, "adr/use-rust.md");
+        let rule = Adr009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("does not start with ADR number")
+        );
+    }
+
+    #[test]
+    fn test_madr_no_check() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need a database.
+"#;
+        let doc = create_test_document_with_path(content, "adr/use-postgres.md");
+        let rule = Adr009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "MADR format should skip number check"
+        );
+    }
+
+    #[test]
+    fn test_larger_numbers() {
+        let content = r#"# 42. Use Kubernetes
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document_with_path(content, "adr/0042-use-kubernetes.md");
+        let rule = Adr009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_extract_filename_number() {
+        assert_eq!(Adr009::extract_filename_number("0001-use-rust.md"), Some(1));
+        assert_eq!(Adr009::extract_filename_number("42-use-rust.md"), Some(42));
+        assert_eq!(
+            Adr009::extract_filename_number("0042_use_rust.md"),
+            Some(42)
+        );
+        assert_eq!(Adr009::extract_filename_number("use-rust.md"), None);
+        assert_eq!(Adr009::extract_filename_number("adr-001.md"), None);
+    }
+
+    #[test]
+    fn test_underscore_separator() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+"#;
+        let doc = create_test_document_with_path(content, "adr/0001_use_rust.md");
+        let rule = Adr009::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty());
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/mod.rs
@@ -74,6 +74,12 @@
 //! | ADR001 | adr-title-format | Title follows appropriate format for ADR type |
 //! | ADR002 | adr-required-status | Status is defined (section or frontmatter) |
 //! | ADR003 | adr-required-date | Date is defined (line or frontmatter) |
+//! | ADR004 | adr-required-context | Context section is present |
+//! | ADR005 | adr-required-decision | Decision section is present |
+//! | ADR006 | adr-required-consequences | Consequences section is present (Nygard only) |
+//! | ADR007 | adr-valid-status | Status value is recognized |
+//! | ADR008 | adr-date-format | Date follows ISO 8601 format |
+//! | ADR009 | adr-filename-matches-number | Filename matches ADR number (Nygard only) |
 //!
 //! # Configuration
 //!
@@ -91,12 +97,24 @@ pub mod frontmatter;
 mod adr001;
 mod adr002;
 mod adr003;
+mod adr004;
+mod adr005;
+mod adr006;
+mod adr007;
+mod adr008;
+mod adr009;
 
 use crate::{RuleProvider, RuleRegistry};
 
 pub use adr001::Adr001;
 pub use adr002::Adr002;
 pub use adr003::Adr003;
+pub use adr004::Adr004;
+pub use adr005::Adr005;
+pub use adr006::Adr006;
+pub use adr007::Adr007;
+pub use adr008::Adr008;
+pub use adr009::Adr009;
 pub use format::AdrFormat;
 pub use frontmatter::AdrFrontmatter;
 
@@ -124,10 +142,19 @@ impl RuleProvider for AdrRuleProvider {
         registry.register(Box::new(Adr001::default()));
         registry.register(Box::new(Adr002::default()));
         registry.register(Box::new(Adr003::default()));
+        registry.register(Box::new(Adr004::default()));
+        registry.register(Box::new(Adr005::default()));
+        registry.register(Box::new(Adr006::default()));
+        registry.register(Box::new(Adr007::default()));
+        registry.register(Box::new(Adr008::default()));
+        registry.register(Box::new(Adr009::default()));
     }
 
     fn rule_ids(&self) -> Vec<&'static str> {
-        vec!["ADR001", "ADR002", "ADR003"]
+        vec![
+            "ADR001", "ADR002", "ADR003", "ADR004", "ADR005", "ADR006", "ADR007", "ADR008",
+            "ADR009",
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary

Add six new ADR rules for comprehensive validation:

| Rule | Name | Description |
|------|------|-------------|
| ADR004 | adr-required-context | Context section is present |
| ADR005 | adr-required-decision | Decision section is present |
| ADR006 | adr-required-consequences | Consequences section is present (Nygard only) |
| ADR007 | adr-valid-status | Status value is recognized |
| ADR008 | adr-date-format | Date follows ISO 8601 format |
| ADR009 | adr-filename-matches-number | Filename matches ADR number (Nygard only) |

All rules support both Nygard and MADR 4.0 formats where applicable.

## Test plan

- [x] 36 new unit tests across all rules
- [x] All 1398 tests pass
- [x] `cargo clippy` and `cargo fmt` pass