### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
A new advisory published 2026-07-07, [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204), flags `crossbeam-epoch < 0.9.20` for an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`. It began failing the `Security Audit` job on `main` and every open PR.

It reaches the tree transitively: `rayon` → `rayon-core` → `crossbeam-deque` → `crossbeam-epoch`.

## Change

Lockfile-only bump `crossbeam-epoch` 0.9.18 → 0.9.20 (`cargo update -p crossbeam-epoch`).

## Result

`cargo audit` exits 0 (only the informational `proc-macro-error2` unmaintained warning remains, which does not fail the audit). `cargo build` unaffected.

Follows #426; same class of moving-target advisory noted in #425.