### PR TITLE
fix: resolve ADR010 and ADR014 false positives

### DIFF
--- a/crates/mdbook-lint-rulesets/src/adr/adr010.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr010.rs
@@ -15,10 +15,14 @@ use std::sync::LazyLock;
 static ADR_REFERENCE_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)ADR[-\s]?(\d+)").expect("Invalid regex"));
 
-/// Regex to find markdown links to ADR files
+/// Regex to find markdown links to ADR files with directory prefix (e.g., `[...](adr/0001-test.md)`)
 static ADR_LINK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\[.*?\]\([^)]*?(?:adr|ADR)[/\\]?\d+[^)]*\.md\)").expect("Invalid regex")
 });
+
+/// Regex to find markdown links using bare ADR filenames (e.g., `[3. Use MySQL](0003-use-mysql.md)`)
+static ADR_BARE_LINK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[.*?\]\(\d{4}-[^)]*\.md\)").expect("Invalid regex"));
 
 /// Regex to extract status from "## Status" section in Nygard format
 static STATUS_SECTION_REGEX: LazyLock<Regex> =
@@ -42,7 +46,9 @@ impl Default for Adr010 {
 impl Adr010 {
     /// Check if content contains a reference to another ADR
     fn has_adr_reference(content: &str) -> bool {
-        ADR_REFERENCE_REGEX.is_match(content) || ADR_LINK_REGEX.is_match(content)
+        ADR_REFERENCE_REGEX.is_match(content)
+            || ADR_LINK_REGEX.is_match(content)
+            || ADR_BARE_LINK_REGEX.is_match(content)
     }
 
     /// Extract status from document
@@ -228,7 +234,25 @@ Decision here.
         assert!(Adr010::has_adr_reference("See ADR-001 for details"));
         assert!(Adr010::has_adr_reference("Replaced by ADR 42"));
         assert!(Adr010::has_adr_reference("See [link](adr/0001-test.md)"));
+        // Bare filename links (format produced by adrs CLI and adr-tools)
+        assert!(Adr010::has_adr_reference(
+            "Superseded by [3. Use MySQL](0003-use-mysql.md)"
+        ));
         assert!(!Adr010::has_adr_reference("No reference here"));
+    }
+
+    #[test]
+    fn test_superseded_with_bare_filename_link() {
+        let docs = vec![create_nygard_adr(
+            "Superseded",
+            "\nSuperseded by [3. Use MySQL](0003-use-mysql.md)",
+        )];
+        let rule = Adr010;
+        let violations = rule.check_collection(&docs).unwrap();
+        assert!(
+            violations.is_empty(),
+            "Should recognize bare filename ADR links"
+        );
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/adr/adr014.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr014.rs
@@ -7,27 +7,17 @@ use comrak::nodes::{AstNode, NodeValue};
 use mdbook_lint_core::Document;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::violation::{Severity, Violation};
+use regex::Regex;
 use std::sync::LazyLock;
 
-/// Common placeholder patterns that indicate incomplete content
-static PLACEHOLDER_PATTERNS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
-    vec![
-        "todo",
-        "tbd",
-        "to be determined",
-        "to be decided",
-        "fill in",
-        "placeholder",
-        "describe",
-        "add content",
-        "write here",
-        "...",
-        "xxx",
-        "[insert",
-        "<insert",
-        "lorem ipsum",
-    ]
+/// Regex for word-boundary placeholder patterns (avoids false positives on
+/// words like "described" matching "describe")
+static PLACEHOLDER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\b(?:todo|tbd|to be determined|to be decided|fill in|placeholder|describe|add content|write here|xxx|lorem ipsum)\b").expect("Invalid regex")
 });
+
+/// Literal placeholder patterns that don't need word boundaries
+static PLACEHOLDER_LITERALS: &[&str] = &["...", "[insert", "<insert"];
 
 /// ADR014: Validates that ADR sections have meaningful content
 ///
@@ -63,21 +53,21 @@ impl Adr014 {
 
     /// Check if content appears to be placeholder text
     fn is_placeholder_content(content: &str) -> bool {
-        let content_lower = content.trim().to_lowercase();
+        let trimmed = content.trim();
 
         // Empty or very short content
-        if content_lower.is_empty() || content_lower.len() < 3 {
+        if trimmed.is_empty() || trimmed.len() < 3 {
             return true;
         }
 
-        // Check for placeholder patterns
-        for pattern in PLACEHOLDER_PATTERNS.iter() {
-            if content_lower.contains(pattern) {
-                return true;
-            }
+        // Check word-boundary placeholder patterns (e.g. "describe" won't match "described")
+        if PLACEHOLDER_REGEX.is_match(trimmed) {
+            return true;
         }
 
-        false
+        // Check literal placeholder patterns that don't need word boundaries
+        let lower = trimmed.to_lowercase();
+        PLACEHOLDER_LITERALS.iter().any(|p| lower.contains(p))
     }
 
     /// Get required section names based on format
@@ -405,5 +395,40 @@ Chosen option: PostgreSQL.
         assert!(!Adr014::is_placeholder_content(
             "The team decided to use Rust."
         ));
+        // "described" should NOT match the "describe" placeholder pattern
+        assert!(!Adr014::is_placeholder_content(
+            r#"We will use Architecture Decision Records, as described by Michael Nygard in his article "Documenting Architecture Decisions"."#
+        ));
+    }
+
+    #[test]
+    fn test_no_false_positive_on_initial_adr() {
+        let content = r#"# 1. Record architecture decisions
+
+Date: 2024-01-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in his article "Documenting Architecture Decisions".
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's adr-tools.
+"#;
+        let doc = create_test_document(content);
+        let rule = Adr014::default();
+        let violations = rule.check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "False positive on initial ADR #0001: {violations:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **ADR014**: Replace substring matching with word-boundary regex for placeholder detection. Words like "described" in legitimate prose no longer match the "describe" placeholder pattern.
- **ADR010**: Add support for bare ADR filename links (`NNNN-slug.md`) without a directory prefix. The `adrs` CLI and `adr-tools` both generate this link format.

## Test plan

- [ ] `cargo test --lib adr010` passes
- [ ] `cargo test --lib adr014` passes
- [ ] Verify "described" in body text does not trigger ADR014
- [ ] Verify bare `0001-use-rust.md` links satisfy ADR010