### PR TITLE
feat: expose ADR ruleset (ADR001-ADR017) in CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           # Lint module-level docs in Rust source files
           # Disable content rules as they trigger on rule docs that describe those patterns
-          ./bin/mdbook-lint rustdoc crates/ --disable CONTENT001,CONTENT002,CONTENT006,CONTENT007,CONTENT010,CONTENT011,MD012,MD030,MD044,MD053
+          ./bin/mdbook-lint rustdoc crates/ --disable CONTENT001,CONTENT002,CONTENT006,CONTENT007,CONTENT010,CONTENT011,MD012,MD030,MD044,MD053,ADR001,ADR002,ADR003,ADR004,ADR005,ADR006,ADR007,ADR008,ADR009,ADR010,ADR011,ADR012,ADR013,ADR014,ADR015,ADR016,ADR017
 
       - name: Test comprehensive fixtures
         run: |

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -20,9 +20,10 @@ name = "debug_preprocessor"
 path = "src/bin/debug_preprocessor.rs"
 
 [features]
-default = ["lsp", "content"]
+default = ["lsp", "content", "adr"]
 lsp = ["tower-lsp", "tokio"]
 content = ["mdbook-lint-rulesets/content"]  # Enable content quality rules (CONTENT001-005)
+adr = ["mdbook-lint-rulesets/adr"]  # Enable ADR rules (ADR001-ADR017)
 
 [dependencies]
 # Workspace dependencies

--- a/crates/mdbook-lint-cli/src/lsp_server.rs
+++ b/crates/mdbook-lint-cli/src/lsp_server.rs
@@ -8,6 +8,8 @@
 
 use crate::config::Config;
 use mdbook_lint_core::{Document, LintEngine, PluginRegistry, Severity, Violation};
