### PR TITLE
fix: wire ADR provider rule configuration (format override)

### DIFF
--- a/crates/mdbook-lint-rulesets/src/adr/adr001.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr001.rs
@@ -171,6 +171,26 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_format() {
+        // Default is Auto (detect per document).
+        let empty: toml::Value = toml::from_str("").unwrap();
+        assert_eq!(Adr001::from_config(&empty).format, AdrFormat::Auto);
+
+        for (value, expected) in [
+            ("nygard", AdrFormat::Nygard),
+            ("madr", AdrFormat::Madr4),
+            ("auto", AdrFormat::Auto),
+        ] {
+            let cfg: toml::Value = toml::from_str(&format!("format = \"{value}\"")).unwrap();
+            assert_eq!(Adr001::from_config(&cfg).format, expected);
+        }
+
+        // Unrecognized value is ignored, leaving the default.
+        let cfg: toml::Value = toml::from_str("format = \"bogus\"").unwrap();
+        assert_eq!(Adr001::from_config(&cfg).format, AdrFormat::Auto);
+    }
+
+    #[test]
     fn test_valid_nygard_title() {
         let content = r#"# 1. Use Rust for implementation
 

--- a/crates/mdbook-lint-rulesets/src/adr/adr001.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr001.rs
@@ -31,6 +31,23 @@ impl Default for Adr001 {
 }
 
 impl Adr001 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr002.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr002.rs
@@ -36,6 +36,23 @@ impl Default for Adr002 {
 }
 
 impl Adr002 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr003.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr003.rs
@@ -36,6 +36,23 @@ impl Default for Adr003 {
 }
 
 impl Adr003 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr004.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr004.rs
@@ -29,6 +29,23 @@ impl Default for Adr004 {
 }
 
 impl Adr004 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr005.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr005.rs
@@ -29,6 +29,23 @@ impl Default for Adr005 {
 }
 
 impl Adr005 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr006.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr006.rs
@@ -27,6 +27,23 @@ impl Default for Adr006 {
 }
 
 impl Adr006 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr007.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr007.rs
@@ -49,6 +49,23 @@ impl Default for Adr007 {
 }
 
 impl Adr007 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with custom valid statuses
     #[allow(dead_code)]
     pub fn with_statuses(statuses: Vec<String>) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr008.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr008.rs
@@ -34,6 +34,23 @@ impl Default for Adr008 {
 }
 
 impl Adr008 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Get the effective format for the document
     fn effective_format(&self, content: &str) -> AdrFormat {
         match self.format {

--- a/crates/mdbook-lint-rulesets/src/adr/adr009.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr009.rs
@@ -32,6 +32,23 @@ impl Default for Adr009 {
 }
 
 impl Adr009 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Get the effective format for the document
     fn effective_format(&self, content: &str) -> AdrFormat {
         match self.format {

--- a/crates/mdbook-lint-rulesets/src/adr/adr014.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr014.rs
@@ -37,6 +37,23 @@ impl Default for Adr014 {
 }
 
 impl Adr014 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr015.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr015.rs
@@ -26,6 +26,23 @@ impl Default for Adr015 {
 }
 
 impl Adr015 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr016.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr016.rs
@@ -29,6 +29,23 @@ impl Default for Adr016 {
 }
 
 impl Adr016 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/adr017.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr017.rs
@@ -39,6 +39,23 @@ impl Default for Adr017 {
 }
 
 impl Adr017 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized key:
+    /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
+    ///   per-document format auto-detection. Unrecognized values are ignored.
+    pub fn from_config(config: &toml::Value) -> Self {
+        let mut rule = Self::default();
+        if let Some(format) = config
+            .get("format")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<AdrFormat>().ok())
+        {
+            rule.format = format;
+        }
+        rule
+    }
+
     /// Create a new rule with a specific format
     #[allow(dead_code)]
     pub fn with_format(format: AdrFormat) -> Self {

--- a/crates/mdbook-lint-rulesets/src/adr/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/mod.rs
@@ -208,11 +208,7 @@ impl RuleProvider for AdrRuleProvider {
         // A provider-level `[ADR]` block (e.g. `format = "nygard"`) applies to
         // every ADR rule; a per-rule `[ADRxxx]` block overrides it for that rule.
         let provider_cfg = config.and_then(|c| c.rule_configs.get("ADR"));
-        let cfg = |id: &str| {
-            config
-                .and_then(|c| c.rule_configs.get(id))
-                .or(provider_cfg)
-        };
+        let cfg = |id: &str| config.and_then(|c| c.rule_configs.get(id)).or(provider_cfg);
 
         macro_rules! register_configurable {
             ($id:literal, $ty:ty) => {{
@@ -267,6 +263,53 @@ mod tests {
     fn create_test_document(content: &str) -> Document {
         // Use a path that matches ADR directory detection
         Document::new(content.to_string(), PathBuf::from("adr/0001-test-adr.md")).unwrap()
+    }
+
+    /// End-to-end regression guard for #414: a provider-level `[ADR] format`
+    /// block must reach the individual rules and override auto-detection.
+    #[test]
+    fn test_adr_format_override_threads_through_provider() {
+        use mdbook_lint_core::{Config, PluginRegistry};
+
+        // A Nygard-style ADR (no YAML frontmatter): auto-detects as Nygard, so
+        // the MADR-only rule ADR004 ("## Context and Problem Statement") does
+        // not apply.
+        let content = "# 1. Use PostgreSQL\n\n\
+            Date: 2024-01-01\n\n\
+            ## Status\n\nAccepted\n\n\
+            ## Context\n\nWe need a database.\n\n\
+            ## Decision\n\nWe will use PostgreSQL.\n\n\
+            ## Consequences\n\nIt works.\n";
+        let doc = create_test_document(content);
+
+        let adr004_violations = |toml: &str| {
+            let config: Config = toml::from_str(toml).unwrap();
+            let mut registry = PluginRegistry::new();
+            registry
+                .register_provider(Box::new(AdrRuleProvider))
+                .unwrap();
+            let engine = registry.create_engine_with_config(Some(&config)).unwrap();
+            engine
+                .lint_document_with_config(&doc, &config)
+                .unwrap()
+                .into_iter()
+                .filter(|v| v.rule_id == "ADR004")
+                .count()
+        };
+
+        // Auto-detected as Nygard: ADR004 (MADR-only) does not fire.
+        assert_eq!(
+            adr004_violations("enabled-rules = [\"ADR004\"]"),
+            0,
+            "ADR004 should not apply to an auto-detected Nygard document"
+        );
+
+        // Forcing MADR via the provider-level [ADR] block makes ADR004 apply,
+        // and it flags the missing '## Context and Problem Statement' section.
+        assert!(
+            adr004_violations("enabled-rules = [\"ADR004\"]\n[ADR]\nformat = \"madr\"") > 0,
+            "[ADR] format = madr must thread through the provider and make ADR004 apply"
+        );
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/adr/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/mod.rs
@@ -137,6 +137,7 @@ mod adr016;
 mod adr017;
 
 use crate::{RuleProvider, RuleRegistry};
+use mdbook_lint_core::Config;
 
 pub use adr001::Adr001;
 pub use adr002::Adr002;
@@ -197,6 +198,50 @@ impl RuleProvider for AdrRuleProvider {
         registry.register(Box::new(Adr017::default()));
 
         // Collection rules (multi-document)
+        registry.register_collection_rule(Box::new(Adr010));
+        registry.register_collection_rule(Box::new(Adr011));
+        registry.register_collection_rule(Box::new(Adr012));
+        registry.register_collection_rule(Box::new(Adr013));
+    }
+
+    fn register_rules_with_config(&self, registry: &mut RuleRegistry, config: Option<&Config>) {
+        // A provider-level `[ADR]` block (e.g. `format = "nygard"`) applies to
+        // every ADR rule; a per-rule `[ADRxxx]` block overrides it for that rule.
+        let provider_cfg = config.and_then(|c| c.rule_configs.get("ADR"));
+        let cfg = |id: &str| {
+            config
+                .and_then(|c| c.rule_configs.get(id))
+                .or(provider_cfg)
+        };
+
+        macro_rules! register_configurable {
+            ($id:literal, $ty:ty) => {{
+                let rule = match cfg($id) {
+                    Some(c) => <$ty>::from_config(c),
+                    None => <$ty>::default(),
+                };
+                registry.register(Box::new(rule));
+            }};
+        }
+
+        // Single-document rules
+        register_configurable!("ADR001", Adr001);
+        register_configurable!("ADR002", Adr002);
+        register_configurable!("ADR003", Adr003);
+        register_configurable!("ADR004", Adr004);
+        register_configurable!("ADR005", Adr005);
+        register_configurable!("ADR006", Adr006);
+        register_configurable!("ADR007", Adr007);
+        register_configurable!("ADR008", Adr008);
+        register_configurable!("ADR009", Adr009);
+
+        // Content quality rules
+        register_configurable!("ADR014", Adr014);
+        register_configurable!("ADR015", Adr015);
+        register_configurable!("ADR016", Adr016);
+        register_configurable!("ADR017", Adr017);
+
+        // Collection rules (multi-document) have no configurable format field
         registry.register_collection_rule(Box::new(Adr010));
         registry.register_collection_rule(Box::new(Adr011));
         registry.register_collection_rule(Box::new(Adr012));


### PR DESCRIPTION
Closes #414.

`AdrRuleProvider` never implemented `register_rules_with_config`, so the documented provider-level override

```toml
[ADR]
format = "nygard"  # "auto" | "nygard" | "madr"
```

was a silent no-op — every ADR rule always auto-detected the format per document via `detect_format`.

## Change

The override mechanism already existed per rule (`format: AdrFormat` field + `effective_format()` that only auto-detects when `format == Auto`); it was just never fed from config.

- Add `from_config` to each ADR rule with a `format` field (ADR001-009, 014-017), reading the `format` key through the existing `FromStr for AdrFormat` (`auto`/`nygard`/`madr`/`madr4`).
- Implement `register_rules_with_config` on `AdrRuleProvider`: a provider-level `[ADR]` block applies to every rule; a per-rule `[ADRxxx]` block overrides it. Collection rules (ADR010-013) have no `format` field and remain `default()`.

## Relationship to other issues

This provides the "force the format" mechanism that #408 asked for (bypass content heuristics when the format is known), but does not itself fix #408's misclassification or #409's directory detection — those remain separate.

## Still to do on this branch

- `from_config` unit test + a provider-threading test asserting `[ADR] format` changes rule behavior end-to-end.