### PR TITLE
docs: fix cli-usage and configuration references to nonexistent flags/env vars

### DIFF
--- a/docs/src/cli-usage.md
+++ b/docs/src/cli-usage.md
@@ -4,20 +4,63 @@ This page documents the command-line interface for mdbook-lint.
 
 ## Basic Commands
 
+### preprocessor
+
+Run as an mdBook preprocessor (reads from stdin, writes to stdout). This is the
+mode mdBook invokes; you normally do not run it by hand.
+
+```bash
+mdbook-lint preprocessor
+```
+
+See [mdBook Integration](./mdbook-integration.md) for details.
+
 ### lint
 
 Lint markdown files and directories.
 
 ```bash
-mdbook-lint lint [OPTIONS] [PATHS]...
+mdbook-lint lint [OPTIONS] [FILES]...
+```
+
+### fix
+
+Automatically fix issues in markdown files (shorthand for `lint --fix`).
+
+```bash
+mdbook-lint fix [OPTIONS] [FILES]...
 ```
 
 ### rules
 
-List available linting rules.
+List available linting rules by category.
 
 ```bash
 mdbook-lint rules [OPTIONS]
+```
+
+### check
+
+Check a configuration file for validity.
+
+```bash
+mdbook-lint check <CONFIG>
+```
+
+### init
+
+Generate a default configuration file.
+
+```bash
+mdbook-lint init [OPTIONS]
+```
+
+### supports
+
+Check whether the preprocessor supports a given renderer (used by mdBook).
+
+```bash
+mdbook-lint supports <RENDERER>
 ```
 
 ### rustdoc
@@ -29,6 +72,15 @@ mdbook-lint rustdoc [OPTIONS] [PATHS]...
 ```
 
 See [Rustdoc Linting](./rustdoc-linting.md) for detailed documentation.
+
+### lsp
+
+Run as a Language Server Protocol (LSP) server. Available only when
+mdbook-lint is built with the `lsp` feature.
+
+```bash
+mdbook-lint lsp [OPTIONS]
+```
 
 ### help
 

--- a/docs/src/cli-usage.md
+++ b/docs/src/cli-usage.md
@@ -62,9 +62,13 @@ mdbook-lint help [COMMAND]
 
 ### Rules Options
 
-- `--detailed`: Show detailed rule descriptions
-- `--enabled`: Show only enabled rules
-- `--format <FORMAT>`: Output format (text, JSON)
+- `-d, --detailed`: Show detailed information about each rule
+- `-c, --category <CATEGORY>`: Filter by rule category
+- `-p, --provider <PROVIDER>`: Show only rules from a specific provider
+- `--standard-only`: Show only standard rules (MD001-MD059)
+- `--mdbook-only`: Show only mdBook-specific rules
+- `--format <FORMAT>`: Output format (default, json)
+- `--json`: Output in JSON format (shorthand for `--format json`)
 
 ## Output Format
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -17,9 +17,9 @@ mdbook-lint searches for configuration files in the following order:
 
 1. Current directory
 2. Parent directories (recursively up to root)
-3. Custom path via `MDBOOK_LINT_CONFIG` environment variable
 
-The first configuration file found is used.
+The first configuration file found is used. To use a specific file instead of
+discovery, pass `--config <FILE>` to `lint`, `fix`, or `rustdoc`.
 
 ## Basic Configuration
 
@@ -175,13 +175,7 @@ Configuration is resolved in the following order (later overrides earlier):
 1. Built-in defaults
 2. Configuration file (`.mdbook-lint.toml`, etc.)
 3. mdBook preprocessor config (in `book.toml`)
-4. Environment variables (`MDBOOK_LINT_*`)
-5. Command-line arguments
-
-## Environment Variables
-
-- `MDBOOK_LINT_CONFIG` - Path to custom configuration file
-- `MDBOOK_LINT_LOG` - Log level (`error`, `warn`, `info`, `debug`, `trace`)
+4. Command-line arguments
 
 ## mdBook Integration
 
@@ -313,8 +307,8 @@ To validate your configuration:
 # Check if configuration file is valid
 mdbook-lint check .mdbook-lint.toml
 
-# Show which rules are enabled with current config
-mdbook-lint rules --enabled
+# List the available rules and their categories
+mdbook-lint rules
 ```
 
 ## Next Steps

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -123,8 +123,8 @@ mdbook-lint rules
 # Show detailed rule descriptions
 mdbook-lint rules --detailed
 
-# Show only enabled rules
-mdbook-lint rules --enabled
+# Filter rules by category
+mdbook-lint rules --category structure
 ```
 
 ## Next Steps

--- a/docs/src/mdbook-integration.md
+++ b/docs/src/mdbook-integration.md
@@ -490,9 +490,8 @@ jobs:
 mdbook-lint automatically searches for configuration files in the following order:
 
 1. Explicit `--config` flag (CLI mode only)
-2. Environment variable: `MDBOOK_LINT_CONFIG`
-3. `book.toml` preprocessor configuration
-4. Configuration file discovery (searches up the directory tree):
+2. `book.toml` preprocessor configuration
+3. Configuration file discovery (searches up the directory tree):
 
 
 - `.mdbook-lint.toml`


### PR DESCRIPTION
closes #422

## Problem

`docs/src/cli-usage.md` and `docs/src/configuration.md` document CLI flags, subcommands, and environment variables that `clap`/`Config` do not support:

- `rules --enabled` flag does not exist.
- `rules --format text` is documented, but `RulesFormat` only has `default`/`json`.
- The "Basic Commands" list omits `preprocessor`, `fix`, `check`, `init`, `supports`, and `lsp`.
- `MDBOOK_LINT_CONFIG` and `MDBOOK_LINT_LOG` are documented but read nowhere in the code; `discover_config` only walks the filesystem.

## Plan

Correct the docs to match what `clap` and `Config` actually support (doc-only fix; no feature work):

- **cli-usage.md**
  - Fix the `rules` options list: drop `--enabled`, correct `--format` values to `default`/`json`, add the real `--category`, `--provider`, `--standard-only`, `--mdbook-only`, `--json` flags. (done)
  - Expand "Basic Commands" to list all real subcommands: `preprocessor`, `lint`, `fix`, `rules`, `check`, `init`, `supports`, `rustdoc`, and `lsp` (behind its feature flag).
- **configuration.md**
  - Remove `MDBOOK_LINT_CONFIG` from "Configuration Discovery".
  - Remove the "Environment Variables" section and the env-vars entry from the precedence list.
  - Replace the fictional `rules --enabled` example in "Configuration Validation".

## Verification

`cargo build && cargo test`, `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`.