### PR TITLE
fix: standard rules ignore YAML frontmatter (MD041, MD022, MD007)

### DIFF
--- a/crates/mdbook-lint-core/src/document.rs
+++ b/crates/mdbook-lint-core/src/document.rs
@@ -204,6 +204,51 @@ impl Document {
             None
         }
     }
+
+    /// Detect a leading YAML frontmatter block.
+    ///
+    /// Recognition matches comrak's front-matter extension (configured in
+    /// [`Self::parse_ast`] with a `---` delimiter): the block must begin on the
+    /// very first line of the document, its opening and closing delimiter lines
+    /// must each be exactly `---` (no indentation, no trailing whitespace, no
+    /// extra dashes), and a closing delimiter must be present. Returns the
+    /// 1-based, inclusive `(start_line, end_line)` of the block with the
+    /// delimiters included, or `None` when the document has no frontmatter.
+    ///
+    /// Line-based rules use this to avoid treating frontmatter delimiters and
+    /// YAML keys as Markdown headings or lists (see MD041, MD007).
+    pub fn frontmatter_line_range(&self) -> Option<(usize, usize)> {
+        // comrak only recognizes frontmatter that begins on the first line; a
+        // leading blank line disables it, so check line 1 directly.
+        if self.lines.first().map(String::as_str) != Some("---") {
+            return None;
+        }
+
+        // Find the closing delimiter. comrak requires an exact `---` line.
+        self.lines
+            .iter()
+            .enumerate()
+            .skip(1)
+            .find(|(_, line)| line.as_str() == "---")
+            .map(|(idx, _)| (1, idx + 1))
+    }
+
+    /// Number of leading source lines that comrak folds into a front-matter node.
+    ///
+    /// When frontmatter is present, comrak renumbers every following node as if
+    /// the document began at line 1, so the source positions reported for nodes
+    /// after the frontmatter are shifted up by the number of lines the
+    /// frontmatter occupied (delimiters plus a single trailing blank line). Add
+    /// this offset back to translate an AST line number into an index into
+    /// [`Self::lines`]. Returns 0 when the document has no frontmatter.
+    pub fn frontmatter_ast_offset<'a>(&self, ast: &'a AstNode<'a>) -> usize {
+        ast.children()
+            .find_map(|child| match &child.data.borrow().value {
+                NodeValue::FrontMatter(text) => Some(text.matches('\n').count()),
+                _ => None,
+            })
+            .unwrap_or(0)
+    }
 }
 
 #[cfg(test)]
@@ -477,6 +522,65 @@ title: Test
             node_count > 5,
             "Expected AST to contain multiple nodes, got {node_count}"
         );
