### PR TITLE
fix: honor ignore-paths and MDBOOK005 ignore_patterns config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1213,7 @@ dependencies = [
  "clap",
  "comrak",
  "criterion",
+ "glob",
  "mdbook",
  "mdbook-lint-core",
  "mdbook-lint-rulesets",
@@ -1247,6 +1254,7 @@ version = "0.14.4"
 dependencies = [
  "anyhow",
  "comrak",
+ "glob",
  "mdbook",
  "mdbook-lint-core",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ mdbook = { version = "0.4", default-features = false }
 
 # Utilities
 walkdir = "2.3"
+glob = "0.3"
 
 # Internal workspace crates
 mdbook-lint-core = { version = "0.14.4", path = "crates/mdbook-lint-core" }

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -37,6 +37,7 @@ comrak = { workspace = true }
 clap = { workspace = true }
 mdbook = { workspace = true }
 walkdir = { workspace = true }
+glob = { workspace = true }
 rayon = "1.10"
 tabled = "0.20"
 anstream = "0.6"

--- a/crates/mdbook-lint-cli/src/lib.rs
+++ b/crates/mdbook-lint-cli/src/lib.rs
@@ -27,6 +27,8 @@ pub mod rustdoc;
 #[cfg(test)]
 mod batch1_rule_config_test;
 #[cfg(test)]
+mod mdbook_ignore_config_test;
+#[cfg(test)]
 mod rule_config_test;
 
 // Re-export everything from core

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -21,7 +21,7 @@ use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -655,6 +655,70 @@ fn collect_markdown_files(dir: &PathBuf, files: &mut Vec<PathBuf>) -> Result<()>
     Ok(())
 }
 
+/// Return true if `path` matches any of the given ignore glob patterns.
+///
+/// Matching is intentionally forgiving so the patterns behave the way users
+/// expect from `.gitignore`-style configuration:
+/// - a trailing `/` marks a directory prefix (`target/` behaves like `target/**`),
+/// - a pattern without any `/` also matches anywhere in the tree
+///   (`*.backup.md` matches `sub/dir/file.backup.md`),
+/// - `*` does not cross path separators, but `**` does.
+///
+/// Paths are normalized (leading `./` stripped, backslashes converted to `/`)
+/// before matching so results are consistent across platforms.
+fn path_is_ignored(path: &Path, patterns: &[String]) -> bool {
+    use glob::{MatchOptions, Pattern};
+
+    if patterns.is_empty() {
+        return false;
+    }
+
+    let normalized = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_string();
+
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+
+    for pattern in patterns {
+        let mut pat = pattern.replace('\\', "/");
+        pat = pat.trim_start_matches("./").to_string();
+        // A trailing slash means "everything under this directory".
+        if pat.ends_with('/') {
+            pat.push_str("**");
+        }
+
+        // A bare name or relative pattern should also match deeper in the tree.
+        let mut candidates = vec![pat.clone()];
+        if !pat.starts_with("**/") {
+            candidates.push(format!("**/{pat}"));
+        }
+
+        for candidate in candidates {
+            if let Ok(compiled) = Pattern::new(&candidate)
+                && compiled.matches_with(&normalized, options)
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Remove files matching any of the configured ignore-paths patterns.
+fn filter_ignored_paths(files: &mut Vec<PathBuf>, patterns: &[String]) {
+    if patterns.is_empty() {
+        return;
+    }
+    files.retain(|path| !path_is_ignored(path, patterns));
+}
+
 /// Apply fixes to file content, returning the fixed content if any fixes were applied
 fn apply_fixes_to_content(
     content: &str,
@@ -999,6 +1063,9 @@ fn run_cli_mode(
             }
         }
 
+        // Drop any files matching the configured ignore-paths patterns
+        filter_ignored_paths(&mut markdown_files, &config.core.ignore_paths);
+
         // Process markdown files in parallel
         let violations_mutex = Mutex::new(Vec::new());
         let total_count = AtomicUsize::new(0);
@@ -1143,6 +1210,8 @@ fn run_cli_mode(
             {
                 current_markdown_files.push(path);
             }
+
+            filter_ignored_paths(&mut current_markdown_files, &config.core.ignore_paths);
 
             for md_path in current_markdown_files {
                 let file_path = md_path.to_string_lossy().to_string();
@@ -1973,6 +2042,52 @@ fn get_all_available_rule_ids() -> Vec<String> {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    #[test]
+    fn test_path_is_ignored() {
+        let p = |s: &str| PathBuf::from(s);
+
+        // Directory prefix (trailing slash)
+        let pats = vec!["vendor/".to_string()];
+        assert!(path_is_ignored(&p("vendor/skip.md"), &pats));
+        assert!(path_is_ignored(&p("./vendor/nested/skip.md"), &pats));
+        assert!(!path_is_ignored(&p("docs/keep.md"), &pats));
+
+        // Bare suffix glob matches at any depth
+        let pats = vec!["*.backup.md".to_string()];
+        assert!(path_is_ignored(&p("notes.backup.md"), &pats));
+        assert!(path_is_ignored(&p("a/b/notes.backup.md"), &pats));
+        assert!(!path_is_ignored(&p("notes.md"), &pats));
+
+        // Bare name matches anywhere
+        let pats = vec!["not-found.md".to_string()];
+        assert!(path_is_ignored(&p("not-found.md"), &pats));
+        assert!(path_is_ignored(&p("src/deep/not-found.md"), &pats));
+
+        // Explicit ** prefix
+        let pats = vec!["**/generated.md".to_string()];
+        assert!(path_is_ignored(&p("x/y/generated.md"), &pats));
+
+        // Empty patterns never match
+        assert!(!path_is_ignored(&p("anything.md"), &[]));
+    }
+
+    #[test]
+    fn test_filter_ignored_paths() {
+        let mut files = vec![
+            PathBuf::from("docs/keep.md"),
+            PathBuf::from("vendor/skip.md"),
+            PathBuf::from("drafts/wip.md"),
+            PathBuf::from("notes.backup.md"),
+        ];
+        let patterns = vec![
+            "vendor/".to_string(),
+            "drafts/".to_string(),
+            "*.backup.md".to_string(),
+        ];
+        filter_ignored_paths(&mut files, &patterns);
+        assert_eq!(files, vec![PathBuf::from("docs/keep.md")]);
+    }
 
     #[test]
     fn test_cli_parsing() {

--- a/crates/mdbook-lint-cli/src/mdbook_ignore_config_test.rs
+++ b/crates/mdbook-lint-cli/src/mdbook_ignore_config_test.rs
@@ -1,0 +1,94 @@
+//! Tests for ignore-related configuration wired through the engine.
+//!
+//! Covers two regressions:
+//! - #411: the global `ignore-paths` / `ignore_paths` option now parses into
+//!   `Config`.
+//! - #412: `MdBookRuleProvider` now threads rule configuration, so MDBOOK005
+//!   honors `ignore_patterns`.
+
+#[cfg(test)]
+mod tests {
+    use crate::config::Config;
+    use mdbook_lint_core::{Document, PluginRegistry};
+    use mdbook_lint_rulesets::MdBookRuleProvider;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_ignore_paths_config_parses_both_spellings() {
+        // Underscore spelling (as used in the example config / issue #411)
+        let config =
+            Config::from_toml_str("ignore_paths = [\"vendor/\", \"*.backup.md\"]").unwrap();
+        assert_eq!(config.core.ignore_paths, vec!["vendor/", "*.backup.md"]);
+
+        // Kebab spelling (matches the rest of the config keys)
+        let config = Config::from_toml_str("ignore-paths = [\"drafts/\"]").unwrap();
+        assert_eq!(config.core.ignore_paths, vec!["drafts/"]);
+
+        // Absent: defaults to empty
+        let config = Config::from_toml_str("").unwrap();
+        assert!(config.core.ignore_paths.is_empty());
+    }
+
+    #[test]
+    fn test_mdbook005_ignore_patterns_threads_through_engine() {
+        // Reproduces issue #412 end-to-end through the provider/engine path,
+        // which is where the config was previously dropped.
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("SUMMARY.md"),
+            "# Summary\n\n- [Chapter 1](chapter1.md)\n",
+        )
+        .unwrap();
+        fs::write(root.join("chapter1.md"), "# Chapter 1").unwrap();
+        fs::write(root.join("not-found.md"), "# Not Found").unwrap();
+
+        let summary = Document::new(
+            fs::read_to_string(root.join("SUMMARY.md")).unwrap(),
+            root.join("SUMMARY.md"),
+        )
+        .unwrap();
+
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(MdBookRuleProvider))
+            .unwrap();
+
+        // Without config: not-found.md is reported as an orphan.
+        let config = Config::from_toml_str("enabled-rules = [\"MDBOOK005\"]").unwrap();
+        let engine = registry
+            .create_engine_with_config(Some(&config.core))
+            .unwrap();
+        let violations = engine
+            .lint_document_with_config(&summary, &config.core)
+            .unwrap();
+        let orphans: Vec<_> = violations
+            .iter()
+            .filter(|v| v.rule_id == "MDBOOK005")
+            .collect();
+        assert_eq!(orphans.len(), 1, "orphan should be reported without config");
+
+        // With ignore_patterns: the orphan is suppressed.
+        let config = Config::from_toml_str(
+            "enabled-rules = [\"MDBOOK005\"]\n[MDBOOK005]\nignore_patterns = [\"not-found.md\"]\n",
+        )
+        .unwrap();
+        let engine = registry
+            .create_engine_with_config(Some(&config.core))
+            .unwrap();
+        let violations = engine
+            .lint_document_with_config(&summary, &config.core)
+            .unwrap();
+        let orphans: Vec<_> = violations
+            .iter()
+            .filter(|v| v.rule_id == "MDBOOK005")
+            .collect();
+        assert_eq!(
+            orphans.len(),
+            0,
+            "ignore_patterns should suppress the orphan through the engine"
+        );
+    }
+}

--- a/crates/mdbook-lint-core/src/config.rs
+++ b/crates/mdbook-lint-core/src/config.rs
@@ -38,6 +38,16 @@ pub struct Config {
     #[serde(rename = "auto-fix", default = "default_auto_fix")]
     pub auto_fix: bool,
 
+    /// Glob patterns for paths to skip entirely when linting.
+    ///
+    /// Patterns are matched against each candidate file path. A trailing `/`
+    /// is treated as a directory prefix (`target/` behaves like `target/**`),
+    /// and patterns without a `/` also match anywhere in the tree
+    /// (`*.backup.md` matches nested files). Both `ignore-paths` and
+    /// `ignore_paths` spellings are accepted.
+    #[serde(rename = "ignore-paths", alias = "ignore_paths", default)]
+    pub ignore_paths: Vec<String>,
+
     /// Rule-specific configuration
     #[serde(flatten)]
     pub rule_configs: HashMap<String, toml::Value>,
@@ -57,6 +67,7 @@ impl Default for Config {
             deprecated_warning: DeprecatedWarningLevel::default(),
             markdownlint_compatible: false,
             auto_fix: true, // Default to true - fixes are applied when --fix is used
+            ignore_paths: Vec::new(),
             rule_configs: HashMap::new(),
         }
     }

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -42,6 +42,7 @@ serde_yaml = { workspace = true, optional = true }
 
 # Utilities
 walkdir = { workspace = true }
+glob = { workspace = true }
 regex = "1.10"
 toml = { workspace = true }
 

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook005.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook005.rs
@@ -31,22 +31,39 @@ use std::{fs, io};
 /// - Ignores common files like README.md by default
 /// - Supports configuration for custom ignore patterns
 pub struct MDBOOK005 {
-    /// Files to ignore when checking for orphans (case-insensitive)
+    /// Files to ignore when checking for orphans (case-insensitive, by file name)
     ignored_files: HashSet<String>,
+    /// Glob patterns (relative to the book source directory) to ignore
+    ignore_patterns: Vec<String>,
+    /// Whether to scan subdirectories of the book source directory
+    check_nested: bool,
 }
 
 impl Default for MDBOOK005 {
     fn default() -> Self {
-        let mut ignored_files = HashSet::new();
-        // Common files that are typically not in SUMMARY.md
-        ignored_files.insert("readme.md".to_string());
-        ignored_files.insert("contributing.md".to_string());
-        ignored_files.insert("license.md".to_string());
-        ignored_files.insert("changelog.md".to_string());
-        ignored_files.insert("summary.md".to_string()); // Don't report SUMMARY.md itself
-
-        Self { ignored_files }
+        Self {
+            ignored_files: default_ignored_files(true),
+            ignore_patterns: Vec::new(),
+            check_nested: true,
+        }
     }
+}
+
+/// Build the default set of ignored file names.
+///
+/// These are files that are conventionally present in a book source tree but
+/// not referenced from SUMMARY.md. `exclude_readme` controls whether README.md
+/// is part of that set.
+fn default_ignored_files(exclude_readme: bool) -> HashSet<String> {
+    let mut ignored_files = HashSet::new();
+    if exclude_readme {
+        ignored_files.insert("readme.md".to_string());
+    }
+    ignored_files.insert("contributing.md".to_string());
+    ignored_files.insert("license.md".to_string());
+    ignored_files.insert("changelog.md".to_string());
+    ignored_files.insert("summary.md".to_string()); // Don't report SUMMARY.md itself
+    ignored_files
 }
 
 impl MDBOOK005 {
@@ -59,6 +76,87 @@ impl MDBOOK005 {
         }
         instance
     }
+
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `ignore_patterns`: array of glob patterns, relative to the book
+    ///   source directory, for orphan files to skip.
+    /// - `exclude_readme`: whether README.md is ignored by default (default true).
+    /// - `check_nested`: whether to scan subdirectories (default true).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let get = |snake: &str, kebab: &str| config.get(snake).or_else(|| config.get(kebab));
+
+        let exclude_readme = get("exclude_readme", "exclude-readme")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let check_nested = get("check_nested", "check-nested")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let ignore_patterns = get("ignore_patterns", "ignore-patterns")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Self {
+            ignored_files: default_ignored_files(exclude_readme),
+            ignore_patterns,
+            check_nested,
+        }
+    }
+}
+
+/// Return true if `relative_path` matches any of the configured ignore globs.
+///
+/// Matching mirrors the CLI `ignore-paths` behavior: a trailing `/` marks a
+/// directory prefix, a pattern without any `/` also matches deeper in the tree,
+/// and `*` does not cross path separators while `**` does.
+fn matches_ignore_pattern(relative_path: &str, patterns: &[String]) -> bool {
+    use glob::{MatchOptions, Pattern};
+
+    if patterns.is_empty() {
+        return false;
+    }
+
+    let normalized = relative_path
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_string();
+
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+
+    for pattern in patterns {
+        let mut pat = pattern.replace('\\', "/");
+        pat = pat.trim_start_matches("./").to_string();
+        if pat.ends_with('/') {
+            pat.push_str("**");
+        }
+
+        let mut candidates = vec![pat.clone()];
+        if !pat.starts_with("**/") {
+            candidates.push(format!("**/{pat}"));
+        }
+
+        for candidate in candidates {
+            if let Ok(compiled) = Pattern::new(&candidate)
+                && compiled.matches_with(&normalized, options)
+            {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 impl Rule for MDBOOK005 {
@@ -119,7 +217,8 @@ impl Rule for MDBOOK005 {
         };
 
         // Find orphaned files
-        let orphaned_files = self.find_orphaned_files(&referenced_files, &all_markdown_files);
+        let orphaned_files =
+            self.find_orphaned_files(&referenced_files, &all_markdown_files, book_src_dir);
 
         // Create violations for each orphaned file
         for orphaned_file in orphaned_files {
@@ -199,7 +298,7 @@ impl MDBOOK005 {
     fn find_markdown_files(&self, book_src_dir: &Path) -> io::Result<HashSet<PathBuf>> {
         let mut markdown_files = HashSet::new();
         // Only scan within the book's source directory
-        scan_directory_recursive(book_src_dir, &mut markdown_files)?;
+        scan_directory(book_src_dir, &mut markdown_files, self.check_nested)?;
         Ok(markdown_files)
     }
 
@@ -208,6 +307,7 @@ impl MDBOOK005 {
         &self,
         referenced: &HashSet<PathBuf>,
         all_files: &HashSet<PathBuf>,
+        book_src_dir: &Path,
     ) -> Vec<PathBuf> {
         all_files
             .iter()
@@ -222,6 +322,19 @@ impl MDBOOK005 {
                     && self.ignored_files.contains(&filename.to_lowercase())
                 {
                     return false;
+                }
+
+                // Skip files matching any configured ignore glob (matched against
+                // the path relative to the book source directory)
+                if !self.ignore_patterns.is_empty() {
+                    let relative = file
+                        .strip_prefix(book_src_dir)
+                        .unwrap_or(file.as_path())
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    if matches_ignore_pattern(&relative, &self.ignore_patterns) {
+                        return false;
+                    }
                 }
 
                 true
@@ -241,8 +354,12 @@ fn is_summary_file(document: &Document) -> bool {
         .unwrap_or(false)
 }
 
-/// Recursively scan directory for markdown files
-fn scan_directory_recursive(dir: &Path, markdown_files: &mut HashSet<PathBuf>) -> io::Result<()> {
+/// Scan a directory for markdown files, optionally recursing into subdirectories
+fn scan_directory(
+    dir: &Path,
+    markdown_files: &mut HashSet<PathBuf>,
+    recursive: bool,
+) -> io::Result<()> {
     let entries = fs::read_dir(dir)?;
 
     for entry in entries {
@@ -250,6 +367,9 @@ fn scan_directory_recursive(dir: &Path, markdown_files: &mut HashSet<PathBuf>) -
         let path = entry.path();
 
         if path.is_dir() {
+            if !recursive {
+                continue;
+            }
             // Skip common directories that shouldn't be scanned
             if let Some(dir_name) = path.file_name().and_then(|n| n.to_str())
                 && matches!(
@@ -260,7 +380,7 @@ fn scan_directory_recursive(dir: &Path, markdown_files: &mut HashSet<PathBuf>) -
                 continue;
             }
             // Recursively scan subdirectories
-            scan_directory_recursive(&path, markdown_files)?;
+            scan_directory(&path, markdown_files, recursive)?;
         } else if let Some(extension) = path.extension().and_then(|e| e.to_str())
             && matches!(extension, "md" | "markdown")
         {
@@ -573,6 +693,172 @@ mod tests {
         assert_eq!(violations.len(), 1);
         assert!(violations[0].message.contains("orphan.md"));
         assert!(!violations[0].message.contains("custom.md"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_matches_ignore_pattern() {
+        // Bare name matches at root and anywhere in the tree
+        assert!(matches_ignore_pattern(
+            "not-found.md",
+            &["not-found.md".to_string()]
+        ));
+        assert!(matches_ignore_pattern(
+            "external/docs/not-found.md",
+            &["not-found.md".to_string()]
+        ));
+
+        // Explicit ** prefix matches nested paths
+        assert!(matches_ignore_pattern(
+            "a/b/not-found.md",
+            &["**/not-found.md".to_string()]
+        ));
+
+        // Directory prefix (trailing slash) matches everything under it
+        assert!(matches_ignore_pattern(
+            "drafts/wip.md",
+            &["drafts/".to_string()]
+        ));
+        assert!(matches_ignore_pattern(
+            "drafts/nested/wip.md",
+            &["drafts/".to_string()]
+        ));
+
+        // Suffix glob matches at any depth
+        assert!(matches_ignore_pattern(
+            "guide/notes.backup.md",
+            &["*.backup.md".to_string()]
+        ));
+
+        // Non-matching patterns
+        assert!(!matches_ignore_pattern(
+            "chapter1.md",
+            &["not-found.md".to_string()]
+        ));
+        assert!(!matches_ignore_pattern("chapter1.md", &[]));
+        // An anchored pattern with a separator: `*` does not cross `/`, so a
+        // deeper path is not matched.
+        assert!(matches_ignore_pattern(
+            "sub/chapter1.md",
+            &["sub/*.md".to_string()]
+        ));
+        assert!(!matches_ignore_pattern(
+            "sub/deep/chapter1.md",
+            &["sub/*.md".to_string()]
+        ));
+    }
+
+    #[test]
+    fn test_from_config_defaults() {
+        // Empty config yields the same behavior as default()
+        let cfg: toml::Value = toml::from_str("").unwrap();
+        let rule = MDBOOK005::from_config(&cfg);
+        assert!(rule.ignore_patterns.is_empty());
+        assert!(rule.check_nested);
+        assert!(rule.ignored_files.contains("readme.md"));
+    }
+
+    #[test]
+    fn test_ignore_patterns_config() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+
+        let summary_content = r#"# Summary
+
+- [Chapter 1](chapter1.md)
+"#;
+        let summary_path = root.join("SUMMARY.md");
+        let doc = create_test_document(summary_content, &summary_path)?;
+
+        create_test_document("# Chapter 1", &root.join("chapter1.md"))?;
+        create_test_document("# Not Found", &root.join("not-found.md"))?;
+        create_test_document("# Real Orphan", &root.join("orphan.md"))?;
+
+        // Reproduces issue #412: ignore_patterns should suppress not-found.md
+        let cfg: toml::Value =
+            toml::from_str("ignore_patterns = [\"not-found.md\", \"**/not-found.md\"]").unwrap();
+        let rule = MDBOOK005::from_config(&cfg);
+        let violations = rule.check(&doc)?;
+
+        assert_eq!(violations.len(), 1, "only the real orphan should remain");
+        assert!(violations[0].message.contains("orphan.md"));
+        assert!(!violations[0].message.contains("not-found.md"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_ignore_patterns_config_nested_dir() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+
+        let summary_content = r#"# Summary
+
+- [Chapter 1](chapter1.md)
+"#;
+        let summary_path = root.join("SUMMARY.md");
+        let doc = create_test_document(summary_content, &summary_path)?;
+
+        create_test_document("# Chapter 1", &root.join("chapter1.md"))?;
+        create_test_document("# Draft", &root.join("drafts/wip.md"))?;
+        create_test_document("# Draft 2", &root.join("drafts/nested/wip2.md"))?;
+        create_test_document("# Real Orphan", &root.join("orphan.md"))?;
+
+        let cfg: toml::Value = toml::from_str("ignore_patterns = [\"drafts/\"]").unwrap();
+        let rule = MDBOOK005::from_config(&cfg);
+        let violations = rule.check(&doc)?;
+
+        assert_eq!(violations.len(), 1, "drafts/ should be fully ignored");
+        assert!(violations[0].message.contains("orphan.md"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_exclude_readme_false_reports_readme() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+
+        let summary_content = r#"# Summary
+
+- [Chapter 1](chapter1.md)
+"#;
+        let summary_path = root.join("SUMMARY.md");
+        let doc = create_test_document(summary_content, &summary_path)?;
+
+        create_test_document("# Chapter 1", &root.join("chapter1.md"))?;
+        create_test_document("# Readme", &root.join("README.md"))?;
+
+        // Default: README ignored
+        assert_eq!(MDBOOK005::default().check(&doc)?.len(), 0);
+
+        // exclude_readme = false: README reported as orphan
+        let cfg: toml::Value = toml::from_str("exclude_readme = false").unwrap();
+        let violations = MDBOOK005::from_config(&cfg).check(&doc)?;
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.to_lowercase().contains("readme.md"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_check_nested_false_skips_subdirs() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+
+        let summary_content = r#"# Summary
+
+- [Chapter 1](chapter1.md)
+"#;
+        let summary_path = root.join("SUMMARY.md");
+        let doc = create_test_document(summary_content, &summary_path)?;
+
+        create_test_document("# Chapter 1", &root.join("chapter1.md"))?;
+        create_test_document("# Nested Orphan", &root.join("sub/orphan.md"))?;
+
+        // Default recurses and finds the nested orphan
+        assert_eq!(MDBOOK005::default().check(&doc)?.len(), 1);
+
+        // check_nested = false: subdirectories are not scanned
+        let cfg: toml::Value = toml::from_str("check_nested = false").unwrap();
+        assert_eq!(MDBOOK005::from_config(&cfg).check(&doc)?.len(), 0);
         Ok(())
     }
 }

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook022.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook022.rs
@@ -41,6 +41,21 @@ impl MDBOOK022 {
     pub fn with_max_line(max_line: usize) -> Self {
         Self { max_line }
     }
+
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `max_line`: highest line number at which a `{{#title}}` directive is
+    ///   still considered "near the top".
+    pub fn from_config(config: &toml::Value) -> Self {
+        let max_line = config
+            .get("max_line")
+            .or_else(|| config.get("max-line"))
+            .and_then(|v| v.as_integer())
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(DEFAULT_MAX_LINE);
+        Self { max_line }
+    }
 }
 
 impl Rule for MDBOOK022 {
@@ -162,6 +177,22 @@ mod tests {
         let rule = MDBOOK022::with_max_line(10);
         let violations = rule.check(&doc).unwrap();
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_from_config_max_line() {
+        let content = "# Chapter\n\nParagraph.\n\n{{#title Title on Line 5}}";
+        let doc = create_test_document(content);
+
+        // Default threshold (5) passes
+        let cfg: toml::Value = toml::from_str("").unwrap();
+        assert_eq!(MDBOOK022::from_config(&cfg).check(&doc).unwrap().len(), 0);
+
+        // Lowered threshold fails; both spellings accepted
+        let cfg: toml::Value = toml::from_str("max_line = 3").unwrap();
+        assert_eq!(MDBOOK022::from_config(&cfg).check(&doc).unwrap().len(), 1);
+        let cfg: toml::Value = toml::from_str("max-line = 3").unwrap();
+        assert_eq!(MDBOOK022::from_config(&cfg).check(&doc).unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
@@ -23,6 +23,7 @@ mod mdbook023;
 mod mdbook025;
 
 use crate::{RuleProvider, RuleRegistry};
+use mdbook_lint_core::Config;
 
 /// Provider for mdBook-specific rules (MDBOOK001-007)
 pub struct MdBookRuleProvider;
@@ -57,6 +58,41 @@ impl RuleProvider for MdBookRuleProvider {
         registry.register(Box::new(mdbook017::MDBOOK017));
         registry.register(Box::new(mdbook021::MDBOOK021));
         registry.register(Box::new(mdbook022::MDBOOK022::default()));
+        registry.register(Box::new(mdbook023::MDBOOK023::default()));
+        registry.register(Box::new(mdbook025::MDBOOK025));
+    }
+
+    fn register_rules_with_config(&self, registry: &mut RuleRegistry, config: Option<&Config>) {
+        registry.register(Box::new(mdbook001::MDBOOK001));
+        registry.register(Box::new(mdbook002::MDBOOK002));
+        registry.register(Box::new(mdbook003::MDBOOK003));
+        registry.register(Box::new(mdbook004::MDBOOK004));
+
+        // MDBOOK005 - orphaned files (supports ignore_patterns/exclude_readme/check_nested)
+        let mdbook005 = match config.and_then(|c| c.rule_configs.get("MDBOOK005")) {
+            Some(cfg) => mdbook005::MDBOOK005::from_config(cfg),
+            None => mdbook005::MDBOOK005::default(),
+        };
+        registry.register(Box::new(mdbook005));
+
+        registry.register(Box::new(mdbook006::MDBOOK006::default()));
+        registry.register(Box::new(mdbook007::MDBOOK007::default()));
+        registry.register(Box::new(mdbook008::MDBOOK008));
+        registry.register(Box::new(mdbook009::MDBOOK009));
+        registry.register(Box::new(mdbook010::MDBOOK010));
+        registry.register(Box::new(mdbook011::MDBOOK011));
+        registry.register(Box::new(mdbook012::MDBOOK012));
+        registry.register(Box::new(mdbook016::MDBOOK016));
+        registry.register(Box::new(mdbook017::MDBOOK017));
+        registry.register(Box::new(mdbook021::MDBOOK021));
+
+        // MDBOOK022 - title directive near top (supports max_line)
+        let mdbook022 = match config.and_then(|c| c.rule_configs.get("MDBOOK022")) {
+            Some(cfg) => mdbook022::MDBOOK022::from_config(cfg),
+            None => mdbook022::MDBOOK022::default(),
+        };
+        registry.register(Box::new(mdbook022));
+
         registry.register(Box::new(mdbook023::MDBOOK023::default()));
         registry.register(Box::new(mdbook025::MDBOOK025));
     }

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -164,9 +164,26 @@ This disables rules that are disabled by default in markdownlint.
 | `enabled-rules` | array | `[]` | List of rule IDs to explicitly enable |
 | `enabled-categories` | array | `[]` | List of categories to enable |
 | `disabled-categories` | array | `[]` | List of categories to disable |
+| `ignore-paths` | array | `[]` | Glob patterns for files to skip entirely |
 | `markdownlint-compatible` | boolean | `false` | Enable markdownlint compatibility |
 | `deprecated-warning` | string | `"warn"` | How to handle deprecated rules (`"warn"`, `"info"`, `"silent"`) |
 | `malformed-markdown` | string | `"warn"` | How to handle malformed markdown (`"error"`, `"warn"`, `"skip"`) |
+
+### Ignoring Paths
+
+Use `ignore-paths` to skip files entirely before any rule runs. Patterns are
+glob-style and behave like `.gitignore` entries:
+
+```toml
+ignore-paths = [
+    "vendor/",        # a trailing slash ignores everything under a directory
+    "drafts/**",      # or use ** explicitly
+    "*.backup.md",    # a slash-less pattern matches at any depth
+]
+```
+
+`*` does not cross path separators; `**` does. Both `ignore-paths` and
+`ignore_paths` spellings are accepted.
 
 ## Configuration Precedence
 


### PR DESCRIPTION
Fixes #411 and #412: two documented "ignore" configuration options that were never wired up.

## #411 `ignore-paths` does nothing

The example config advertises a global `ignore_paths = [...]`, but there is no such field on `Config` and `collect_markdown_files` never filters. The option was documentation with no backing code.

Plan:
- Add `ignore_paths: Vec<String>` to core `Config` (`rename = "ignore-paths"`, `alias = "ignore_paths"` so both spellings work).
- Filter collected files against these glob patterns in the CLI lint and fix flows.
- Directory patterns (`target/`) and nested patterns (`**/foo.md`, `*.backup.md`) supported via the `glob` crate.

## #412 MDBOOK005 `ignore_patterns` does nothing

Two layers were broken:
1. `MdBookRuleProvider` never implemented `register_rules_with_config`, so no mdbook rule ever received configuration.
2. `MDBOOK005` had no `from_config` and only used a hardcoded ignore list, never reading `ignore_patterns`.

Plan:
- Implement `register_rules_with_config` on `MdBookRuleProvider`, threading config to every mdbook rule (rules opt in via `from_config`).
- Add `from_config` to `MDBOOK005` honoring `ignore_patterns` (glob), plus documented `exclude_readme` / `check_nested`.
- Wire `MDBOOK022 max_line` through the same plumbing to confirm it works for more than one rule.

## Notes

- Adds `glob = "0.3"` to workspace dependencies.
- Other mdbook rules document config options that are still not backed by fields; the plumbing added here lets them opt in incrementally via `from_config`.

## Testing

- Unit tests for `ignore_patterns` glob matching in MDBOOK005.
- Unit/integration tests for `ignore-paths` file filtering.
- `cargo fmt`, `cargo clippy -D warnings`, full test suite.