### PR TITLE
fix: resolve ADR format detection false positives (#408, #409)

### DIFF
--- a/crates/mdbook-lint-rulesets/src/adr/adr004.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr004.rs
@@ -139,6 +139,38 @@ mod tests {
     }
 
     #[test]
+    fn test_ng_nygard_not_flagged_as_madr() {
+        // Regression for #408: a ng+Nygard document (YAML frontmatter with
+        // Nygard sections) must be detected as Nygard, so the MADR-only ADR004
+        // does not fire "missing Context and Problem Statement".
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# 1. Use PostgreSQL
+
+## Context
+
+We need a database.
+
+## Decision
+
+Use PostgreSQL.
+
+## Consequences
+
+It works.
+"#;
+        let doc = create_test_document(content);
+        let violations = Adr004::default().check(&doc).unwrap();
+        assert!(
+            violations.is_empty(),
+            "ADR004 should not apply to a ng+Nygard document, got: {violations:?}"
+        );
+    }
+
+    #[test]
     fn test_valid_nygard_context() {
         let content = r#"# 1. Use Rust for implementation
 

--- a/crates/mdbook-lint-rulesets/src/adr/format.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/format.rs
@@ -47,18 +47,55 @@ static NYGARD_TITLE_REGEX: LazyLock<Regex> =
 
 /// Detect the ADR format based on content
 ///
-/// Returns `AdrFormat::Madr4` if YAML frontmatter is present (starts with `---`),
-/// otherwise returns `AdrFormat::Nygard`.
+/// MADR 4.0 uses YAML frontmatter, but the `adrs` tool's "ng" mode also emits
+/// YAML frontmatter while keeping Nygard-style section headings, so the mere
+/// presence of frontmatter is not enough to tell the two apart. When
+/// frontmatter is present we disambiguate by the section headings actually used:
+///
+/// - MADR headings (`## Context and Problem Statement`, `## Decision Outcome`)
+///   -> [`AdrFormat::Madr4`]
+/// - Nygard headings (`## Consequences`, or both `## Context` and `## Decision`)
+///   without MADR headings -> [`AdrFormat::Nygard`]
+/// - frontmatter with neither signature -> [`AdrFormat::Madr4`] (frontmatter is
+///   MADR's defining feature)
+///
+/// Without frontmatter the document is treated as Nygard.
 pub fn detect_format(content: &str) -> AdrFormat {
     let trimmed = content.trim_start();
 
-    // MADR 4.0 uses YAML frontmatter
     if trimmed.starts_with("---") {
+        let headings = section_headings(content);
+        let has_madr = headings
+            .iter()
+            .any(|h| h == "context and problem statement" || h == "decision outcome");
+        let has_nygard = headings.iter().any(|h| h == "consequences")
+            || (headings.iter().any(|h| h == "context")
+                && headings.iter().any(|h| h == "decision"));
+
+        if has_nygard && !has_madr {
+            return AdrFormat::Nygard;
+        }
         return AdrFormat::Madr4;
     }
 
     // Default to Nygard format for plain markdown
     AdrFormat::Nygard
+}
+
+/// Collect the (lowercased, trimmed) text of all level-2+ ATX headings.
+fn section_headings(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("##") {
+                let title = trimmed.trim_start_matches('#').trim().to_lowercase();
+                if title.is_empty() { None } else { Some(title) }
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Check if a document looks like an ADR based on content or path
@@ -68,41 +105,73 @@ pub fn detect_format(content: &str) -> AdrFormat {
 /// - Has a numbered title like "# 1. Title" (Nygard)
 /// - Has a path containing "adr" or "adrs" directory
 pub fn is_adr_document(content: &str, file_path: Option<&std::path::Path>) -> bool {
-    // Check if in an ADR directory (handle both absolute and relative paths)
-    if let Some(path) = file_path {
-        let path_str = path.to_string_lossy().to_lowercase();
-        // Check for ADR directory anywhere in path, including at start for relative paths
-        if path_str.contains("/adr/")
-            || path_str.contains("/adrs/")
-            || path_str.contains("\\adr\\")
-            || path_str.contains("\\adrs\\")
-            || path_str.starts_with("adr/")
-            || path_str.starts_with("adrs/")
-            || path_str.starts_with("adr\\")
-            || path_str.starts_with("adrs\\")
-        {
-            return true;
-        }
+    // Check if the file lives in a known ADR directory
+    if let Some(path) = file_path
+        && path_in_adr_dir(path)
+    {
+        return true;
     }
 
     // Check for MADR frontmatter with status field
     let trimmed = content.trim_start();
-    if let Some(after_open) = trimmed.strip_prefix("---") {
-        // Simple check for status in frontmatter
-        if let Some(end) = after_open.find("---") {
-            let frontmatter = &after_open[..end];
-            if frontmatter.lines().any(|line| {
-                let line = line.trim();
-                line.starts_with("status:") || line.starts_with("status :")
-            }) {
-                return true;
-            }
+    if let Some(after_open) = trimmed.strip_prefix("---")
+        && let Some(end) = after_open.find("---")
+    {
+        let frontmatter = &after_open[..end];
+        if frontmatter.lines().any(|line| {
+            let line = line.trim();
+            line.starts_with("status:") || line.starts_with("status :")
+        }) {
+            return true;
         }
     }
 
-    // Check for Nygard-style numbered title
-    for line in content.lines().take(5) {
-        if is_nygard_title(line) {
+    // Check for a Nygard-style numbered title near the top, skipping leading
+    // blank lines and license/SPDX HTML comment headers (REUSE compliance) that
+    // can push the title past the first few lines.
+    has_nygard_title_near_top(content)
+}
+
+/// Known directory names that indicate a document is an ADR.
+const ADR_DIRECTORY_NAMES: &[&str] = &["adr", "adrs", "decisions", "architecture-decisions"];
+
+/// Check whether any path segment is a known ADR directory.
+///
+/// The path is normalized to forward slashes so it matches on every platform
+/// (e.g. a `docs\decisions\0001.md` string on Linux still matches `decisions`).
+fn path_in_adr_dir(path: &std::path::Path) -> bool {
+    let normalized = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    normalized
+        .split('/')
+        .any(|segment| ADR_DIRECTORY_NAMES.contains(&segment))
+}
+
+/// Look for a Nygard-style numbered title in the first portion of the document,
+/// skipping blank lines and HTML comment blocks so that license/SPDX headers
+/// before the title do not hide it.
+fn has_nygard_title_near_top(content: &str) -> bool {
+    let mut in_comment = false;
+
+    for line in content.lines().take(30) {
+        let trimmed = line.trim();
+
+        if in_comment {
+            if trimmed.contains("-->") {
+                in_comment = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("<!--") {
+            // A single-line comment closes on the same line.
+            if !trimmed.contains("-->") {
+                in_comment = true;
+            }
+            continue;
+        }
+        if trimmed.is_empty() {
+            continue;
+        }
+        if is_nygard_title(trimmed) {
             return true;
         }
     }

--- a/crates/mdbook-lint-rulesets/src/adr/format.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/format.rs
@@ -298,6 +298,94 @@ Accepted
     }
 
     #[test]
+    fn test_detect_format_ng_nygard() {
+        // #408: frontmatter + Nygard sections (adrs "ng" mode) is Nygard, not MADR.
+        let content = r#"---
+status: accepted
+date: 2024-01-15
+---
+
+# 1. Use PostgreSQL
+
+## Context
+
+We need a database.
+
+## Decision
+
+Use PostgreSQL.
+
+## Consequences
+
+It works.
+"#;
+        assert_eq!(detect_format(content), AdrFormat::Nygard);
+    }
+
+    #[test]
+    fn test_detect_format_madr_sections() {
+        // Frontmatter + MADR sections stays MADR.
+        let content = r#"---
+status: accepted
+---
+
+# Use PostgreSQL
+
+## Context and Problem Statement
+
+We need a database.
+
+## Decision Outcome
+
+Chosen option: PostgreSQL.
+"#;
+        assert_eq!(detect_format(content), AdrFormat::Madr4);
+    }
+
+    #[test]
+    fn test_detect_format_frontmatter_without_known_sections() {
+        // Frontmatter but no recognizable Nygard/MADR sections defaults to MADR.
+        let content = "---\nstatus: accepted\n---\n\n# Use PostgreSQL\n";
+        assert_eq!(detect_format(content), AdrFormat::Madr4);
+    }
+
+    #[test]
+    fn test_is_adr_document_decisions_dir() {
+        // #409: docs/decisions/ is a recognized ADR directory.
+        let path = std::path::PathBuf::from("docs/decisions/0001-use-postgres.md");
+        assert!(is_adr_document("# Use PostgreSQL\n", Some(&path)));
+
+        let arch = std::path::PathBuf::from("docs/architecture-decisions/0001.md");
+        assert!(is_adr_document("# Anything\n", Some(&arch)));
+    }
+
+    #[test]
+    fn test_is_adr_document_title_after_comment_header() {
+        // #409: a REUSE/SPDX comment header before the title must not hide it.
+        let content = r#"<!--
+SPDX-FileCopyrightText: 2024 Example
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# 1. Record architecture decisions
+
+## Status
+
+Accepted
+"#;
+        assert!(is_adr_document(content, None));
+    }
+
+    #[test]
+    fn test_is_adr_document_non_adr() {
+        // A plain doc with no ADR directory, no status frontmatter, and no
+        // numbered title is not treated as an ADR.
+        let content = "# Just a Guide\n\nSome prose about a topic.\n";
+        let path = std::path::PathBuf::from("docs/guide.md");
+        assert!(!is_adr_document(content, Some(&path)));
+    }
+
+    #[test]
     fn test_extract_nygard_number() {
         assert_eq!(extract_nygard_number("# 1. Use Rust"), Some(1));
         assert_eq!(extract_nygard_number("# 42. Some Decision"), Some(42));


### PR DESCRIPTION
Closes #408 and #409 — two false-positive sources in ADR format detection, both surfaced from the `adrs` sibling project.

## #408 — `detect_format` misclassifies ng+Nygard as MADR4

`detect_format` returned `Madr4` for any content starting with `---`. The `adrs` tool's "ng" mode emits YAML frontmatter *plus* Nygard-style sections (`## Context`, `## Decision`, `## Consequences`), so it was misclassified as MADR, and ADR004 (`## Context and Problem Statement`) / ADR005 (`## Decision Outcome`) fired as false errors, blocking `adrs doctor`.

Now, when frontmatter is present, detection disambiguates by section headings:
- MADR headings (`Context and Problem Statement`, `Decision Outcome`) → `Madr4`
- Nygard headings (`Consequences`, or both `Context` and `Decision`) without MADR headings → `Nygard`
- frontmatter with neither signature → `Madr4` (unchanged default)

## #409 — `is_adr_document` misses `docs/decisions/` and titles below line 5

Two gaps:
- Directory detection only matched `adr`/`adrs`. Now matches path segments `adr`, `adrs`, `decisions`, `architecture-decisions` (normalized to forward slashes, so it works cross-platform).
- The Nygard-title scan only looked at the first 5 raw lines, so SPDX/REUSE HTML comment headers before the title hid it. The scan now covers a larger window and skips blank lines and HTML comment blocks.

## Scope notes

- Provides better heuristics; does not add the "caller asserts `is_adr = true`" API bypass that #409 also mentions (an API-design change for external callers like `adrs-core`) — noted as a possible follow-up.
- Bare `architecture` was intentionally **not** added as an ADR directory name, to avoid applying ADR rules to general architecture docs.

## Testing

- Existing 150 ADR tests still pass.
- New tests to be added on this branch for ng+Nygard detection and the new directory/comment-header cases.