+#[cfg(feature = "adr")]
+use mdbook_lint_rulesets::AdrRuleProvider;
 use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -32,6 +34,10 @@ impl MdBookLintServer {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
+        #[cfg(feature = "adr")]
+        registry
+            .register_provider(Box::new(AdrRuleProvider))
+            .expect("Failed to register ADR rules");
         let engine = registry.create_engine().expect("Failed to create engine");
 
         Self {

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -13,6 +13,8 @@ use mdbook_lint_core::{
     error::Result,
     rule::{RuleCategory, RuleStability},
 };
+#[cfg(feature = "adr")]
+use mdbook_lint_rulesets::AdrRuleProvider;
 #[cfg(feature = "content")]
 use mdbook_lint_rulesets::ContentRuleProvider;
 use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
@@ -909,16 +911,22 @@ fn run_cli_mode(
         registry.register_provider(Box::new(StandardRuleProvider))?;
         #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
+        #[cfg(feature = "adr")]
+        registry.register_provider(Box::new(AdrRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
         #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
+        #[cfg(feature = "adr")]
+        registry.register_provider(Box::new(AdrRuleProvider))?;
     } else {
         // Default: use all rules (standard + mdBook + content if enabled)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
         #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
+        #[cfg(feature = "adr")]
+        registry.register_provider(Box::new(AdrRuleProvider))?;
     }
 
     let engine = registry.create_engine_with_config(Some(&config.core))?;
@@ -1245,16 +1253,22 @@ fn run_rules_command(
         registry.register_provider(Box::new(StandardRuleProvider))?;
         #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
+        #[cfg(feature = "adr")]
+        registry.register_provider(Box::new(AdrRuleProvider))?;
     } else if mdbook_only {
         registry.register_provider(Box::new(MdBookRuleProvider))?;
         #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
+        #[cfg(feature = "adr")]
+        registry.register_provider(Box::new(AdrRuleProvider))?;
     } else {
         // Default: show all rules (standard + mdBook + content if enabled)
         registry.register_provider(Box::new(StandardRuleProvider))?;
         registry.register_provider(Box::new(MdBookRuleProvider))?;
         #[cfg(feature = "content")]
         registry.register_provider(Box::new(ContentRuleProvider))?;
+        #[cfg(feature = "adr")]
+        registry.register_provider(Box::new(AdrRuleProvider))?;
     }
 
     let engine = registry.create_engine()?;
@@ -1439,6 +1453,8 @@ fn run_check_command(config_path: &PathBuf) -> Result<()> {
     registry.register_provider(Box::new(MdBookRuleProvider))?;
     #[cfg(feature = "content")]
     registry.register_provider(Box::new(ContentRuleProvider))?;
+    #[cfg(feature = "adr")]
+    registry.register_provider(Box::new(AdrRuleProvider))?;
     let engine = registry.create_engine()?;
 
     let available_rules: std::collections::HashSet<String> = engine
@@ -1778,6 +1794,8 @@ fn run_rustdoc_mode(
     registry.register_provider(Box::new(StandardRuleProvider))?;
     #[cfg(feature = "content")]
     registry.register_provider(Box::new(ContentRuleProvider))?;
+    #[cfg(feature = "adr")]
+    registry.register_provider(Box::new(AdrRuleProvider))?;
 
     let engine = registry.create_engine_with_config(Some(&config.core))?;
 
@@ -1936,6 +1954,10 @@ fn get_all_available_rule_ids() -> Vec<String> {
     #[cfg(feature = "content")]
     registry
         .register_provider(Box::new(ContentRuleProvider))
+        .unwrap();
+    #[cfg(feature = "adr")]
+    registry
+        .register_provider(Box::new(AdrRuleProvider))
         .unwrap();
 
     // Create engine to get available rules
@@ -2135,6 +2157,10 @@ mod tests {
         #[cfg(feature = "content")]
         all_registry
             .register_provider(Box::new(ContentRuleProvider))
+            .unwrap();
+        #[cfg(feature = "adr")]
+        all_registry
+            .register_provider(Box::new(AdrRuleProvider))
             .unwrap();
         let all_engine = all_registry.create_engine().unwrap();
         let all_rules = all_engine.available_rules().len();

--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -7,6 +7,8 @@ use mdbook_lint_core::RuleCategory;
 use mdbook_lint_core::{
     Document, LintEngine, MdBookLintError, PluginRegistry, Severity, Violation,
 };
+#[cfg(feature = "adr")]
+use mdbook_lint_rulesets::AdrRuleProvider;
 #[cfg(feature = "content")]
 use mdbook_lint_rulesets::ContentRuleProvider;
 use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
@@ -38,6 +40,10 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(ContentRuleProvider))
             .expect("Failed to register content rules");
+        #[cfg(feature = "adr")]
+        registry
+            .register_provider(Box::new(AdrRuleProvider))
+            .expect("Failed to register ADR rules");
         let engine = registry.create_engine().expect("Failed to create engine");
 
         Self {
@@ -61,6 +67,10 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(ContentRuleProvider))
             .expect("Failed to register content rules");
+        #[cfg(feature = "adr")]
+        registry
+            .register_provider(Box::new(AdrRuleProvider))
+            .expect("Failed to register ADR rules");
         let engine = registry.create_engine().expect("Failed to create engine");
 
         Self {

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook004.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook004.rs
@@ -211,7 +211,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mdbook004_unicode_normalization(){
+    fn test_mdbook004_unicode_normalization() {
         let content: String = MarkdownBuilder::new()
             .line("# Introduction")
             .blank_line()


### PR DESCRIPTION
## Summary

- Wire `AdrRuleProvider` into the CLI, preprocessor, and LSP server following the existing `ContentRuleProvider` pattern
- Add `adr = ["mdbook-lint-rulesets/adr"]` feature to `crates/mdbook-lint-cli/Cargo.toml` and add it to `default`
- Register `AdrRuleProvider` at every site where `ContentRuleProvider` is registered, gated on `#[cfg(feature = "adr")]`

Closes #401.

## Test plan

- [ ] `cargo build --release --all-features` succeeds
- [ ] `cargo test --lib --all-features` passes
- [ ] `./target/release/mdbook-lint rules | grep -c "^ADR"` outputs `17`
- [ ] `./target/release/mdbook-lint lint --enable ADR001 /dev/null` runs without error