### PR TITLE
fix: wire CONTENT provider rule configuration

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -314,28 +314,50 @@
 # ============================================================================
 # Rules for checking document content quality and structure
 
-# CONTENT001 - Document should have a title (H1 heading)
+# CONTENT001 - TODO/FIXME/XXX comments should be resolved before publishing
 # [CONTENT001]
+# markers = ["TODO", "FIXME", "XXX"]  # Custom markers to detect
+# include_defaults = true             # Also check the built-in markers
+# check_code_blocks = false           # Scan inside code blocks
+
+# CONTENT002 - Placeholder text should be replaced with actual content
+# [CONTENT002]
+# check_code_blocks = false   # Scan inside code blocks
+# allow_example_urls = true   # Allow example.com URLs in examples
+
+# CONTENT003 - Chapters should have sufficient content (minimum word count)
+# [CONTENT003]
+# min_words = 50              # Flag chapters below this word count
+# include_code_blocks = false # Count words inside code blocks
+
+# CONTENT004 - Headings should use consistent capitalization
+# [CONTENT004]
+# style = "consistent"  # Options: "title", "sentence", "consistent"
+
+# CONTENT005 - Chapters should have introductory content before the first subheading
+# [CONTENT005]
+# min_words = 10  # Minimum words required in the introduction
+
+# CONTENT006 - Internal anchor links should reference valid headings
+# [CONTENT006]
 # No configuration options
 
-# CONTENT002 - Document should have an introduction/summary
-# [CONTENT002]
-# min_words = 10  # Minimum words in introduction paragraph
+# CONTENT007 - Terms should be used consistently throughout a document
+# [CONTENT007]
+# term_groups = [["email", "e-mail"]]  # Groups of terms to keep consistent
+# min_occurrences = 1                  # Occurrences before reporting
 
-# CONTENT003 - Headings should be descriptive
-# [CONTENT003]
-# min_length = 3  # Minimum heading length in characters
-# max_length = 80  # Maximum heading length in characters
+# CONTENT009 - Heading nesting should not be too deep
+# [CONTENT009]
+# max_depth = 4  # Deepest heading level allowed (1-6)
 
-# CONTENT004 - Code blocks should have explanatory text
-# [CONTENT004]
-# require_before = true  # Require text before code block
-# require_after = false  # Require text after code block
+# CONTENT010 - Link text should be descriptive
+# [CONTENT010]
+# No configuration options
 
-# CONTENT005 - Document should have adequate content
-# [CONTENT005]
-# min_words = 50  # Minimum word count for document
-# min_headings = 1  # Minimum number of headings
+# CONTENT011 - Documentation should use present tense
+# [CONTENT011]
+# No configuration options
 
 # ============================================================================
 # MDBOOK-SPECIFIC RULES

