### PR TITLE
fix: use hardcoded GitHub URL in cliff.toml template

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -15,10 +15,6 @@ All notable changes to this project will be documented in this file.
 """
 # Template for each release section
 body = """
-{%- macro remote_url() -%}
-  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
-{%- endmacro -%}
-
 {% if version -%}
 ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
@@ -29,9 +25,9 @@ body = """
 ### {{ group | upper_first }}
 {% for commit in commits %}
 {%- if commit.scope -%}
-- *({{ commit.scope }})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))
+- *({{ commit.scope }})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/joshrotenberg/mdbook-lint/commit/{{ commit.id }}))
 {% else -%}
-- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/joshrotenberg/mdbook-lint/commit/{{ commit.id }}))
 {% endif -%}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Summary
Fixes release-plz changelog generation failure caused by undefined template variables.

## Problem
The git-cliff template was using `remote.github.owner` and `remote.github.repo` variables, but these aren't available in the context when release-plz runs git-cliff:

```
Template render error:
Variable `remote.github.owner` not found in context while rendering 'body'
```

## Solution
Replace the macro using template variables with hardcoded GitHub URLs.

## Test plan
- [ ] release-plz workflow should now generate changelog successfully