### PR TITLE
docs: remove fictional [[overrides]] and [output] config sections

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -435,30 +435,6 @@
 # No configuration options
 
 # ============================================================================
-# FILE-SPECIFIC OVERRIDES
-# ============================================================================
-
-# Override rules for specific files or patterns
-# [[overrides]]
-# path = "README.md"
-# disabled_rules = ["MD041"]  # README doesn't need H1 as first line
-
-# [[overrides]]
-# path = "CHANGELOG.md"
-# disabled_rules = ["MD024", "MD025"]  # Allow duplicate headings in changelog
-
-# [[overrides]]
-# path = "examples/**/*.md"
-# disabled_rules = ["MD013"]  # No line length limit in examples
-# [overrides.rules.MD009]
-# br_spaces = 0  # No trailing spaces allowed in examples
-
-# [[overrides]]
-# path = "docs/api/**"
-# [overrides.rules.MD013]
-# line_length = 120  # Longer lines for API docs
-
-# ============================================================================
 # PREPROCESSOR CONFIGURATION
 # ============================================================================
 
@@ -466,14 +442,3 @@
 # [preprocessor]
 # fail_on_warnings = true  # Fail the build on warnings
 # renderer = ["html", "pdf"]  # Run for specific renderers
-
-# ============================================================================
-# OUTPUT CONFIGURATION
-# ============================================================================
-
-# [output]
-# format = "github"  # Options: "github", "json", "checkstyle"
-# file = "lint-report.json"  # Output to file instead of stdout
-# verbose = false  # Verbose output
-# quiet = false  # Suppress non-error output
-# color = "auto"  # Options: "auto", "always", "never"

--- a/docs/src/example-configuration.md
+++ b/docs/src/example-configuration.md
@@ -99,31 +99,6 @@ style = "asterisk"
 style = "asterisk"
 ```
 
-## File-Specific Overrides
-
-### Example: Different Rules for Different Directories
-
-```toml
-# Strict rules for source documentation
-[[overrides]]
-path = "src/**/*.md"
-[overrides.rules.MD013]
-line_length = 80
-
-# Relaxed rules for examples
-[[overrides]]
-path = "examples/**/*.md"
-disabled_rules = ["MD013", "MD009"]
-
-# Special rules for CHANGELOG
-[[overrides]]
-path = "CHANGELOG.md"
-disabled_rules = [
-    "MD024",  # Allow duplicate version headings
-    "MD025"   # Allow multiple H1s for versions
-]
-```
-
 ## Integration Configurations
 
 ### GitHub Actions
@@ -131,9 +106,6 @@ disabled_rules = [
 ```toml
 # For CI/CD pipelines
 fail-on-warnings = true
-
-[output]
-format = "github"  # GitHub Actions annotations
 ```
 
 ### mdBook Preprocessor
@@ -142,15 +114,6 @@ format = "github"  # GitHub Actions annotations
 [preprocessor]
 fail_on_warnings = false  # Warning but don't fail build
 renderer = ["html"]  # Only run for HTML output
-```
-
-### Editor Integration
-
-```toml
-# For real-time feedback
-[output]
-format = "json"  # Machine-readable output
-verbose = false  # Minimal output
 ```
 
 ## Rule Categories Quick Reference
@@ -180,10 +143,9 @@ disabled_rules = [
 ## Tips
 
 1. **Start minimal**: Begin with defaults and add configuration as needed
-2. **Use overrides**: Apply different rules to different parts of your project
-3. **Document choices**: Comment why certain rules are disabled
-4. **Version control**: Commit `.mdbook-lint.toml` to your repository
-5. **Team agreement**: Discuss and agree on rules with your team
+2. **Document choices**: Comment why certain rules are disabled
+3. **Version control**: Commit `.mdbook-lint.toml` to your repository
+4. **Team agreement**: Discuss and agree on rules with your team
 
 ## Next Steps
 

--- a/docs/src/rules/mdbook/mdbook005.md
+++ b/docs/src/rules/mdbook/mdbook005.md
@@ -151,14 +151,6 @@ Consider disabling this rule if:
 disabled_rules = ["MDBOOK005"]
 ```
 
-### Disable for Specific Directories
-
-```toml
-[[overrides]]
-path = "src/reference/**"
-disabled_rules = ["MDBOOK005"]
-```
-
 ## Best Practices
 
 1. **Regular cleanup**: Periodically review and remove orphaned files

--- a/docs/src/rules/standard/md047.md
+++ b/docs/src/rules/standard/md047.md
@@ -81,15 +81,12 @@ Consider disabling this rule if:
 disabled_rules = ["MD047"]
 ```
 
-### Disable for Specific Files
+### Disable for a Specific File
 
-Since this is a file-level rule, you can exclude specific files:
+Add an inline directive at the top of the file you want to exclude:
 
-```toml
-# .mdbook-lint.toml
-[[overrides]]
-path = "no-newline.md"
-disabled_rules = ["MD047"]
+```markdown
+<!-- mdbook-lint-disable MD047 -->
 ```
 
 ## Related Rules


### PR DESCRIPTION
closes #421

## Problem

First-party docs document a per-path `[[overrides]]` array-of-tables and an `[output]` config table, neither of which exists on `Config` (`mdbook-lint-core` or the CLI wrapper). Copying either into a `.mdbook-lint.toml` produces no error and no effect: unknown top-level keys are flattened into the `rule_configs` map and silently ignored.

## Plan

Remove the fictional references so the docs only describe supported configuration (option 1 in the issue; implementing per-path overrides warrants its own design issue).

- `crates/mdbook-lint-cli/example-mdbook-lint.toml`: drop the `FILE-SPECIFIC OVERRIDES` and `OUTPUT CONFIGURATION` blocks.
- `docs/src/example-configuration.md`: drop the `File-Specific Overrides` section, the `[output]` entries in the GitHub Actions and Editor Integration examples, and the overrides tip.
- `docs/src/rules/standard/md047.md`: replace the `[[overrides]]` per-file example with the real inline `<!-- mdbook-lint-disable MD047 -->` directive.
- `docs/src/rules/mdbook/mdbook005.md`: drop the fictional per-directory `[[overrides]]` example (global disable is already documented above it).

`README.md` contains no such references. The `[preprocessor]` sections are out of scope for this issue.

## Verification

`cargo build && cargo test`, `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`.