### PR TITLE
fix: resolve false positives for Unicode headings in MD051, CONTENT006, MDBOOK006

### DIFF
--- a/crates/mdbook-lint-rulesets/src/content/content006.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content006.rs
@@ -41,7 +41,7 @@ impl CONTENT006 {
 
         for ch in text.chars() {
             if ch.is_alphanumeric() {
-                anchor.push(ch.to_ascii_lowercase());
+                anchor.extend(ch.to_lowercase());
             } else if ch == '-' || ch == '_' {
                 // Preserve hyphens and underscores as-is
                 anchor.push(ch);
@@ -223,6 +223,24 @@ mod tests {
         assert_eq!(CONTENT006::generate_anchor("a_title"), "a_title");
         // Multiple spaces become multiple hyphens
         assert_eq!(CONTENT006::generate_anchor("a  b"), "a--b");
+    }
+
+    #[test]
+    fn test_issue_399_unicode_anchors() {
+        // Unicode/umlaut headings must use Unicode-aware lowercasing
+        assert_eq!(CONTENT006::generate_anchor("Übungen"), "übungen");
+        assert_eq!(CONTENT006::generate_anchor("Ärger"), "ärger");
+        assert_eq!(CONTENT006::generate_anchor("Überprüfung"), "überprüfung");
+
+        // Full lint pass: valid link to Unicode heading must not false-positive
+        let content = "# Übungen\n\n[link](#übungen)\n";
+        let doc = create_test_document(content);
+        let violations = CONTENT006.check(&doc).unwrap();
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations for Unicode heading link, got: {violations:#?}"
+        );
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook004.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook004.rs
@@ -211,7 +211,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mdbook004_unicode_normalization(){
+    fn test_mdbook004_unicode_normalization() {
         let content: String = MarkdownBuilder::new()
             .line("# Introduction")
             .blank_line()

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook006.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook006.rs
@@ -289,7 +289,7 @@ impl MDBOOK006 {
 
         for ch in heading_text.chars() {
             if ch.is_alphanumeric() {
-                fragment.push(ch.to_ascii_lowercase());
+                fragment.extend(ch.to_lowercase());
             } else if ch == '-' || ch == '_' {
                 // Preserve hyphens and underscores as-is
                 fragment.push(ch);
@@ -578,6 +578,16 @@ See [target](target.md) for more.
             rule.generate_anchor_id("[2026-01-28] - V5.1.2"),
             "2026-01-28---v512"
         );
+    }
+
+    #[test]
+    fn test_issue_399_unicode_anchor_ids() {
+        let rule = MDBOOK006::default();
+
+        // Unicode/umlaut headings must use Unicode-aware lowercasing
+        assert_eq!(rule.generate_anchor_id("Übungen"), "übungen");
+        assert_eq!(rule.generate_anchor_id("Ärger"), "ärger");
+        assert_eq!(rule.generate_anchor_id("Überprüfung"), "überprüfung");
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md042.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md042.rs
@@ -64,17 +64,17 @@ impl MD042 {
                     ));
                 }
             }
-            NodeValue::Image(_) => {
+            NodeValue::Image(_)
                 // Also check images for empty alt text
-                if self.is_empty_link(node) {
-                    let (line, column) = self.get_position(node);
-                    violations.push(self.create_violation(
-                        "Found image with empty alt text".to_string(),
-                        line,
-                        column,
-                        Severity::Warning,
-                    ));
-                }
+                if self.is_empty_link(node) =>
+            {
+                let (line, column) = self.get_position(node);
+                violations.push(self.create_violation(
+                    "Found image with empty alt text".to_string(),
+                    line,
+                    column,
+                    Severity::Warning,
+                ));
             }
             _ => {}
         }

--- a/crates/mdbook-lint-rulesets/src/standard/md051.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md051.rs
@@ -98,7 +98,7 @@ impl MD051 {
 
         for ch in text.chars() {
             if ch.is_alphanumeric() {
-                fragment.push(ch.to_ascii_lowercase());
+                fragment.extend(ch.to_lowercase());
             } else if ch == '-' || ch == '_' {
                 // Preserve hyphens and underscores as-is
                 fragment.push(ch);
@@ -1061,6 +1061,20 @@ More content.
             0,
             "Expected no violations but found: {violations:#?}"
         );
+    }
+
+    #[test]
+    fn test_issue_399_unicode_headings() {
+        let rule = MD051::new();
+
+        // Unicode/umlaut headings must be lowercased with Unicode-aware lowercasing
+        assert_eq!(rule.generate_heading_fragment("Übungen"), "übungen");
+        assert_eq!(rule.generate_heading_fragment("Ärger"), "ärger");
+        assert_eq!(rule.generate_heading_fragment("Überprüfung"), "überprüfung");
+
+        // Full lint pass: link using correct Unicode-lowercased anchor must not false-positive
+        let content = "# Übungen\n\n[link](#übungen)\n";
+        assert_no_violations(rule, content);
     }
 }
 


### PR DESCRIPTION
## Summary

Rules MD051, CONTENT006, and MDBOOK006 use `ch.to_ascii_lowercase()` in their anchor generation logic. This only converts ASCII A-Z but leaves non-ASCII Unicode characters (like `Ü`, `Ö`, `Ä`) unchanged. mdBook uses Unicode-aware lowercasing, so `# Übungen` generates anchor `übungen` in mdBook while the rules generate `Übungen` -- causing false positive "missing anchor" violations.

The fix replaces `fragment.push(ch.to_ascii_lowercase())` with `fragment.extend(ch.to_lowercase())` in all three anchor generation functions. `char::to_lowercase()` returns an iterator (because some Unicode chars map to multiple code points when lowercased) and `extend()` handles this correctly.

Tests are added to each file verifying that `Ü`, `Ä`, and compound forms like `Überprüfung` are properly lowercased, and that a document with `# Übungen` and a link to `#übungen` produces no violations.

Closes #399.

## Test plan

- [ ] `cargo test --lib md051 --all-features` -- new `test_issue_399_unicode_headings` passes
- [ ] `cargo test --lib content006 --all-features` -- new `test_issue_399_unicode_anchors` passes
- [ ] `cargo test --lib mdbook006 --all-features` -- new `test_issue_399_unicode_anchor_ids` passes
- [ ] `cargo test --lib --all-features` -- full test suite green