### PR TITLE
fix: add workflow_dispatch trigger to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,12 @@ on:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.14.0)'
+        required: true
+        type: string
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -50,14 +56,15 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      tag: ${{ !github.event.pull_request && (inputs.tag || github.ref_name) || '' }}
+      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', inputs.tag || github.ref_name) || '' }}
       publishing: ${{ !github.event.pull_request }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
           submodules: recursive
       - name: Install dist


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to the cargo-dist release workflow to allow manual triggering.

## Problem
When release-plz creates a tag using `GITHUB_TOKEN`, GitHub doesn't trigger other workflows that listen for tag pushes (security feature to prevent recursive triggers). This means the cargo-dist release workflow never runs automatically.

## Solution
Add `workflow_dispatch` with a `tag` input so the release can be triggered manually:

```bash
gh workflow run release.yml -f tag=v0.14.0
```

## Changes
- Add `workflow_dispatch` trigger with `tag` input
- Update plan job outputs to use `inputs.tag` when available
- Update checkout step to use the input tag ref

## Test plan
- [ ] workflow_dispatch trigger works with tag input