### PR TITLE
docs: add RELEASE.md documenting the release process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.github/
+*.md
+!README.md
+LICENSE*
+.gitignore
+.cargo/
+tests/
+docs/
+*.log

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v0.14.1)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Build stage
+FROM rust:1.84-slim-bookworm AS builder
+
+WORKDIR /build
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy source
+COPY . .
+
+# Build release binary
+RUN cargo build --release --bin mdbook-lint
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+# Install runtime dependencies (CA certificates for any HTTPS operations)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy binary from builder
+COPY --from=builder /build/target/release/mdbook-lint /usr/local/bin/mdbook-lint
+
+# Create non-root user
+RUN useradd -m -s /bin/bash linter
+USER linter
+
+WORKDIR /workspace
+
+ENTRYPOINT ["mdbook-lint"]
+CMD ["--help"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,8 +61,10 @@ release-plz analyzes commits
 | `release-plz.toml` | release-plz configuration |
 | `dist-workspace.toml` | cargo-dist configuration |
 | `cliff.toml` | git-cliff changelog template |
+| `Dockerfile` | Docker image build |
 | `.github/workflows/release-plz.yml` | release-plz workflow |
 | `.github/workflows/release.yml` | cargo-dist workflow |
+| `.github/workflows/docker.yml` | Docker image build/push workflow |
 
 ## Commit Convention
 
@@ -213,6 +215,38 @@ Each binary archive also has a corresponding `.sha256` checksum file.
 A version tag matching the release (e.g., `v0.14.1`):
 ```bash
 git tag -l "v*" | tail -1
+```
+
+### Docker Image
+
+A Docker image pushed to GitHub Container Registry:
+```bash
+# Pull latest
+docker pull ghcr.io/joshrotenberg/mdbook-lint:latest
+
+# Pull specific version
+docker pull ghcr.io/joshrotenberg/mdbook-lint:0.14.1
+```
+
+Available tags:
+- `latest` - Most recent release
+- `X.Y.Z` - Specific version (e.g., `0.14.1`)
+- `X.Y` - Minor version (e.g., `0.14`)
+- `X` - Major version (e.g., `0`)
+
+Platforms: `linux/amd64`, `linux/arm64`
+
+#### Docker Usage
+
+```bash
+# Lint files in current directory
+docker run --rm -v $(pwd):/workspace ghcr.io/joshrotenberg/mdbook-lint lint .
+
+# List rules
+docker run --rm ghcr.io/joshrotenberg/mdbook-lint rules
+
+# Run as mdBook preprocessor
+docker run --rm -i ghcr.io/joshrotenberg/mdbook-lint preprocessor < input.json
 ```
 
 ## Checking Release Status


### PR DESCRIPTION
## Summary
Adds comprehensive documentation for the release process and Docker support.

## Contents

### RELEASE.md
- Overview of tools (release-plz, cargo-dist, git-cliff)
- Automated flow diagram
- Configuration files reference
- Commit convention guide
- Required secrets and how to set them up
- Manual release steps (fallback)
- Troubleshooting common issues
- Expected artifacts checklist (crates.io, GitHub Release, Docker)
- Commands for checking release status

### Docker Support
- `Dockerfile` - Multi-stage build for small final image (~50MB)
- `.dockerignore` - Reduces build context
- `.github/workflows/docker.yml` - Builds and pushes to ghcr.io on releases

Docker images available at `ghcr.io/joshrotenberg/mdbook-lint` with:
- Version tags (`0.14.1`, `0.14`, `0`)
- `latest` tag

Platforms: `linux/amd64`, `linux/arm64`

## Usage
```bash
docker run --rm -v $(pwd):/workspace ghcr.io/joshrotenberg/mdbook-lint lint .
```