+    }
+
+    #[test]
+    fn test_frontmatter_line_range_detected() {
+        let content = "---\ntitle: My Document\nstatus: accepted\n---\n\n# My Document\n";
+        let doc = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        assert_eq!(doc.frontmatter_line_range(), Some((1, 4)));
+    }
+
+    #[test]
+    fn test_frontmatter_line_range_none_without_frontmatter() {
+        let doc = Document::new("# Heading\n\nBody.\n".to_string(), PathBuf::from("t.md")).unwrap();
+        assert_eq!(doc.frontmatter_line_range(), None);
+    }
+
+    #[test]
+    fn test_frontmatter_line_range_requires_first_line() {
+        // A leading blank line disables comrak's frontmatter recognition.
+        let doc =
+            Document::new("\n---\ntitle: x\n---\n".to_string(), PathBuf::from("t.md")).unwrap();
+        assert_eq!(doc.frontmatter_line_range(), None);
+    }
+
+    #[test]
+    fn test_frontmatter_line_range_requires_exact_delimiter() {
+        // Extra dashes / trailing space are not the `---` delimiter.
+        let doc =
+            Document::new("----\ntitle: x\n----\n".to_string(), PathBuf::from("t.md")).unwrap();
+        assert_eq!(doc.frontmatter_line_range(), None);
+    }
+
+    #[test]
+    fn test_frontmatter_line_range_requires_closing() {
+        let doc = Document::new("---\ntitle: x\n# H\n".to_string(), PathBuf::from("t.md")).unwrap();
+        assert_eq!(doc.frontmatter_line_range(), None);
+    }
+
+    #[test]
+    fn test_frontmatter_ast_offset_matches_comrak() {
+        // The heading below sits on source line 6 but comrak reports it at line 1
+        // after folding the 5 frontmatter lines (delimiters + trailing blank).
+        let content = "---\ntitle: x\nstatus: y\n---\n\n# My Document\n";
+        let doc = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let arena = Arena::new();
+        let ast = doc.parse_ast(&arena);
+        let offset = doc.frontmatter_ast_offset(ast);
+        assert_eq!(offset, 5);
+
+        let heading = doc.headings(ast)[0];
+        let (line, _) = doc.node_position(heading).unwrap();
+        assert_eq!(line + offset, 6);
+    }
+
+    #[test]
+    fn test_frontmatter_ast_offset_zero_without_frontmatter() {
+        let doc = Document::new("# H\n\nBody.\n".to_string(), PathBuf::from("t.md")).unwrap();
+        let arena = Arena::new();
+        let ast = doc.parse_ast(&arena);
+        assert_eq!(doc.frontmatter_ast_offset(ast), 0);
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md007.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md007.rs
@@ -214,13 +214,31 @@ impl AstRule for MD007 {
         let mut violations = Vec::new();
         let lines: Vec<&str> = document.content.lines().collect();
 
-        // Get code block line ranges from AST
-        let code_block_lines = self.get_code_block_line_ranges(ast);
+        // YAML frontmatter uses `---` fences and can contain YAML block sequences
+        // (`  - item`) that must not be linted as Markdown list indentation.
+        let frontmatter_range = document.frontmatter_line_range();
+
+        // Get code block line ranges from AST. comrak renumbers nodes after
+        // frontmatter, so shift the ranges back onto the real source lines.
+        let frontmatter_offset = document.frontmatter_ast_offset(ast);
+        let code_block_lines: Vec<(usize, usize)> = self
+            .get_code_block_line_ranges(ast)
+            .into_iter()
+            .map(|(start, end)| (start + frontmatter_offset, end + frontmatter_offset))
+            .collect();
 
         let mut list_stack: Vec<(usize, char, bool)> = Vec::new(); // (indent, marker, is_ordered)
 
         for (line_number, line) in lines.iter().enumerate() {
             let line_number = line_number + 1;
+
+            // Skip frontmatter lines (delimiters and YAML content)
+            if let Some((fm_start, fm_end)) = frontmatter_range
+                && line_number >= fm_start
+                && line_number <= fm_end
+            {
+                continue;
+            }
 
             // Skip lines inside code blocks
             let in_code_block = code_block_lines
@@ -669,6 +687,37 @@ Another regular list:
         // Verify it's the right violation (line 19 is the "    * Too much indent" line)
         assert_eq!(violations[0].line, 19);
         assert!(violations[0].message.contains("Expected 2 spaces, found 4"));
+    }
+
+    #[test]
+    fn test_md007_ignores_frontmatter_block_sequence() {
+        // Regression for issue #406: a YAML block sequence inside frontmatter
+        // (`  - item`) must not be linted as mis-indented Markdown list items.
+        let content = "---\nstatus: accepted\ndecision-makers:\n  - Alice\n  - Bob\n---\n\n# Title\n\nBody.\n";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD007::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(
+            violations.len(),
+            0,
+            "YAML block sequence in frontmatter should not be flagged"
+        );
+    }
+
+    #[test]
+    fn test_md007_body_list_after_frontmatter_reported_at_real_line() {
+        // A genuine list-indentation problem in the body must still be flagged,
+        // and reported at the real source line despite the frontmatter above it.
+        let content =
+            "---\nstatus: accepted\ndeciders:\n  - Alice\n---\n\n# T\n\n* Item\n   * Bad indent\n";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD007::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 10);
+        assert!(violations[0].message.contains("Expected 2 spaces, found 3"));
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md022.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md022.rs
@@ -40,11 +40,18 @@ impl AstRule for MD022 {
     fn check_ast<'a>(&self, document: &Document, ast: &'a AstNode<'a>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
 
+        // comrak renumbers nodes after YAML frontmatter as if the document began
+        // at line 1. Add the frontmatter offset back so heading positions map to
+        // the real source lines (and so the blank-line checks read the right
+        // lines rather than the frontmatter delimiters).
+        let frontmatter_offset = document.frontmatter_ast_offset(ast);
+
         // Find all heading nodes in the AST
         for node in ast.descendants() {
             if let NodeValue::Heading(_) = &node.data.borrow().value
                 && let Some((line, column)) = document.node_position(node)
             {
+                let line = line + frontmatter_offset;
                 // Check for blank line before the heading
                 if !self.has_blank_line_before(document, line) {
                     // Create fix to add blank line before heading
@@ -425,6 +432,32 @@ mod tests {
 
         // Single heading at start and end of document should be valid
         assert_no_violations(MD022, &content);
+    }
+
+    #[test]
+    fn test_md022_frontmatter_heading_valid() {
+        // Regression for issue #406: the frontmatter fence must not be treated as
+        // a heading, and the body heading below it must not be reported at line 1.
+        let content = "---\ntitle: My Document\nstatus: accepted\n---\n\n# My Document\n\nA short paragraph of body text.\n";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD022;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md022_frontmatter_violation_reported_at_real_line() {
+        // With frontmatter present, a genuine missing-blank violation must be
+        // reported at the real body line, not comrak's frontmatter-shifted line.
+        let content = "---\ntitle: X\n---\n\n# Title\nNo blank after heading.\n";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD022;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("followed by a blank line"));
+        assert_eq!(violations[0].line, 5);
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md041.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md041.rs
@@ -41,6 +41,24 @@ impl MD041 {
         let trimmed = line.trim();
         !trimmed.is_empty() && !trimmed.starts_with('#')
     }
+
+    /// Check whether any frontmatter line declares a title field, e.g. `title: X`.
+    ///
+    /// Mirrors markdownlint's default `front_matter_title` pattern
+    /// (`^\s*"?title"?\s*[:=]`), covering the common YAML (`title:`) and TOML
+    /// (`title =`) spellings, with or without quotes around the key. A document
+    /// whose frontmatter declares a title satisfies MD041's title requirement.
+    fn frontmatter_declares_title(lines: &[String]) -> bool {
+        lines.iter().any(|line| {
+            let rest = line.trim_start();
+            let rest = rest.strip_prefix('"').unwrap_or(rest);
+            let Some(after_key) = rest.strip_prefix("title") else {
+                return false;
+            };
+            let after_key = after_key.strip_prefix('"').unwrap_or(after_key);
+            after_key.trim_start().starts_with([':', '='])
+        })
+    }
 }
 
 impl Rule for MD041 {
@@ -71,10 +89,22 @@ impl Rule for MD041 {
             return Ok(violations);
         }
 
+        // YAML frontmatter is not Markdown content. If the document declares a
+        // title there, the title requirement is already satisfied; otherwise skip
+        // past the frontmatter block so its delimiters and keys are not linted as
+        // the first heading.
+        let mut scan_start = 0;
+        if let Some((_, end)) = document.frontmatter_line_range() {
+            if Self::frontmatter_declares_title(&document.lines[..end]) {
+                return Ok(violations);
+            }
+            scan_start = end;
+        }
+
         // Find the first non-empty, non-HTML-comment line
         let mut first_content_line_idx = None;
         let mut in_comment = false;
-        for (idx, line) in document.lines.iter().enumerate() {
+        for (idx, line) in document.lines.iter().enumerate().skip(scan_start) {
             let trimmed = line.trim();
 
             if trimmed.is_empty() {
@@ -322,6 +352,44 @@ mod tests {
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md041_frontmatter_then_heading_valid() {
+        // Regression for issue #406: YAML frontmatter must not be linted as the
+        // first heading; the body's H1 satisfies the rule.
+        let content =
+            "---\ntitle: My Document\nstatus: accepted\n---\n\n# My Document\n\nBody text.\n";
+        let document = create_test_document(content);
+        let rule = MD041;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md041_frontmatter_title_satisfies_rule() {
+        // Issue #406: a frontmatter `title:` field satisfies the title requirement
+        // even when the body does not open with an H1.
+        let content = "---\ntitle: My Document\nstatus: accepted\n---\n\nJust a paragraph.\n";
+        let document = create_test_document(content);
+        let rule = MD041;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md041_frontmatter_without_title_still_checks_body() {
+        // Without a title field, the body must still open with an H1; the
+        // violation is reported at the real body line, not the frontmatter fence.
+        let content = "---\nstatus: accepted\n---\n\nJust a paragraph, no heading.\n";
+        let document = create_test_document(content);
+        let rule = MD041;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 5);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

closes #406

On any document with leading YAML frontmatter, the standard rules linted the frontmatter as Markdown:

- **MD041** reported "first line in file should be a top level heading" on the opening `---`.
- **MD022** treated the `---` fence as a heading and reported missing surrounding blank lines at line 1.
- **MD007** flagged YAML block sequences (`  - item`) as mis-indented Markdown list items.

## Root cause

comrak is configured with `front_matter_delimiter = Some("---")`, so it recognizes the frontmatter and folds it into a `FrontMatter` node. But comrak then renumbers every following node as if the document began at line 1. The standard rules did not consult the frontmatter node, so:

- Line-based rules (MD041, MD007) scanned the frontmatter lines directly.
- AST-based MD022 read heading positions that were shifted up by the frontmatter line count, so it read `document.lines[0]` (`---`) instead of the real heading line.

## Fix

Two helpers on `Document`:

- `frontmatter_line_range()` detects a leading frontmatter block using comrak's exact recognition rules (opening/closing lines must be exactly `---`, block must start on line 1, closing delimiter required). Used by line-based rules to skip the block.
- `frontmatter_ast_offset()` returns the number of lines comrak folded into the `FrontMatter` node, so AST rules can map source positions back onto the real lines.

Per-rule changes:

| Rule | Change |
| --- | --- |
| MD041 | Skip the frontmatter block; a `title:` field satisfies the title requirement (markdownlint `front_matter_title` behavior). |
| MD022 | Add the frontmatter offset to heading positions so checks and reported lines use the real source lines. |
| MD007 | Skip frontmatter lines; shift AST code-block ranges by the offset. |

Genuine violations in the document body are still reported, at the correct source lines.

## Tests

- Core: `frontmatter_line_range` / `frontmatter_ast_offset` detection and edge cases (leading blank line, non-exact delimiter, missing closing delimiter, offset matches comrak).
- MD041: frontmatter + body H1 clean; `title:` field satisfies the rule; frontmatter without title still checks the body at the real line.
- MD022: frontmatter heading clean; genuine violation reported at the real body line.
- MD007: frontmatter block sequence not flagged; genuine body list mis-indent reported at the real line.

## Verification

```
$ mdbook-lint lint --enable MD041,MD022,MD007 doc.md
No issues found
```

Gates: `cargo test`, `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` all pass.