### PR TITLE
fix: remove dry-run package checks for workspace-dependent crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,13 +230,7 @@ jobs:
         uses: swatinem/rust-cache@v2
 
       - name: Dry run package core
+        # Only check core - rulesets and cli depend on workspace crates
+        # which may not be published yet during version bumps.
+        # release-plz handles correct publish order.
         run: cargo package --allow-dirty -p mdbook-lint-core
-
-      - name: Dry run package rulesets
-        # --no-verify skips build verification against crates.io deps
-        # Required because rulesets uses new features from core that aren't published yet
-        # Actual publish order is handled correctly by release-plz
-        run: cargo package --allow-dirty --no-verify -p mdbook-lint-rulesets
-
-      - name: Dry run package CLI
-        run: cargo package --allow-dirty --no-verify -p mdbook-lint


### PR DESCRIPTION
## Summary
Removes the dry-run package checks for rulesets and cli crates that depend on workspace crates.

## Problem
During version bumps, `cargo package` fails because the new version of `mdbook-lint-core` isn't published to crates.io yet:

```
failed to select a version for the requirement `mdbook-lint-core = "^0.14.1"`
candidate versions found which didn't match: 0.14.0, 0.13.7, ...
```

The `--no-verify` flag doesn't help because dependency resolution still happens during packaging, not just during verification.

## Solution
Only run the dry-run check for `mdbook-lint-core` (which has no internal workspace dependencies). release-plz handles the correct publish order when actually releasing.

## Test plan
- [ ] CI passes on release PRs