### PR TITLE
chore: release v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.3] - 2026-03-04
+
+### Bug Fixes
+- Resolve ADR010 and ADR014 false positives ([#394](https://github.com/joshrotenberg/mdbook-lint/pull/394)) ([1463c78](https://github.com/joshrotenberg/mdbook-lint/commit/1463c786cb0ee7e2816df5c16e51b08e7e1b21a1))
+- Resolve MD058 and MD041 false positives ([#395](https://github.com/joshrotenberg/mdbook-lint/pull/395)) ([36b0557](https://github.com/joshrotenberg/mdbook-lint/commit/36b05578aeb07de701398ca1b8b34344d970adad))
+
+
+### Documentation
+- Update Docker version examples to 0.14.2 ([#388](https://github.com/joshrotenberg/mdbook-lint/pull/388)) ([479d545](https://github.com/joshrotenberg/mdbook-lint/commit/479d5452d475b69b0b6f5f5038dbdf30addf401b))
+
+
+
 ## [0.14.2] - 2026-02-02
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -37,8 +37,8 @@ mdbook = { version = "0.4", default-features = false }
 walkdir = "2.3"
 
 # Internal workspace crates
-mdbook-lint-core = { version = "0.14.2", path = "crates/mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.14.2", path = "crates/mdbook-lint-rulesets" }
+mdbook-lint-core = { version = "0.14.3", path = "crates/mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.14.3", path = "crates/mdbook-lint-rulesets" }
 
 # Dev dependencies
 tempfile = "3.0"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-lint-core`: 0.14.2 -> 0.14.3
* `mdbook-lint-rulesets`: 0.14.2 -> 0.14.3 (✓ API compatible changes)
* `mdbook-lint`: 0.14.2 -> 0.14.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `mdbook-lint`

<blockquote>

## [0.14.3] - 2026-03-04

### Bug Fixes
- Resolve ADR010 and ADR014 false positives ([#394](https://github.com/joshrotenberg/mdbook-lint/pull/394)) ([1463c78](https://github.com/joshrotenberg/mdbook-lint/commit/1463c786cb0ee7e2816df5c16e51b08e7e1b21a1))
- Resolve MD058 and MD041 false positives ([#395](https://github.com/joshrotenberg/mdbook-lint/pull/395)) ([36b0557](https://github.com/joshrotenberg/mdbook-lint/commit/36b05578aeb07de701398ca1b8b34344d970adad))


### Documentation
- Update Docker version examples to 0.14.2 ([#388](https://github.com/joshrotenberg/mdbook-lint/pull/388)) ([479d545](https://github.com/joshrotenberg/mdbook-lint/commit/479d5452d475b69b0b6f5f5038dbdf30addf401b))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).