### PR TITLE
fix: use PAT for release-plz to trigger cargo-dist

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,9 +30,10 @@ jobs:
         id: release-plz
         uses: release-plz/action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT instead of GITHUB_TOKEN so that tag pushes trigger cargo-dist workflow
+          # (GitHub prevents GITHUB_TOKEN from triggering other workflows)
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      # Note: Binary builds are handled by cargo-dist (release.yml) which triggers on tags
 
   update-homebrew:
     name: Update Homebrew Formula


### PR DESCRIPTION
## Summary
Use a Personal Access Token instead of `GITHUB_TOKEN` for release-plz so that tag pushes trigger the cargo-dist workflow automatically.

## Problem
GitHub prevents `GITHUB_TOKEN` from triggering other workflows (security feature to prevent infinite loops). When release-plz creates a tag, cargo-dist never sees it.

## Solution
Use a PAT (`RELEASE_TOKEN`) which doesn't have this restriction.

## Setup Required
After merging, create a fine-grained PAT:
1. Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
2. Create token with:
   - Repository access: Only select `joshrotenberg/mdbook-lint`
   - Permissions: Contents (read/write), Pull requests (read/write)
3. Add as repository secret named `RELEASE_TOKEN`

Supersedes #379 (workflow_dispatch approach).

## Test plan
- [ ] Next release-plz run should trigger cargo-dist automatically