--- a/crates/mdbook-lint-rulesets/src/content/content001.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content001.rs
@@ -75,6 +75,38 @@ impl CONTENT001 {
         self
     }
 
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `markers`: array of custom marker strings to detect.
+    /// - `include_defaults`: also check the built-in markers (default true).
+    /// - `check_code_blocks`: scan inside code blocks (default false).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+
+        if let Some(markers) = config.get("markers").and_then(|v| v.as_array()) {
+            rule.markers = markers
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(b) = config
+            .get("include_defaults")
+            .or_else(|| config.get("include-defaults"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.include_defaults = b;
+        }
+        if let Some(b) = config
+            .get("check_code_blocks")
+            .or_else(|| config.get("check-code-blocks"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.check_code_blocks = b;
+        }
+        rule
+    }
+
     /// Get all markers to check
     fn get_markers(&self) -> Vec<&str> {
         let mut markers: Vec<&str> = Vec::new();

--- a/crates/mdbook-lint-rulesets/src/content/content001.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content001.rs
@@ -273,6 +273,25 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config() {
+        let cfg: toml::Value = toml::from_str(
+            "markers = [\"REVIEW\"]\ninclude_defaults = false\ncheck_code_blocks = true",
+        )
+        .unwrap();
+        let rule = CONTENT001::from_config(&cfg);
+        assert_eq!(rule.markers, vec!["REVIEW".to_string()]);
+        assert!(!rule.include_defaults);
+        assert!(rule.check_code_blocks);
+
+        // Empty config matches default().
+        let empty: toml::Value = toml::from_str("").unwrap();
+        let d = CONTENT001::from_config(&empty);
+        assert!(d.markers.is_empty());
+        assert!(d.include_defaults);
+        assert!(!d.check_code_blocks);
+    }
+
+    #[test]
     fn test_no_markers() {
         let content = "# Title\n\nThis is clean documentation.";
         let doc = create_test_document(content);

--- a/crates/mdbook-lint-rulesets/src/content/content002.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content002.rs
@@ -137,6 +137,30 @@ impl Default for CONTENT002 {
 }
 
 impl CONTENT002 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `check_code_blocks`: scan inside code blocks (default false).
+    /// - `allow_example_urls`: allow `example.com` URLs in examples (default true).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(b) = config
+            .get("check_code_blocks")
+            .or_else(|| config.get("check-code-blocks"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.check_code_blocks = b;
+        }
+        if let Some(b) = config
+            .get("allow_example_urls")
+            .or_else(|| config.get("allow-example-urls"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.allow_example_urls = b;
+        }
+        rule
+    }
+
     /// Set whether to check inside code blocks
     #[allow(dead_code)]
     pub fn check_code_blocks(mut self, check: bool) -> Self {

--- a/crates/mdbook-lint-rulesets/src/content/content003.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content003.rs
@@ -35,6 +35,32 @@ impl Default for CONTENT003 {
 }
 
 impl CONTENT003 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `min_words`: minimum word count below which a chapter is flagged
+    ///   (default 50).
+    /// - `include_code_blocks`: count words inside code blocks (default false).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(n) = config
+            .get("min_words")
+            .or_else(|| config.get("min-words"))
+            .and_then(|v| v.as_integer())
+            .and_then(|v| usize::try_from(v).ok())
+        {
+            rule.min_words = n;
+        }
+        if let Some(b) = config
+            .get("include_code_blocks")
+            .or_else(|| config.get("include-code-blocks"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.include_code_blocks = b;
+        }
+        rule
+    }
+
     /// Create with a custom minimum word count
     #[allow(dead_code)]
     pub fn with_min_words(min_words: usize) -> Self {

--- a/crates/mdbook-lint-rulesets/src/content/content004.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content004.rs
@@ -292,6 +292,20 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_style() {
+        let mk = |s: &str| {
+            let cfg: toml::Value = toml::from_str(&format!("style = \"{s}\"")).unwrap();
+            CONTENT004::from_config(&cfg).style
+        };
+        assert_eq!(mk("title"), CapitalizationStyle::TitleCase);
+        assert_eq!(mk("title_case"), CapitalizationStyle::TitleCase);
+        assert_eq!(mk("sentence"), CapitalizationStyle::SentenceCase);
+        assert_eq!(mk("consistent"), CapitalizationStyle::Consistent);
+        // Unknown values fall back to the default (Consistent).
+        assert_eq!(mk("bogus"), CapitalizationStyle::Consistent);
+    }
+
+    #[test]
     fn test_consistent_title_case() {
         let content = "# Getting Started Guide
 

--- a/crates/mdbook-lint-rulesets/src/content/content004.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content004.rs
@@ -49,6 +49,25 @@ impl CONTENT004 {
         Self { style }
     }
 
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `style`: `"title"`/`"title_case"`, `"sentence"`/`"sentence_case"`, or
+    ///   `"consistent"` (default: use whatever style the first heading uses).
+    ///   Unrecognized values fall back to the default.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(style) = config.get("style").and_then(|v| v.as_str()) {
+            rule.style = match style.to_lowercase().replace(['-', ' '], "_").as_str() {
+                "title" | "title_case" => CapitalizationStyle::TitleCase,
+                "sentence" | "sentence_case" => CapitalizationStyle::SentenceCase,
+                "consistent" => CapitalizationStyle::Consistent,
+                _ => rule.style,
+            };
+        }
+        rule
+    }
+
     /// Extract heading text from a line
     fn extract_heading(&self, line: &str) -> Option<(usize, String)> {
         HEADING_REGEX.captures(line).map(|caps| {

--- a/crates/mdbook-lint-rulesets/src/content/content005.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content005.rs
@@ -43,6 +43,27 @@ impl CONTENT005 {
         }
     }
 
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted). `min_words`
+    /// and `min_intro_words` are aliases for the same setting:
+    /// - `min_words` / `min_intro_words`: minimum words required in the
+    ///   introduction paragraph (default 10).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(n) = config
+            .get("min_words")
+            .or_else(|| config.get("min-words"))
+            .or_else(|| config.get("min_intro_words"))
+            .or_else(|| config.get("min-intro-words"))
+            .and_then(|v| v.as_integer())
+            .and_then(|v| usize::try_from(v).ok())
+        {
+            rule.min_intro_words = n;
+        }
+        rule
+    }
+
     /// Get the heading level from a line (1-6, or 0 if not a heading)
     fn get_heading_level(&self, line: &str) -> usize {
         let trimmed = line.trim();

--- a/crates/mdbook-lint-rulesets/src/content/content007.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content007.rs
@@ -271,6 +271,18 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_term_groups() {
+        let cfg: toml::Value =
+            toml::from_str("term_groups = [[\"email\", \"e-mail\"]]\nmin_occurrences = 3").unwrap();
+        let rule = CONTENT007::from_config(&cfg);
+        assert_eq!(
+            rule.term_groups,
+            vec![vec!["email".to_string(), "e-mail".to_string()]]
+        );
+        assert_eq!(rule.min_occurrences, 3);
+    }
+
+    #[test]
     fn test_consistent_config() {
         let content = "# Settings
 

--- a/crates/mdbook-lint-rulesets/src/content/content007.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content007.rs
@@ -70,6 +70,48 @@ impl CONTENT007 {
         }
     }
 
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `term_groups`: array of term groups; each group is an array of strings
+    ///   that should be used consistently (e.g. `[["email", "e-mail"]]`).
+    ///   Replaces the built-in term groups when provided.
+    /// - `min_occurrences`: minimum times a group's terms must appear before an
+    ///   inconsistency is reported (default 1).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+
+        if let Some(groups) = config
+            .get("term_groups")
+            .or_else(|| config.get("term-groups"))
+            .and_then(|v| v.as_array())
+        {
+            rule.term_groups = groups
+                .iter()
+                .filter_map(|group| {
+                    group.as_array().map(|terms| {
+                        terms
+                            .iter()
+                            .filter_map(|t| t.as_str().map(String::from))
+                            .collect::<Vec<String>>()
+                    })
+                })
+                .filter(|group: &Vec<String>| !group.is_empty())
+                .collect();
+        }
+
+        if let Some(n) = config
+            .get("min_occurrences")
+            .or_else(|| config.get("min-occurrences"))
+            .and_then(|v| v.as_integer())
+            .and_then(|v| usize::try_from(v).ok())
+        {
+            rule.min_occurrences = n;
+        }
+
+        rule
+    }
+
     /// Find all occurrences of terms in the document
     fn find_term_occurrences(
         &self,

--- a/crates/mdbook-lint-rulesets/src/content/content009.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content009.rs
@@ -41,6 +41,23 @@ impl CONTENT009 {
             max_depth: max_depth.clamp(1, 6),
         }
     }
+
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key (both `snake_case` and `kebab-case` accepted):
+    /// - `max_depth`: deepest heading level allowed, clamped to 1..=6 (default 4).
+    pub fn from_config(config: &toml::Value) -> Self {
+        if let Some(n) = config
+            .get("max_depth")
+            .or_else(|| config.get("max-depth"))
+            .and_then(|v| v.as_integer())
+            .and_then(|v| usize::try_from(v).ok())
+        {
+            Self::with_max_depth(n)
+        } else {
+            Self::default()
+        }
+    }
 }
 
 impl Rule for CONTENT009 {

--- a/crates/mdbook-lint-rulesets/src/content/content009.rs
+++ b/crates/mdbook-lint-rulesets/src/content/content009.rs
@@ -134,6 +134,18 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_max_depth() {
+        let cfg: toml::Value = toml::from_str("max_depth = 2").unwrap();
+        assert_eq!(CONTENT009::from_config(&cfg).max_depth, 2);
+        // kebab-case accepted
+        let cfg: toml::Value = toml::from_str("max-depth = 3").unwrap();
+        assert_eq!(CONTENT009::from_config(&cfg).max_depth, 3);
+        // clamped to 1..=6
+        let cfg: toml::Value = toml::from_str("max_depth = 99").unwrap();
+        assert_eq!(CONTENT009::from_config(&cfg).max_depth, 6);
+    }
+
+    #[test]
     fn test_normal_nesting() {
         let content = "# Chapter
 

--- a/crates/mdbook-lint-rulesets/src/content/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/content/mod.rs
@@ -112,3 +112,49 @@ impl RuleProvider for ContentRuleProvider {
         ]
     }
 }
+
+#[cfg(test)]
+mod provider_tests {
+    use super::ContentRuleProvider;
+    use mdbook_lint_core::{Config, Document, PluginRegistry};
+    use std::path::PathBuf;
+
+    /// End-to-end: config set on the CONTENT provider actually reaches the rule.
+    /// This is the regression guard for #415 (the provider previously ignored
+    /// all configuration).
+    #[test]
+    fn test_content009_max_depth_threads_through_provider() {
+        // h1..h5; CONTENT009 default max depth is 4, so the h5 is flagged.
+        let content = "# H1\n\n## H2\n\n### H3\n\n#### H4\n\n##### H5\n\nsome text\n";
+        let doc = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+
+        let build = |toml: &str| {
+            let config: Config = toml::from_str(toml).unwrap();
+            let mut registry = PluginRegistry::new();
+            registry
+                .register_provider(Box::new(ContentRuleProvider))
+                .unwrap();
+            let engine = registry.create_engine_with_config(Some(&config)).unwrap();
+            engine
+                .lint_document_with_config(&doc, &config)
+                .unwrap()
+                .into_iter()
+                .filter(|v| v.rule_id == "CONTENT009")
+                .count()
+        };
+
+        // Without config: the h5 is too deep.
+        assert_eq!(
+            build("enabled-rules = [\"CONTENT009\"]"),
+            1,
+            "CONTENT009 should flag the h5 at the default depth"
+        );
+
+        // With max_depth raised: no violation.
+        assert_eq!(
+            build("enabled-rules = [\"CONTENT009\"]\n[CONTENT009]\nmax_depth = 6"),
+            0,
+            "max_depth config must thread through the provider and suppress the violation"
+        );
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/content/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/content/mod.rs
@@ -15,6 +15,7 @@ mod content010;
 mod content011;
 
 use crate::{RuleProvider, RuleRegistry};
+use mdbook_lint_core::Config;
 
 /// Provider for content quality rules (CONTENT001+)
 pub struct ContentRuleProvider;
@@ -41,6 +42,57 @@ impl RuleProvider for ContentRuleProvider {
         registry.register(Box::new(content006::CONTENT006));
         registry.register(Box::new(content007::CONTENT007::default()));
         registry.register(Box::new(content009::CONTENT009::default()));
+        registry.register(Box::new(content010::CONTENT010));
+        registry.register(Box::new(content011::CONTENT011));
+    }
+
+    fn register_rules_with_config(&self, registry: &mut RuleRegistry, config: Option<&Config>) {
+        let cfg = |id: &str| config.and_then(|c| c.rule_configs.get(id));
+
+        let content001 = match cfg("CONTENT001") {
+            Some(c) => content001::CONTENT001::from_config(c),
+            None => content001::CONTENT001::default(),
+        };
+        registry.register(Box::new(content001));
+
+        let content002 = match cfg("CONTENT002") {
+            Some(c) => content002::CONTENT002::from_config(c),
+            None => content002::CONTENT002::default(),
+        };
+        registry.register(Box::new(content002));
+
+        let content003 = match cfg("CONTENT003") {
+            Some(c) => content003::CONTENT003::from_config(c),
+            None => content003::CONTENT003::default(),
+        };
+        registry.register(Box::new(content003));
+
+        let content004 = match cfg("CONTENT004") {
+            Some(c) => content004::CONTENT004::from_config(c),
+            None => content004::CONTENT004::default(),
+        };
+        registry.register(Box::new(content004));
+
+        let content005 = match cfg("CONTENT005") {
+            Some(c) => content005::CONTENT005::from_config(c),
+            None => content005::CONTENT005::default(),
+        };
+        registry.register(Box::new(content005));
+
+        registry.register(Box::new(content006::CONTENT006));
+
+        let content007 = match cfg("CONTENT007") {
+            Some(c) => content007::CONTENT007::from_config(c),
+            None => content007::CONTENT007::default(),
+        };
+        registry.register(Box::new(content007));
+
+        let content009 = match cfg("CONTENT009") {
+            Some(c) => content009::CONTENT009::from_config(c),
+            None => content009::CONTENT009::default(),
+        };
+        registry.register(Box::new(content009));
+
         registry.register(Box::new(content010::CONTENT010));
         registry.register(Box::new(content011::CONTENT011));
     }


### PR DESCRIPTION
Closes #415.

`ContentRuleProvider` never implemented `register_rules_with_config`, so it fell through to the `RuleProvider` trait default and ignored `Config` entirely. None of the CONTENT rules implemented `from_config`, so every documented per-rule option was a silent no-op.

## Plan

- Implement `register_rules_with_config` on `ContentRuleProvider` (same pattern as the standard/mdbook providers).
- Add `from_config` to each rule with configurable fields:
  - CONTENT001 — `markers`, `include_defaults`, `check_code_blocks`
  - CONTENT002 — `check_code_blocks`, `allow_example_urls`
  - CONTENT003 — `min_words`, `include_code_blocks`
  - CONTENT004 — `style` (`title`/`sentence`/`consistent`)
  - CONTENT005 — `min_words` (alias `min_intro_words`)
  - CONTENT007 — `term_groups`, `min_occurrences`
  - CONTENT009 — `max_depth`
- CONTENT006/010/011 are unit structs with no config.
- Keys accept `snake_case` and `kebab-case`.

## Still to do on this branch

- Reconcile the `CONTENT*` blocks in `example-mdbook-lint.toml` with the actual field names (the audit found the documented keys, e.g. `CONTENT003 min_length/max_length`, don't match the real fields). Filed under #415's scope.
- Unit tests per `from_config` and an engine-level test that config threads through `ContentRuleProvider`.

## Notes

The auditor (#415) flagged that the documented option names in the example config describe different rules than what's implemented under those IDs; this PR uses the actual field names as the config keys and updates the docs to match.