### PR TITLE
docs: update Docker version examples to 0.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run --rm -v $(pwd):/workspace ghcr.io/joshrotenberg/mdbook-lint lint .
 docker run --rm ghcr.io/joshrotenberg/mdbook-lint rules
 
 # Use a specific version
-docker run --rm -v $(pwd):/workspace ghcr.io/joshrotenberg/mdbook-lint:0.14.1 lint .
+docker run --rm -v $(pwd):/workspace ghcr.io/joshrotenberg/mdbook-lint:0.14.2 lint .
 ```
 
 Available for `linux/amd64` and `linux/arm64`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -225,7 +225,7 @@ A Docker image pushed to GitHub Container Registry:
 docker pull ghcr.io/joshrotenberg/mdbook-lint:latest
 
 # Pull specific version
-docker pull ghcr.io/joshrotenberg/mdbook-lint:0.14.1
+docker pull ghcr.io/joshrotenberg/mdbook-lint:0.14.2
 ```
 
 Available tags:


### PR DESCRIPTION
Docker images were first published with v0.14.2. Updates examples to use this version instead of the non-existent 0.14.1 image.