### PR TITLE
docs: fix From Source install path and stale version sample

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -41,8 +41,11 @@ To install the latest development version or contribute to the project:
 ```bash
 git clone https://github.com/joshrotenberg/mdbook-lint.git
 cd mdbook-lint
-cargo install --path .
+cargo install --path crates/mdbook-lint-cli
 ```
+
+The repository root is a virtual workspace manifest, so the path must point at the
+`mdbook-lint-cli` crate rather than at `.`.
 
 ## Pre-built Binaries
 
@@ -63,10 +66,10 @@ After installation, verify that mdbook-lint is working correctly:
 mdbook-lint --version
 ```
 
-You should see output similar to:
+The output shows the installed version:
 
 ```
-mdbook-lint 0.1.0
+mdbook-lint x.y.z
 ```
 
 ## Next Steps


### PR DESCRIPTION
Closes #424.

## Problem

`docs/src/installation.md` told readers to build from source with:

```bash
cargo install --path .
```

That fails from the repo root, because the root `Cargo.toml` is a virtual workspace manifest:

```text
error: found a virtual manifest at `/.../mdbook-lint/Cargo.toml` instead of a package manifest
```

The same page's Verification section showed sample output of `mdbook-lint 0.1.0`, which has been stale since the earliest release (current workspace version is 0.14.4).

## Change

- "From Source" now uses `cargo install --path crates/mdbook-lint-cli`, with a one-line note on why the root path does not work.
- The verification sample is now a generic `mdbook-lint x.y.z` placeholder instead of a hardcoded version, so it does not go stale on each release.

## Verification

Ran the documented command against this checkout:

```text
Installed package `mdbook-lint v0.14.4 (.../crates/mdbook-lint-cli)` (executable `mdbook-lint`)
$ mdbook-lint --version
mdbook-lint 0.14.4
```

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` pass. The docs workflow's own gates were run locally: `mdbook-lint lint --config .mdbook-lint.toml src/installation.md` reports only pre-existing warnings (unchanged from before this diff), and `mdbook build` succeeds.

## Note, not addressed here

`crates/mdbook-lint-cli` declares a second binary, `debug_preprocessor`, so the plain `cargo install --path crates/mdbook-lint-cli` also installs that into the user's cargo bin directory. Adding `--bin mdbook-lint` to the documented command, or marking that binary as non-installable, is outside the scope of #424 but may be worth a follow-up.