### PR TITLE
chore: release v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.4] - 2026-03-08
+
+
 ## [0.14.3] - 2026-03-04
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.4] - 2026-06-03
+
+### Bug Fixes
+- Resolve false positives for Unicode headings in MD051, CONTENT006, MDBOOK006 ([#403](https://github.com/joshrotenberg/mdbook-lint/pull/403)) ([828fa4f](https://github.com/joshrotenberg/mdbook-lint/commit/828fa4fea0ff198fe331ec8e741c19e21c41b543))
+
+
+### Features
+- Expose ADR ruleset (ADR001-ADR017) in CLI ([#402](https://github.com/joshrotenberg/mdbook-lint/pull/402)) ([4c73b32](https://github.com/joshrotenberg/mdbook-lint/commit/4c73b32f9f21e92c8efa71148939535132dfbf41))
+- ADR009 validates number field in MADR frontmatter ([#405](https://github.com/joshrotenberg/mdbook-lint/pull/405)) ([b70c7b6](https://github.com/joshrotenberg/mdbook-lint/commit/b70c7b6185af33e7059487f5c677bb0d076356fd))
+
+
+
 ## [0.14.3] - 2026-03-04
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -37,8 +37,8 @@ mdbook = { version = "0.4", default-features = false }
 walkdir = "2.3"
 
 # Internal workspace crates
-mdbook-lint-core = { version = "0.14.3", path = "crates/mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.14.3", path = "crates/mdbook-lint-rulesets" }
+mdbook-lint-core = { version = "0.14.4", path = "crates/mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.14.4", path = "crates/mdbook-lint-rulesets" }
 
 # Dev dependencies
 tempfile = "3.0"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-lint-core`: 0.14.3 -> 0.14.4
* `mdbook-lint-rulesets`: 0.14.3 -> 0.14.4 (✓ API compatible changes)
* `mdbook-lint`: 0.14.3 -> 0.14.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `mdbook-lint`

<blockquote>

## [0.14.4] - 2026-06-03

### Bug Fixes
- Resolve false positives for Unicode headings in MD051, CONTENT006, MDBOOK006 ([#403](https://github.com/joshrotenberg/mdbook-lint/pull/403)) ([828fa4f](https://github.com/joshrotenberg/mdbook-lint/commit/828fa4fea0ff198fe331ec8e741c19e21c41b543))


### Features
- Expose ADR ruleset (ADR001-ADR017) in CLI ([#402](https://github.com/joshrotenberg/mdbook-lint/pull/402)) ([4c73b32](https://github.com/joshrotenberg/mdbook-lint/commit/4c73b32f9f21e92c8efa71148939535132dfbf41))
- ADR009 validates number field in MADR frontmatter ([#405](https://github.com/joshrotenberg/mdbook-lint/pull/405)) ([b70c7b6](https://github.com/joshrotenberg/mdbook-lint/commit/b70c7b6185af33e7059487f5c677bb0d076356fd))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).