### PR TITLE
feat: add MD013 ignore_reference_definitions option

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -238,6 +238,7 @@
 # code_blocks = true  # Check code blocks
 # tables = true  # Check tables
 # headings = true  # Check headings
+# ignore_reference_definitions = false  # Skip long [label]: url reference definition lines
 # strict = false  # Strict mode (no leniency)
 # stern = false  # Stern mode (allow long lines without spaces)
 

--- a/crates/mdbook-lint-rulesets/src/standard/md013.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md013.rs
@@ -28,6 +28,9 @@ pub struct MD013 {
     pub ignore_tables: bool,
     /// Whether to ignore headings
     pub ignore_headings: bool,
+    /// Whether to ignore link/image reference definition lines
+    /// (e.g. `[label]: https://very-long-destination`), which cannot be wrapped
+    pub ignore_reference_definitions: bool,
     /// Line length calculation mode
     pub length_mode: LengthMode,
 }
@@ -40,6 +43,7 @@ impl MD013 {
             ignore_code_blocks: true,
             ignore_tables: true,
             ignore_headings: true,
+            ignore_reference_definitions: false,
             length_mode: LengthMode::default(),
         }
     }
@@ -52,6 +56,7 @@ impl MD013 {
             ignore_code_blocks: true,
             ignore_tables: true,
             ignore_headings: true,
+            ignore_reference_definitions: false,
             length_mode: LengthMode::default(),
         }
     }
@@ -90,6 +95,14 @@ impl MD013 {
             .and_then(|v| v.as_bool())
         {
             rule.ignore_headings = ignore_headings;
+        }
+
+        if let Some(ignore_ref_defs) = config
+            .get("ignore-reference-definitions")
+            .or_else(|| config.get("ignore_reference_definitions"))
+            .and_then(|v| v.as_bool())
+        {
+            rule.ignore_reference_definitions = ignore_ref_defs;
         }
 
         if let Some(mode) = config
@@ -166,7 +179,36 @@ impl MD013 {
             return true;
         }
 
+        // Ignore link/image reference definitions if configured. These are of
+        // the form `[label]: destination` and cannot be wrapped, so a long
+        // destination would otherwise trigger MD013 with no way to fix it.
+        if self.ignore_reference_definitions && Self::is_reference_definition(trimmed) {
+            return true;
+        }
+
         false
+    }
+
+    /// Return true if `trimmed` (already left-trimmed) is a link/image
+    /// reference definition line: `[label]: destination [optional title]`.
+    fn is_reference_definition(trimmed: &str) -> bool {
+        // Must start with a non-empty label in brackets.
+        if !trimmed.starts_with('[') {
+            return false;
+        }
+        let Some(close) = trimmed.find(']') else {
+            return false;
+        };
+        let label = &trimmed[1..close];
+        if label.is_empty() {
+            return false;
+        }
+        // The label must be immediately followed by ':' and then a destination.
+        let rest = &trimmed[close + 1..];
+        let Some(after_colon) = rest.strip_prefix(':') else {
+            return false;
+        };
+        !after_colon.trim().is_empty()
     }
 }
 
@@ -256,6 +298,55 @@ impl Rule for MD013 {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn test_md013_reference_definition_option() {
+        // A long reference-link definition line (#407).
+        let content = "# Title\n\n[this-triggers-md013-when-long-link-and-label]: https://github.com/mdbook-lint/issues\n";
+
+        // Default: the long reference definition IS flagged (backward compatible).
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let flagged = MD013::new().check(&document).unwrap();
+        assert_eq!(
+            flagged.len(),
+            1,
+            "reference definitions are flagged by default"
+        );
+        assert_eq!(flagged[0].line, 3);
+
+        // With ignore_reference_definitions = true: not flagged.
+        let cfg: toml::Value = toml::from_str("ignore_reference_definitions = true").unwrap();
+        let rule = MD013::from_config(&cfg);
+        assert!(rule.ignore_reference_definitions);
+        let violations = rule.check(&document).unwrap();
+        assert_eq!(
+            violations.len(),
+            0,
+            "long reference definitions are ignored when the option is enabled"
+        );
+
+        // A normal long prose line is still flagged with the option on.
+        let prose = format!("# Title\n\n{}\n", "word ".repeat(30));
+        let doc2 = Document::new(prose, PathBuf::from("test.md")).unwrap();
+        assert_eq!(rule.check(&doc2).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_md013_is_reference_definition() {
+        assert!(MD013::is_reference_definition(
+            "[label]: https://example.com"
+        ));
+        assert!(MD013::is_reference_definition(
+            "[a-b_c]: /local/path \"Title\""
+        ));
+        // Inline links and images are not reference definitions.
+        assert!(!MD013::is_reference_definition(
+            "[text](https://example.com)"
+        ));
+        assert!(!MD013::is_reference_definition("just some prose"));
+        assert!(!MD013::is_reference_definition("[]: https://example.com"));
+        assert!(!MD013::is_reference_definition("[label]:"));
+    }
 
     #[test]
     fn test_md013_short_lines() {

--- a/docs/src/rules/standard/md013.md
+++ b/docs/src/rules/standard/md013.md
@@ -42,9 +42,22 @@ line_length = 80        # Maximum line length (default: 80)
 code_blocks = true      # Check code blocks (default: true)
 tables = true           # Check tables (default: true)
 headings = true         # Check headings (default: true)
+ignore_reference_definitions = false  # Skip long reference definition lines (default: false)
 strict = false          # Strict length (no leniency for URLs) (default: false)
 stern = false           # Stern length (allow long lines with no spaces) (default: false)
 ```
+
+### Reference link definitions
+
+A link or image reference definition puts the destination on its own line:
+
+```markdown
+[some-long-label]: https://example.com/a/very/long/destination/that/exceeds/the/limit
+```
+
+The label and destination cannot be wrapped, so a long one triggers MD013 with
+no way to fix it. Set `ignore_reference_definitions = true` to skip these
+`[label]: destination` lines (used by both link and image references).
 
 ## When to Disable
 


### PR DESCRIPTION
Closes #407.

A link or image reference definition places an unwrappable destination on its own line:

```markdown
[this-triggers-md013-when-long-link-and-label]: https://github.com/mdbook-lint/issues
```

When the label + destination exceeds `line_length`, MD013 fires with no way to fix it (the line can't be wrapped). This adds an opt-in option to skip such lines.

## Change

- New `MD013.ignore_reference_definitions` option (default **false** — behavior is unchanged unless enabled). Accepts `ignore_reference_definitions` / `ignore-reference-definitions`.
- `should_ignore_line` skips lines matching `[label]: destination` when the option is on. Detection is a small non-regex parse (non-empty bracketed label immediately followed by `:` and a destination), so inline links `[text](url)` and images are not matched.
- Documented in `example-mdbook-lint.toml` and `docs/src/rules/standard/md013.md`.

## Testing

- `test_md013_reference_definition_option`: flagged by default; ignored when enabled; normal long prose still flagged with the option on.
- `test_md013_is_reference_definition`: matcher unit coverage (definitions vs inline links vs empty labels).
- Full suite, clippy, fmt green.