### PR TITLE
chore: release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-02-02
+
+### Bug Fixes
+- Update Dockerfile for Rust edition 2024 and add Docker docs ([#387](https://github.com/joshrotenberg/mdbook-lint/pull/387)) ([b6aa86b](https://github.com/joshrotenberg/mdbook-lint/commit/b6aa86b45261c2cbf89ec8c313cf0bdda4502f16))
+
+
+
 ## [0.14.1] - 2026-02-01
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -37,8 +37,8 @@ mdbook = { version = "0.4", default-features = false }
 walkdir = "2.3"
 
 # Internal workspace crates
-mdbook-lint-core = { version = "0.14.1", path = "crates/mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.14.1", path = "crates/mdbook-lint-rulesets" }
+mdbook-lint-core = { version = "0.14.2", path = "crates/mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.14.2", path = "crates/mdbook-lint-rulesets" }
 
 # Dev dependencies
 tempfile = "3.0"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-lint-core`: 0.14.1 -> 0.14.2
* `mdbook-lint-rulesets`: 0.14.1 -> 0.14.2
* `mdbook-lint`: 0.14.1 -> 0.14.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `mdbook-lint`

<blockquote>

## [0.14.2] - 2026-02-02

### Bug Fixes
- Update Dockerfile for Rust edition 2024 and add Docker docs ([#387](https://github.com/joshrotenberg/mdbook-lint/pull/387)) ([b6aa86b](https://github.com/joshrotenberg/mdbook-lint/commit/b6aa86b45261c2cbf89ec8c313cf0bdda4502f16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).