### PR TITLE
fix: duplicate-heading link fragments match mdBook unique ids

### DIFF
--- a/crates/mdbook-lint-rulesets/src/content/content006.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content006.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::Document;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::violation::{Severity, Violation};
 use regex::Regex;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 /// Regex to match ATX headings and capture the text
@@ -67,6 +67,9 @@ impl CONTENT006 {
     /// Extract all valid anchors from the document (from headings)
     fn extract_anchors(&self, document: &Document) -> HashSet<String> {
         let mut anchors = HashSet::new();
+        // Counter of how many times each base anchor has been seen, so duplicate
+        // headings get the same unique ids mdBook generates (bare, then "-1", "-2", ...).
+        let mut anchor_counts: HashMap<String, usize> = HashMap::new();
         let mut in_code_block = false;
 
         for line in &document.lines {
@@ -86,8 +89,15 @@ impl CONTENT006 {
             if let Some(caps) = HEADING_REGEX.captures(trimmed)
                 && let Some(heading_text) = caps.get(1)
             {
-                let anchor = Self::generate_anchor(heading_text.as_str());
-                if !anchor.is_empty() {
+                let base_anchor = Self::generate_anchor(heading_text.as_str());
+                if !base_anchor.is_empty() {
+                    let count = anchor_counts.entry(base_anchor.clone()).or_insert(0);
+                    let anchor = if *count == 0 {
+                        base_anchor.clone()
+                    } else {
+                        format!("{base_anchor}-{count}")
+                    };
+                    *count += 1;
                     anchors.insert(anchor);
                 }
             }
@@ -428,6 +438,63 @@ See [instructions](#installation) for details.";
         let rule = CONTENT006;
         let violations = rule.check(&doc).unwrap();
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_issue_410_duplicate_heading_fragments() {
+        // Issue #410: two "Details" headings resolve to ids "details" and
+        // "details-1"; a link to the second must not be flagged.
+        let content = "# Demo
+
+## Topic
+
+Look at its [details](#details).
+
+### Details
+
+Details about the topic.
+
+## Another Topic
+
+Look at its [details](#details-1).
+
+### Details
+
+Details about the other topic.";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations: {violations:#?}"
+        );
+    }
+
+    #[test]
+    fn test_issue_410_broken_duplicate_fragment_still_errors() {
+        // With two "Details" headings the valid ids are "details" and
+        // "details-1"; "details-2" is broken and must still be reported.
+        let content = "# Demo
+
+### Details
+
+First.
+
+### Details
+
+Second.
+
+[bad link](#details-2)";
+        let doc = create_test_document(content);
+        let rule = CONTENT006;
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(
+            violations.len(),
+            1,
+            "Expected one violation: {violations:#?}"
+        );
+        assert!(violations[0].message.contains("details-2"));
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook006.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook006.rs
@@ -226,14 +226,24 @@ impl MDBOOK006 {
     /// Extract heading anchors from markdown content
     fn extract_heading_anchors(&self, content: &str) -> Vec<String> {
         let mut anchors = Vec::new();
+        // Counter of how many times each base anchor has been seen, so duplicate
+        // headings get the same unique ids mdBook generates (bare, then "-1", "-2", ...).
+        let mut anchor_counts: HashMap<String, usize> = HashMap::new();
 
         for line in content.lines() {
             let line = line.trim();
 
             // Match ATX headings (# ## ### etc)
             if let Some(heading_text) = self.extract_atx_heading(line) {
-                let anchor = self.generate_anchor_id(&heading_text);
-                if !anchor.is_empty() {
+                let base_anchor = self.generate_anchor_id(&heading_text);
+                if !base_anchor.is_empty() {
+                    let count = anchor_counts.entry(base_anchor.clone()).or_insert(0);
+                    let anchor = if *count == 0 {
+                        base_anchor.clone()
+                    } else {
+                        format!("{base_anchor}-{count}")
+                    };
+                    *count += 1;
                     anchors.push(anchor);
                 }
             }
@@ -620,6 +630,82 @@ See [nested section](guide/deep.md#nested-section).
             0,
             "Nested directory cross-references should work"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_issue_410_duplicate_heading_fragments() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+
+        // Target file with two identical headings -> ids "details" and "details-1".
+        let target_content = r#"# Chapter
+
+### Details
+
+First.
+
+### Details
+
+Second.
+"#;
+        create_test_document(target_content, &root.join("chapter.md"))?;
+
+        // Source links to the second heading via its mdBook-generated id.
+        let source_content = r#"# Source
+
+See [details](chapter.md#details) and [more details](chapter.md#details-1).
+"#;
+        let source_path = root.join("source.md");
+        let doc = create_test_document(source_content, &source_path)?;
+
+        let rule = MDBOOK006::default();
+        let violations = rule.check(&doc)?;
+
+        assert_eq!(
+            violations.len(),
+            0,
+            "Duplicate-heading cross-references should be valid: {violations:#?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_issue_410_broken_duplicate_fragment_still_errors() -> mdbook_lint_core::error::Result<()>
+    {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+
+        // Two "Details" headings -> valid ids "details" and "details-1".
+        let target_content = r#"# Chapter
+
+### Details
+
+First.
+
+### Details
+
+Second.
+"#;
+        create_test_document(target_content, &root.join("chapter.md"))?;
+
+        // "details-2" does not exist and must still be flagged.
+        let source_content = r#"# Source
+
+See [broken](chapter.md#details-2).
+"#;
+        let source_path = root.join("source.md");
+        let doc = create_test_document(source_content, &source_path)?;
+
+        let rule = MDBOOK006::default();
+        let violations = rule.check(&doc)?;
+
+        assert_eq!(
+            violations.len(),
+            1,
+            "Expected one violation: {violations:#?}"
+        );
+        assert!(violations[0].message.contains("details-2"));
         Ok(())
     }
 

--- a/crates/mdbook-lint-rulesets/src/standard/md051.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md051.rs
@@ -155,16 +155,18 @@ impl MD051 {
         match &node.data.borrow().value {
             NodeValue::Heading(_) => {
                 let heading_text = Self::extract_heading_text(node);
-                let mut fragment = self.generate_heading_fragment(&heading_text);
+                let base_fragment = self.generate_heading_fragment(&heading_text);
 
-                // Handle duplicate fragments by appending numbers
-                if let Some(count) = heading_counts.get(&fragment) {
-                    let new_count = count + 1;
-                    heading_counts.insert(fragment.clone(), new_count);
-                    fragment = format!("{fragment}-{new_count}");
+                // Handle duplicate fragments by appending an incrementing counter,
+                // matching mdBook's zero-based scheme: the first occurrence is bare,
+                // the second is "-1", the third "-2", and so on.
+                let count = heading_counts.entry(base_fragment.clone()).or_insert(0);
+                let fragment = if *count == 0 {
+                    base_fragment.clone()
                 } else {
-                    heading_counts.insert(fragment.clone(), 1);
-                }
+                    format!("{base_fragment}-{count}")
+                };
+                *count += 1;
 
                 fragments.insert(fragment);
 
@@ -1061,6 +1063,90 @@ More content.
             0,
             "Expected no violations but found: {violations:#?}"
         );
+    }
+
+    #[test]
+    fn test_issue_410_duplicate_heading_fragments_ast() {
+        // Issue #410: duplicate headings get mdBook's zero-based unique ids
+        // (bare, then "-1", "-2", ...). The AST path is what the CLI uses, and
+        // it previously produced an off-by-one suffix ("-2" for the second heading).
+        use comrak::Arena;
+        use mdbook_lint_core::rule::Rule;
+
+        let content = r#"# Demo
+
+## Topic
+
+Look at its [details](#details).
+
+### Details
+
+Details about the topic.
+
+## Another Topic
+
+Look at its [details](#details-1).
+
+### Details
+
+Details about the other topic.
+"#;
+
+        let document = mdbook_lint_core::Document::new(
+            content.to_string(),
+            std::path::PathBuf::from("demo.md"),
+        )
+        .unwrap();
+
+        let arena = Arena::new();
+        let ast = document.parse_ast(&arena);
+
+        let rule = MD051::new();
+        let violations = rule.check_with_ast(&document, Some(ast)).unwrap();
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no violations but found: {violations:#?}"
+        );
+    }
+
+    #[test]
+    fn test_issue_410_broken_fragment_still_errors_ast() {
+        // A genuinely broken fragment must still be flagged. With two "Details"
+        // headings the valid ids are "details" and "details-1"; "details-2" is bogus.
+        use comrak::Arena;
+        use mdbook_lint_core::rule::Rule;
+
+        let content = r#"# Demo
+
+### Details
+
+First.
+
+### Details
+
+Second.
+
+[bad link](#details-2)
+"#;
+
+        let document = mdbook_lint_core::Document::new(
+            content.to_string(),
+            std::path::PathBuf::from("demo.md"),
+        )
+        .unwrap();
+
+        let arena = Arena::new();
+        let ast = document.parse_ast(&arena);
+
+        let rule = MD051::new();
+        let violations = rule.check_with_ast(&document, Some(ast)).unwrap();
+        assert_eq!(
+            violations.len(),
+            1,
+            "Expected one violation: {violations:#?}"
+        );
+        assert!(violations[0].message.contains("details-2"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #410

## Problem

`MD051`, `CONTENT006`, and `MDBOOK006` flag link fragments of duplicate headings (with a trailing counter) as invalid, even when they are correct given mdBook's rendered output.

Given two headings with the same text, mdBook assigns ids `details` and `details-1`. Clicking the `#details-1` link in the rendered HTML jumps to the second heading, but all three rules reported it as broken.

## Root cause

mdBook assigns unique heading ids with a zero-based counter (`mdbook::utils::unique_id_from_content`): the first occurrence of a normalized id is used bare, and each subsequent occurrence gets `-N` where N is the number of prior occurrences. So the sequence is `details`, `details-1`, `details-2`, and so on.

The three rules each build their set of valid anchors differently, and none matched that algorithm:

- **CONTENT006** (`content006.rs` `extract_anchors`): collected anchors into a `HashSet` with no duplicate handling. Both `### Details` headings produced `details`, so `details-1` was never generated.
- **MDBOOK006** (`mdbook006.rs` `extract_heading_anchors`): pushed each anchor into a `Vec` with no duplicate handling. Same failure.
- **MD051** (`md051.rs` `traverse_for_fragments`): had a duplicate counter but it was off by one. The second `Details` produced `details-2` instead of `details-1` (it incremented before using the count).

### Why MD051's existing duplicate test did not catch it

`test_duplicate_heading_numbering` runs through the default `Rule::check`, which passes `None` for the AST. With no AST, MD051 uses `check_fragments_fallback`, which does not validate fragments against real headings. The real CLI parses the AST and hits the buggy path. This is the same fallback-vs-AST trap already noted in the file's issue-356 comment.

## Fix

All three rules now generate ids in document order using mdBook's zero-based scheme (bare, then `-1`, `-2`, ...):

- **MD051**: use the current count as the suffix, then increment.
- **CONTENT006**: add the counter in `extract_anchors` (plus a `HashMap` import).
- **MDBOOK006**: add the counter in `extract_heading_anchors`.

The anchor-normalization character rules (punctuation, backticks, underscores, Unicode) are unchanged and already correct; only the uniquification step was wrong or missing.

## Tests

Adds two regression tests per rule (6 total): the duplicate-heading case from the issue is valid, and a genuinely broken fragment (`#details-2` when only `details` and `details-1` exist) still errors. MD051's tests use the AST path, since the default check routes through the non-validating fallback.

## Verification

- `cargo build`, `cargo test` (0 failures), `cargo fmt --all -- --check`, and `cargo clippy --all-targets -- -D warnings` all pass.
- Running the built CLI on the issue's exact file produces no MD051, CONTENT006, or MDBOOK006 diagnostics for `#details-1`, and the negative control (`#details-2`) still errors.

## Follow-up (not in this PR)

All three rules now carry duplicate copies of both the anchor normalizer and this counter. Extracting a shared `unique_id_from_content` helper into `mdbook-lint-core` would prevent future drift.