### PR TITLE
fix: update Dockerfile for Rust edition 2024 and add Docker docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM rust:1.84-slim-bookworm AS builder
+# Requires Rust 1.85+ for edition 2024
+FROM rust:slim-bookworm AS builder
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,25 @@ Download the latest release for your platform from [GitHub Releases](https://git
 
 Extract and add to your PATH, or use with GitHub Actions (see [CI Integration](#ci-integration)).
 
-Verify the installation:
+### Docker
+
+```bash
+# Pull from GitHub Container Registry
+docker pull ghcr.io/joshrotenberg/mdbook-lint:latest
+
+# Lint files in current directory
+docker run --rm -v $(pwd):/workspace ghcr.io/joshrotenberg/mdbook-lint lint .
+
+# Show available rules
+docker run --rm ghcr.io/joshrotenberg/mdbook-lint rules
+
+# Use a specific version
+docker run --rm -v $(pwd):/workspace ghcr.io/joshrotenberg/mdbook-lint:0.14.1 lint .
+```
+
+Available for `linux/amd64` and `linux/arm64`.
+
+### Verify Installation
 
 ```bash
 mdbook-lint --version


### PR DESCRIPTION
## Summary
Fixes the Dockerfile to work with Rust edition 2024 and adds Docker documentation to README.

## Changes

### Dockerfile
- Change `rust:1.84-slim-bookworm` to `rust:slim-bookworm`
- Rust 1.85+ is required for edition 2024 support
- Tested locally - builds successfully

### README
- Add Docker installation section with usage examples
- Document available platforms (linux/amd64, linux/arm64)

## Test Results
```bash
$ docker build -t mdbook-lint:test .
# ... builds successfully ...

$ docker run --rm mdbook-lint:test --version
mdbook-lint 0.14.1

$ docker run --rm -v $(pwd):/workspace mdbook-lint:test lint README.md
# ... linting works ...
```

Image size: ~164MB