### PR TITLE
fix: trigger release binaries from release-plz workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,6 +3,12 @@ name: Release Binaries
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.13.7)'
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -76,12 +82,17 @@ jobs:
           cd ..\..\..
           echo "ASSET=${{ matrix.archive }}" >> $env:GITHUB_ENV
 
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/octet-stream
+        run: gh release upload ${{ steps.tag.outputs.tag }} ${{ env.ASSET }} --clobber

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,7 @@ permissions:
   pull-requests: write
   contents: write
   packages: write # Required for crates.io publishing
+  actions: write # Required to trigger other workflows
 
 on:
   push:
@@ -62,3 +63,31 @@ jobs:
           homebrew-tap: joshrotenberg/homebrew-brew
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+
+  build-binaries:
+    name: Build Release Binaries
+    runs-on: ubuntu-latest
+    needs: release-plz
+    if: ${{ needs.release-plz.outputs.releases != '[]' && needs.release-plz.outputs.releases != '' }}
+    steps:
+      - name: Parse release info
+        id: parse
+        run: |
+          VERSION=$(echo '${{ needs.release-plz.outputs.releases }}' | jq -r '.[] | select(.package_name == "mdbook-lint") | .version')
+          if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
+            echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
+            echo "Found mdbook-lint release: v${VERSION}"
+          else
+            echo "No mdbook-lint release found"
+            echo "tag=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Trigger binary builds
+        if: ${{ steps.parse.outputs.tag != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-binaries.yml \
+            --repo ${{ github.repository }} \
+            --field tag=${{ steps.parse.outputs.tag }}
+          echo "Triggered release-binaries workflow for ${{ steps.parse.outputs.tag }}"


### PR DESCRIPTION
## Summary
- Fixes release binary builds that stopped working after v0.11.7
- When release-plz creates releases using `GITHUB_TOKEN`, GitHub doesn't trigger other workflows (security feature)
- Now the release-plz workflow explicitly triggers the binary build workflow after creating a release

## Changes
- **release-binaries.yml**: Added `workflow_dispatch` trigger with `tag` input parameter
- **release-binaries.yml**: Replaced deprecated `actions/upload-release-asset@v1` with `gh release upload`
- **release-plz.yml**: Added `actions: write` permission to allow triggering other workflows
- **release-plz.yml**: Added `build-binaries` job that triggers binary builds after release

## Test plan
- [ ] Merge PR and verify binary workflow can be manually triggered
- [ ] Manually run: `gh workflow run release-binaries.yml --field tag=v0.13.7` to backfill missing assets
- [ ] Future releases will automatically trigger binary builds

Fixes #368