### PR TITLE
feat: add ADR content quality rules (ADR014-ADR017)

### DIFF
--- a/crates/mdbook-lint-rulesets/src/adr/adr014.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr014.rs
@@ -1,0 +1,409 @@
+//! ADR014: Non-empty sections
+//!
+//! Validates that required ADR sections are not empty or contain only placeholder text.
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use std::sync::LazyLock;
+
+/// Common placeholder patterns that indicate incomplete content
+static PLACEHOLDER_PATTERNS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    vec![
+        "todo",
+        "tbd",
+        "to be determined",
+        "to be decided",
+        "fill in",
+        "placeholder",
+        "describe",
+        "add content",
+        "write here",
+        "...",
+        "xxx",
+        "[insert",
+        "<insert",
+        "lorem ipsum",
+    ]
+});
+
+/// ADR014: Validates that ADR sections have meaningful content
+///
+/// Checks that required sections (Context, Decision, etc.) are not empty
+/// and don't contain only placeholder text like "TODO" or "TBD".
+pub struct Adr014 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr014 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr014 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+
+    /// Check if content appears to be placeholder text
+    fn is_placeholder_content(content: &str) -> bool {
+        let content_lower = content.trim().to_lowercase();
+
+        // Empty or very short content
+        if content_lower.is_empty() || content_lower.len() < 3 {
+            return true;
+        }
+
+        // Check for placeholder patterns
+        for pattern in PLACEHOLDER_PATTERNS.iter() {
+            if content_lower.contains(pattern) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Get required section names based on format
+    fn required_sections(format: AdrFormat) -> Vec<&'static str> {
+        match format {
+            AdrFormat::Madr4 => vec!["context and problem statement", "decision outcome"],
+            AdrFormat::Nygard | AdrFormat::Auto => vec!["context", "decision", "consequences"],
+        }
+    }
+
+    /// Recursively collect text content from a node and its descendants
+    fn collect_text_content<'a>(node: &'a AstNode<'a>, content: &mut String) {
+        let node_data = node.data.borrow();
+        match &node_data.value {
+            NodeValue::Text(text) => {
+                content.push_str(text);
+                content.push(' ');
+            }
+            NodeValue::Code(code) => {
+                content.push_str(&code.literal);
+                content.push(' ');
+            }
+            NodeValue::SoftBreak | NodeValue::LineBreak => {
+                content.push(' ');
+            }
+            _ => {
+                // Recurse into children
+                for child in node.children() {
+                    Self::collect_text_content(child, content);
+                }
+            }
+        }
+    }
+}
+
+impl Rule for Adr014 {
+    fn id(&self) -> &'static str {
+        "ADR014"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-non-empty-sections"
+    }
+
+    fn description(&self) -> &'static str {
+        "ADR sections should have meaningful content, not placeholders"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+        let format = self.effective_format(&document.content);
+        let required = Self::required_sections(format);
+
+        // Parse AST locally
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        // Collect all H2 sections with their content
+        let mut sections: Vec<(String, usize, String)> = Vec::new(); // (name, line, content)
+        let mut current_section: Option<(String, usize)> = None;
+        let mut section_content = String::new();
+
+        // Iterate over top-level children to find H2 sections
+        for child in ast_node.children() {
+            let child_data = child.data.borrow();
+            let start_line = child_data.sourcepos.start.line;
+
+            if let NodeValue::Heading(heading) = &child_data.value {
+                if heading.level == 2 {
+                    // Save previous section
+                    if let Some((name, line)) = current_section.take() {
+                        sections.push((name, line, section_content.clone()));
+                    }
+
+                    // Extract heading text
+                    let mut heading_text = String::new();
+                    for text_child in child.children() {
+                        if let NodeValue::Text(text) = &text_child.data.borrow().value {
+                            heading_text.push_str(text);
+                        }
+                    }
+
+                    current_section = Some((heading_text.trim().to_string(), start_line));
+                    section_content.clear();
+                }
+            } else if current_section.is_some() {
+                // Collect content from non-heading nodes
+                Self::collect_text_content(child, &mut section_content);
+            }
+        }
+
+        // Save final section
+        if let Some((name, line)) = current_section {
+            sections.push((name, line, section_content));
+        }
+
+        // Check each section
+        for (section_name, section_line, content) in sections {
+            let section_lower = section_name.to_lowercase();
+            if required.iter().any(|r| section_lower.contains(r))
+                && Self::is_placeholder_content(&content)
+            {
+                violations.push(self.create_violation(
+                    format!(
+                        "Section '## {}' appears to be empty or contains only placeholder text",
+                        section_name
+                    ),
+                    section_line,
+                    1,
+                    Severity::Warning,
+                ));
+            }
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_nygard_sections() {
+        let content = r#"# 1. Use Rust for implementation
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to choose a programming language for our new service.
+The team has experience with multiple languages.
+
+## Decision
+
+We will use Rust for its memory safety and performance characteristics.
+
+## Consequences
+
+Team members will need Rust training.
+Build times may be longer initially.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr014::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid content"
+        );
+    }
+
+    #[test]
+    fn test_empty_context_section() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+Team needs training.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr014::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Context"));
+    }
+
+    #[test]
+    fn test_placeholder_todo() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+TODO: Fill in the context
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+TBD
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr014::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 2, "Expected violations for TODO and TBD");
+    }
+
+    #[test]
+    fn test_placeholder_ellipsis() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+...
+
+## Decision
+
+We will use Rust.
+
+## Consequences
+
+Good consequences here.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr014::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Context"));
+    }
+
+    #[test]
+    fn test_valid_madr_sections() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database for our application's persistence layer.
+The choice will affect performance and scalability.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL, because it provides ACID compliance
+and has excellent tooling support.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr014::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for valid MADR"
+        );
+    }
+
+    #[test]
+    fn test_empty_madr_context() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr014::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("Context and Problem Statement")
+        );
+    }
+
+    #[test]
+    fn test_is_placeholder_content() {
+        assert!(Adr014::is_placeholder_content(""));
+        assert!(Adr014::is_placeholder_content("   "));
+        assert!(Adr014::is_placeholder_content("TODO"));
+        assert!(Adr014::is_placeholder_content("TBD"));
+        assert!(Adr014::is_placeholder_content("To be determined"));
+        assert!(Adr014::is_placeholder_content("..."));
+        assert!(Adr014::is_placeholder_content("[Insert context here]"));
+        assert!(Adr014::is_placeholder_content("Lorem ipsum dolor sit amet"));
+        assert!(!Adr014::is_placeholder_content(
+            "We need to choose a database."
+        ));
+        assert!(!Adr014::is_placeholder_content(
+            "The team decided to use Rust."
+        ));
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr015.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr015.rs
@@ -1,0 +1,333 @@
+//! ADR015: Decision Drivers format
+//!
+//! Validates that the Decision Drivers section (MADR format) uses a bullet list.
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+
+/// ADR015: Validates that Decision Drivers section uses bullet list format
+///
+/// In MADR 4.0, the Decision Drivers section should be a bullet list to clearly
+/// enumerate the factors influencing the decision.
+pub struct Adr015 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr015 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr015 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+}
+
+impl Rule for Adr015 {
+    fn id(&self) -> &'static str {
+        "ADR015"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-decision-drivers-format"
+    }
+
+    fn description(&self) -> &'static str {
+        "Decision Drivers section should use a bullet list (MADR)"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Structure).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let format = self.effective_format(&document.content);
+
+        // This rule only applies to MADR format
+        if format == AdrFormat::Nygard {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        // Parse AST locally
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        let mut in_decision_drivers = false;
+        let mut decision_drivers_line: usize = 0;
+        let mut found_list = false;
+        let mut found_content = false;
+
+        for node in ast_node.descendants() {
+            let node_data = node.data.borrow();
+            let start_line = node_data.sourcepos.start.line;
+
+            match &node_data.value {
+                NodeValue::Heading(heading) if heading.level == 2 => {
+                    // Check if we were in Decision Drivers and leaving it
+                    if in_decision_drivers {
+                        if found_content && !found_list {
+                            violations.push(self.create_violation(
+                                "Decision Drivers section should use a bullet list".to_string(),
+                                decision_drivers_line,
+                                1,
+                                Severity::Info,
+                            ));
+                        }
+                        in_decision_drivers = false;
+                        found_list = false;
+                        found_content = false;
+                    }
+
+                    // Extract heading text
+                    let mut heading_text = String::new();
+                    for child in node.children() {
+                        if let NodeValue::Text(text) = &child.data.borrow().value {
+                            heading_text.push_str(text);
+                        }
+                    }
+
+                    let heading_lower = heading_text.trim().to_lowercase();
+                    if heading_lower == "decision drivers" {
+                        in_decision_drivers = true;
+                        decision_drivers_line = start_line;
+                    }
+                }
+                NodeValue::List(_) if in_decision_drivers => {
+                    found_list = true;
+                }
+                NodeValue::Paragraph if in_decision_drivers => {
+                    found_content = true;
+                }
+                _ => {}
+            }
+        }
+
+        // Check if we ended the document while in Decision Drivers
+        if in_decision_drivers && found_content && !found_list {
+            violations.push(self.create_violation(
+                "Decision Drivers section should use a bullet list".to_string(),
+                decision_drivers_line,
+                1,
+                Severity::Info,
+            ));
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_decision_drivers_list() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Drivers
+
+* Need ACID compliance
+* Team familiarity with SQL
+* Good tooling ecosystem
+
+## Considered Options
+
+* PostgreSQL
+* MySQL
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr015::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for bullet list"
+        );
+    }
+
+    #[test]
+    fn test_decision_drivers_paragraph_only() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Drivers
+
+We need ACID compliance and team familiarity with SQL databases.
+Also good tooling is important.
+
+## Considered Options
+
+* PostgreSQL
+* MySQL
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr015::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("bullet list"));
+    }
+
+    #[test]
+    fn test_no_decision_drivers_section() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr015::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "No violation if section is missing");
+    }
+
+    #[test]
+    fn test_nygard_format_skipped() {
+        // Nygard format doesn't have Decision Drivers, so rule shouldn't apply
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need a language.
+
+## Decision
+
+Use Rust.
+
+## Consequences
+
+Team training needed.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr015::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "Nygard format should be skipped");
+    }
+
+    #[test]
+    fn test_decision_drivers_with_dash_list() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Decision Drivers
+
+- Need ACID compliance
+- Team familiarity
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr015::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "Dash lists should also be valid");
+    }
+
+    #[test]
+    fn test_empty_decision_drivers() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Decision Drivers
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr015::default();
+        let violations = rule.check(&doc).unwrap();
+        // Empty section doesn't trigger this rule (ADR014 handles empty sections)
+        assert!(violations.is_empty());
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr016.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr016.rs
@@ -1,0 +1,424 @@
+//! ADR016: Considered Options format
+//!
+//! Validates that the Considered Options section lists at least 2 options.
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use comrak::nodes::{AstNode, ListType, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+
+/// ADR016: Validates that Considered Options section has multiple options
+///
+/// In MADR 4.0, the Considered Options section should list at least 2 options
+/// to demonstrate that alternatives were evaluated.
+pub struct Adr016 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+    /// Minimum number of options required (default: 2)
+    min_options: usize,
+}
+
+impl Default for Adr016 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+            min_options: 2,
+        }
+    }
+}
+
+impl Adr016 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self {
+            format,
+            min_options: 2,
+        }
+    }
+
+    /// Create a new rule with minimum options requirement
+    #[allow(dead_code)]
+    pub fn with_min_options(min_options: usize) -> Self {
+        Self {
+            format: AdrFormat::Auto,
+            min_options,
+        }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+
+    /// Count items in a list node
+    fn count_list_items<'a>(list_node: &'a AstNode<'a>) -> usize {
+        list_node
+            .children()
+            .filter(|child| matches!(child.data.borrow().value, NodeValue::Item(_)))
+            .count()
+    }
+}
+
+impl Rule for Adr016 {
+    fn id(&self) -> &'static str {
+        "ADR016"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-considered-options-format"
+    }
+
+    fn description(&self) -> &'static str {
+        "Considered Options section should list at least 2 options"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let format = self.effective_format(&document.content);
+
+        // This rule only applies to MADR format
+        if format == AdrFormat::Nygard {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        // Parse AST locally
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        let mut in_considered_options = false;
+        let mut considered_options_line: usize = 0;
+        let mut option_count: usize = 0;
+        let mut found_section = false;
+
+        for node in ast_node.descendants() {
+            let node_data = node.data.borrow();
+            let start_line = node_data.sourcepos.start.line;
+
+            match &node_data.value {
+                NodeValue::Heading(heading) if heading.level == 2 => {
+                    // Check if we were in Considered Options and leaving it
+                    if in_considered_options {
+                        found_section = true;
+                        if option_count < self.min_options {
+                            violations.push(self.create_violation(
+                                format!(
+                                    "Considered Options section should list at least {} options (found {})",
+                                    self.min_options, option_count
+                                ),
+                                considered_options_line,
+                                1,
+                                Severity::Info,
+                            ));
+                        }
+                        in_considered_options = false;
+                        option_count = 0;
+                    }
+
+                    // Extract heading text
+                    let mut heading_text = String::new();
+                    for child in node.children() {
+                        if let NodeValue::Text(text) = &child.data.borrow().value {
+                            heading_text.push_str(text);
+                        }
+                    }
+
+                    let heading_lower = heading_text.trim().to_lowercase();
+                    if heading_lower == "considered options" {
+                        in_considered_options = true;
+                        considered_options_line = start_line;
+                    }
+                }
+                NodeValue::List(list) if in_considered_options => {
+                    // Only count unordered lists (bullet lists)
+                    if matches!(list.list_type, ListType::Bullet) {
+                        option_count += Self::count_list_items(node);
+                    }
+                }
+                NodeValue::Heading(heading) if heading.level == 3 && in_considered_options => {
+                    // H3 headings under Considered Options also count as options
+                    // (MADR allows "### Option 1" format)
+                    option_count += 1;
+                }
+                _ => {}
+            }
+        }
+
+        // Check if we ended the document while in Considered Options
+        if in_considered_options {
+            found_section = true;
+            if option_count < self.min_options {
+                violations.push(self.create_violation(
+                    format!(
+                        "Considered Options section should list at least {} options (found {})",
+                        self.min_options, option_count
+                    ),
+                    considered_options_line,
+                    1,
+                    Severity::Info,
+                ));
+            }
+        }
+
+        // If section exists but is empty, that's also a violation
+        if found_section && option_count == 0 {
+            // Already reported above
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_considered_options() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Considered Options
+
+* PostgreSQL
+* MySQL
+* MongoDB
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for 3 options"
+        );
+    }
+
+    #[test]
+    fn test_minimum_two_options() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Considered Options
+
+* PostgreSQL
+* MySQL
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "2 options should be valid");
+    }
+
+    #[test]
+    fn test_only_one_option() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Considered Options
+
+* PostgreSQL
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("at least 2 options"));
+    }
+
+    #[test]
+    fn test_no_options() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Considered Options
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("found 0"));
+    }
+
+    #[test]
+    fn test_h3_style_options() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Considered Options
+
+### PostgreSQL
+
+A relational database.
+
+### MongoDB
+
+A document database.
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "H3 style options should be counted");
+    }
+
+    #[test]
+    fn test_no_section_no_violation() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "No violation if section missing");
+    }
+
+    #[test]
+    fn test_nygard_format_skipped() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need a language.
+
+## Decision
+
+Use Rust.
+
+## Consequences
+
+Training needed.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "Nygard format should be skipped");
+    }
+
+    #[test]
+    fn test_dash_list_options() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Considered Options
+
+- PostgreSQL
+- MySQL
+
+## Decision Outcome
+
+PostgreSQL chosen.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr016::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "Dash lists should work");
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/adr017.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr017.rs
@@ -1,0 +1,427 @@
+//! ADR017: Consequences structure
+//!
+//! Validates that the Consequences section (MADR format) distinguishes good/bad outcomes.
+
+use crate::adr::format::{AdrFormat, detect_format, is_adr_document};
+use comrak::nodes::{AstNode, NodeValue};
+use mdbook_lint_core::Document;
+use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
+use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex patterns for good/bad consequence markers
+static GOOD_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*\*?\s*good[,:]").expect("Invalid regex"));
+
+static BAD_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*\*?\s*bad[,:]").expect("Invalid regex"));
+
+static NEUTRAL_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*\*?\s*neutral[,:]").expect("Invalid regex"));
+
+/// ADR017: Validates that Consequences section has structured outcomes
+///
+/// In MADR 4.0, the Consequences section (often under "### Consequences" or
+/// "### Positive Consequences" / "### Negative Consequences") should distinguish
+/// between good and bad outcomes using "Good, because..." and "Bad, because..." format.
+pub struct Adr017 {
+    /// Configured format (default: auto-detect)
+    format: AdrFormat,
+}
+
+impl Default for Adr017 {
+    fn default() -> Self {
+        Self {
+            format: AdrFormat::Auto,
+        }
+    }
+}
+
+impl Adr017 {
+    /// Create a new rule with a specific format
+    #[allow(dead_code)]
+    pub fn with_format(format: AdrFormat) -> Self {
+        Self { format }
+    }
+
+    /// Get the effective format for the document
+    fn effective_format(&self, content: &str) -> AdrFormat {
+        match self.format {
+            AdrFormat::Auto => detect_format(content),
+            other => other,
+        }
+    }
+
+    /// Check if a line has good/bad/neutral structure
+    fn has_outcome_marker(text: &str) -> bool {
+        GOOD_PATTERN.is_match(text) || BAD_PATTERN.is_match(text) || NEUTRAL_PATTERN.is_match(text)
+    }
+}
+
+impl Rule for Adr017 {
+    fn id(&self) -> &'static str {
+        "ADR017"
+    }
+
+    fn name(&self) -> &'static str {
+        "adr-consequences-structure"
+    }
+
+    fn description(&self) -> &'static str {
+        "Consequences should distinguish good/bad outcomes (MADR)"
+    }
+
+    fn metadata(&self) -> RuleMetadata {
+        RuleMetadata::stable(RuleCategory::Content).introduced_in("mdbook-lint v0.14.0")
+    }
+
+    fn check_with_ast<'a>(
+        &self,
+        document: &Document,
+        _ast: Option<&'a AstNode<'a>>,
+    ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
+        // Skip non-ADR documents
+        if !is_adr_document(&document.content, Some(&document.path)) {
+            return Ok(Vec::new());
+        }
+
+        let format = self.effective_format(&document.content);
+
+        // This rule only applies to MADR format
+        if format == AdrFormat::Nygard {
+            return Ok(Vec::new());
+        }
+
+        let mut violations = Vec::new();
+
+        // Parse AST locally
+        let arena = comrak::Arena::new();
+        let ast_node = document.parse_ast(&arena);
+
+        // Track if we're in a consequences-related section
+        let mut in_consequences = false;
+        let mut consequences_line: usize = 0;
+        let mut found_structured_outcome = false;
+        let mut found_content = false;
+        let mut section_depth: u8 = 0;
+
+        for node in ast_node.descendants() {
+            let node_data = node.data.borrow();
+            let start_line = node_data.sourcepos.start.line;
+
+            match &node_data.value {
+                NodeValue::Heading(heading) => {
+                    // Check if we were in Consequences and leaving it
+                    if in_consequences && heading.level <= section_depth {
+                        if found_content && !found_structured_outcome {
+                            violations.push(self.create_violation(
+                                "Consequences section should use 'Good, because...' and 'Bad, because...' format to distinguish outcomes".to_string(),
+                                consequences_line,
+                                1,
+                                Severity::Info,
+                            ));
+                        }
+                        in_consequences = false;
+                        found_structured_outcome = false;
+                        found_content = false;
+                    }
+
+                    // Extract heading text
+                    let mut heading_text = String::new();
+                    for child in node.children() {
+                        if let NodeValue::Text(text) = &child.data.borrow().value {
+                            heading_text.push_str(text);
+                        }
+                    }
+
+                    let heading_lower = heading_text.trim().to_lowercase();
+
+                    // Check for consequences-related sections
+                    // MADR often uses "### Consequences" under "## Decision Outcome"
+                    // or separate "### Positive Consequences" / "### Negative Consequences"
+                    if heading_lower == "consequences"
+                        || heading_lower == "positive consequences"
+                        || heading_lower == "negative consequences"
+                    {
+                        // If we find positive/negative specific sections, that's structured
+                        if heading_lower.contains("positive") || heading_lower.contains("negative")
+                        {
+                            found_structured_outcome = true;
+                        } else {
+                            in_consequences = true;
+                            consequences_line = start_line;
+                            section_depth = heading.level;
+                        }
+                    }
+                }
+                NodeValue::Item(_) if in_consequences => {
+                    found_content = true;
+                    // Check item content for good/bad markers
+                    let mut item_text = String::new();
+                    for child in node.descendants() {
+                        if let NodeValue::Text(text) = &child.data.borrow().value {
+                            item_text.push_str(text);
+                        }
+                    }
+                    if Self::has_outcome_marker(&item_text) {
+                        found_structured_outcome = true;
+                    }
+                }
+                NodeValue::Paragraph if in_consequences => {
+                    found_content = true;
+                    // Also check paragraph content
+                    let mut para_text = String::new();
+                    for child in node.descendants() {
+                        if let NodeValue::Text(text) = &child.data.borrow().value {
+                            para_text.push_str(text);
+                        }
+                    }
+                    if Self::has_outcome_marker(&para_text) {
+                        found_structured_outcome = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Check if we ended the document while in Consequences
+        if in_consequences && found_content && !found_structured_outcome {
+            violations.push(self.create_violation(
+                "Consequences section should use 'Good, because...' and 'Bad, because...' format to distinguish outcomes".to_string(),
+                consequences_line,
+                1,
+                Severity::Info,
+            ));
+        }
+
+        Ok(violations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn create_test_document(content: &str) -> Document {
+        Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    #[test]
+    fn test_valid_structured_consequences() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+
+### Consequences
+
+* Good, because it provides ACID compliance
+* Good, because team has SQL experience
+* Bad, because requires more operational overhead
+* Neutral, because licensing is similar to alternatives
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr017::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Expected no violations for structured consequences"
+        );
+    }
+
+    #[test]
+    fn test_unstructured_consequences() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+
+### Consequences
+
+* Provides ACID compliance
+* Team has SQL experience
+* Requires more operational overhead
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr017::default();
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Good, because"));
+    }
+
+    #[test]
+    fn test_positive_negative_sections() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+
+### Positive Consequences
+
+* ACID compliance
+* Good tooling
+
+### Negative Consequences
+
+* Operational overhead
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr017::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Separate positive/negative sections should be valid"
+        );
+    }
+
+    #[test]
+    fn test_no_consequences_section() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL for persistence
+
+## Context and Problem Statement
+
+We need to select a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr017::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "No violation if section missing");
+    }
+
+    #[test]
+    fn test_nygard_format_skipped() {
+        let content = r#"# 1. Use Rust
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need a language.
+
+## Decision
+
+Use Rust.
+
+## Consequences
+
+Team needs training.
+Performance will improve.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr017::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "Nygard format should be skipped");
+    }
+
+    #[test]
+    fn test_mixed_case_markers() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Decision Outcome
+
+PostgreSQL chosen.
+
+### Consequences
+
+* GOOD, because ACID compliance
+* BAD, because operational overhead
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr017::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(violations.is_empty(), "Case insensitive matching");
+    }
+
+    #[test]
+    fn test_empty_consequences() {
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+Need a database.
+
+## Decision Outcome
+
+PostgreSQL chosen.
+
+### Consequences
+
+## Next Steps
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr017::default();
+        let violations = rule.check(&doc).unwrap();
+        // Empty section doesn't trigger - ADR014 handles that
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_has_outcome_marker() {
+        assert!(Adr017::has_outcome_marker("Good, because it works"));
+        assert!(Adr017::has_outcome_marker("* Good, because it works"));
+        assert!(Adr017::has_outcome_marker("Bad, because it's slow"));
+        assert!(Adr017::has_outcome_marker("Neutral, because no change"));
+        assert!(Adr017::has_outcome_marker("  Good: better performance"));
+        assert!(!Adr017::has_outcome_marker("It works well"));
+        assert!(!Adr017::has_outcome_marker("This is good for us"));
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/adr/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/mod.rs
@@ -92,6 +92,15 @@
 //! | ADR012 | adr-no-duplicate-numbers | Each ADR number is unique |
 //! | ADR013 | adr-valid-adr-links | Links to other ADRs point to existing files |
 //!
+//! ## Content Quality Rules
+//!
+//! | Rule | Name | Description |
+//! |------|------|-------------|
+//! | ADR014 | adr-non-empty-sections | Required sections should have meaningful content |
+//! | ADR015 | adr-decision-drivers-format | Decision Drivers should be a bullet list (MADR) |
+//! | ADR016 | adr-considered-options-format | Considered Options should list at least 2 options |
+//! | ADR017 | adr-consequences-structure | Consequences should distinguish good/bad outcomes (MADR) |
+//!
 //! # Configuration
 //!
 //! Rules can be configured in your `.mdbook-lint.toml`:
@@ -118,6 +127,10 @@ mod adr010;
 mod adr011;
 mod adr012;
 mod adr013;
+mod adr014;
+mod adr015;
+mod adr016;
+mod adr017;
 
 use crate::{RuleProvider, RuleRegistry};
 
@@ -134,6 +147,10 @@ pub use adr010::Adr010;
 pub use adr011::Adr011;
 pub use adr012::Adr012;
 pub use adr013::Adr013;
+pub use adr014::Adr014;
+pub use adr015::Adr015;
+pub use adr016::Adr016;
+pub use adr017::Adr017;
 pub use format::AdrFormat;
 pub use frontmatter::AdrFrontmatter;
 
@@ -150,7 +167,7 @@ impl RuleProvider for AdrRuleProvider {
     }
 
     fn description(&self) -> &'static str {
-        "Architecture Decision Record linting rules (ADR001-ADR013)"
+        "Architecture Decision Record linting rules (ADR001-ADR017)"
     }
 
     fn version(&self) -> &'static str {
@@ -169,6 +186,12 @@ impl RuleProvider for AdrRuleProvider {
         registry.register(Box::new(Adr008::default()));
         registry.register(Box::new(Adr009::default()));
 
+        // Content quality rules
+        registry.register(Box::new(Adr014::default()));
+        registry.register(Box::new(Adr015::default()));
+        registry.register(Box::new(Adr016::default()));
+        registry.register(Box::new(Adr017::default()));
+
         // Collection rules (multi-document)
         registry.register_collection_rule(Box::new(Adr010));
         registry.register_collection_rule(Box::new(Adr011));
@@ -179,7 +202,8 @@ impl RuleProvider for AdrRuleProvider {
     fn rule_ids(&self) -> Vec<&'static str> {
         vec![
             "ADR001", "ADR002", "ADR003", "ADR004", "ADR005", "ADR006", "ADR007", "ADR008",
-            "ADR009", "ADR010", "ADR011", "ADR012", "ADR013",
+            "ADR009", "ADR010", "ADR011", "ADR012", "ADR013", "ADR014", "ADR015", "ADR016",
+            "ADR017",
         ]
     }
 }


### PR DESCRIPTION
## Summary

- Adds ADR014-ADR017: Content quality rules for validating ADR document structure and content

## New Rules

| Rule | Name | Description | Severity |
|------|------|-------------|----------|
| ADR014 | adr-non-empty-sections | Required sections should have meaningful content, not placeholders | Warning |
| ADR015 | adr-decision-drivers-format | Decision Drivers should be a bullet list (MADR) | Info |
| ADR016 | adr-considered-options-format | Considered Options should list at least 2 options (MADR) | Info |
| ADR017 | adr-consequences-structure | Consequences should distinguish good/bad outcomes (MADR) | Info |

### Rule Details

**ADR014** detects placeholder text in required sections:
- Empty sections
- TODO, TBD, "to be determined"
- Ellipsis (...)
- Lorem ipsum
- "[Insert here]" style placeholders

**ADR015** ensures Decision Drivers uses bullet list format for clear enumeration of factors.

**ADR016** ensures Considered Options lists at least 2 alternatives to demonstrate evaluation of options.

**ADR017** checks for structured consequence format using "Good, because..." and "Bad, because..." markers, or separate Positive/Negative Consequences sections.

## Test plan

- [x] All unit tests pass (1454 tests, +29 new)
- [x] All integration tests pass
- [x] Clippy clean
- [x] Format check passes