### PR TITLE
fix: derive init --include-all rule count instead of hardcoding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ mdbook-lint init --include-all
 
 **Configuration examples:**
 
-- [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all 83 rules documented
+- [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all 84 rules documented
 - [docs/.mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/docs/.mdbook-lint.toml) - Real-world example used by this project's documentation
 
 ## Rules

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -2077,7 +2077,14 @@ mod tests {
         );
 
         // README describes the same file; the two must not drift apart.
-        let readme = include_str!("../../../README.md");
+        // Read at runtime rather than include_str!: README.md lives outside this
+        // package, so it is relocated when the crate is packaged for publishing.
+        // In the repo (and in CI) it is always there; anywhere else, skip.
+        let readme_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../README.md");
+        let Ok(readme) = std::fs::read_to_string(&readme_path) else {
+            return;
+        };
+
         let claimed = readme
             .lines()
             .find_map(|line| {

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -1711,6 +1711,28 @@ fn levenshtein_distance(a: &str, b: &str) -> usize {
 /// This is embedded from example-mdbook-lint.toml at compile time.
 const EXAMPLE_CONFIG_TOML: &str = include_str!("../example-mdbook-lint.toml");
 
+/// Count the distinct rule IDs documented in a config file's comments.
+///
+/// Rules are documented one per comment block, as `# MD001 - description`.
+/// Counting them here keeps the `init --include-all` message in step with the
+/// file instead of drifting from a hardcoded literal every time a rule is added.
+fn documented_rule_count(config: &str) -> usize {
+    let mut ids: Vec<&str> = config
+        .lines()
+        .filter_map(|line| {
+            let rest = line.strip_prefix("# ")?;
+            let id = rest.split_whitespace().next()?;
+            let (prefix, digits) = id.split_at(id.find(|c: char| c.is_ascii_digit())?);
+            let known = matches!(prefix, "MD" | "MDBOOK" | "CONTENT" | "ADR");
+            (known && !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()))
+                .then_some(id)
+        })
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    ids.len()
+}
+
 fn run_init_command(
     format: ConfigFormat,
     output_path: Option<PathBuf>,
@@ -1754,7 +1776,10 @@ fn run_init_command(
 
     println!("Configuration file created: {}", output_file.display());
     if include_all {
-        println!("Includes documentation for all 78 available rules");
+        println!(
+            "Includes documentation for all {} available rules",
+            documented_rule_count(EXAMPLE_CONFIG_TOML)
+        );
         println!("Uncomment and modify settings as needed for your project");
     } else {
         println!("Run with --include-all for a comprehensive example with all rules documented");
@@ -2042,6 +2067,48 @@ fn get_all_available_rule_ids() -> Vec<String> {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    #[test]
+    fn test_documented_rule_count_matches_readme() {
+        let counted = documented_rule_count(EXAMPLE_CONFIG_TOML);
+        assert!(
+            counted > 0,
+            "no rule IDs found in example-mdbook-lint.toml comments"
+        );
+
+        // README describes the same file; the two must not drift apart.
+        let readme = include_str!("../../../README.md");
+        let claimed = readme
+            .lines()
+            .find_map(|line| {
+                let (before, _) = line.split_once(" rules documented")?;
+                before.split_whitespace().next_back()?.parse::<usize>().ok()
+            })
+            .expect("README no longer contains an 'N rules documented' claim");
+
+        assert_eq!(
+            claimed, counted,
+            "README claims {claimed} documented rules but example-mdbook-lint.toml documents {counted}"
+        );
+    }
+
+    #[test]
+    fn test_documented_rule_count_parsing() {
+        let config = "\
+# MD001 - Heading levels
+# MD001 - repeated, counted once
+# MDBOOK002 - SUMMARY.md structure
+# CONTENT001 - Content rule
+# ADR001 - ADR rule
+# Not a rule ID at all
+# MDX999 - unknown prefix
+#MD002 - no space after hash
+# MD - no digits
+[MD003]
+style = \"consistent\"
+";
+        assert_eq!(documented_rule_count(config), 4);
+    }
 
     #[test]
     fn test_path_is_ignored() {

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -301,7 +301,7 @@ Use the `init` command to generate a configuration file:
 # Generate minimal configuration
 mdbook-lint init
 
-# Generate comprehensive configuration with all 83 rules documented
+# Generate comprehensive configuration with every rule documented
 mdbook-lint init --include-all
 
 # Generate in a different format


### PR DESCRIPTION
Closes #423.

## Problem

`mdbook-lint init --include-all` printed a hardcoded count:

```rust
println!("Includes documentation for all 78 available rules");
```

That literal describes the embedded `example-mdbook-lint.toml`, but drifts every time a rule is added. Two other places named a different number for the same file:

| Location | Claimed |
| --- | --- |
| `run_init_command` in `crates/mdbook-lint-cli/src/main.rs` | 78 |
| `README.md` configuration section | 83 |
| `docs/src/configuration.md` example comment | 83 |
| Actual distinct rule IDs documented in `example-mdbook-lint.toml` | 84 |

## Change

- New `documented_rule_count(config: &str)` counts the distinct rule IDs in a config file's comment lines (`# MD001 - description`, for the `MD`/`MDBOOK`/`CONTENT`/`ADR` prefixes). `run_init_command` calls it on `EXAMPLE_CONFIG_TOML`, so the printed count tracks the file rather than a literal.
- `README.md` now says 84, matching what the file documents.
- `docs/src/configuration.md`'s example comment says "with every rule documented" instead of naming a count, so there is one fewer literal to keep in sync.

Output after the change:

```text
$ mdbook-lint init --include-all
Configuration file created: .mdbook-lint.toml
Includes documentation for all 84 available rules
Uncomment and modify settings as needed for your project
```

## Testing

- `test_documented_rule_count_matches_readme` parses README's "N rules documented" claim and asserts it equals the computed count. This is the drift guard the issue asked for: adding a rule to the example config without updating README now fails `cargo test`.
- `test_documented_rule_count_parsing` covers the matcher directly (duplicates counted once, each known prefix, unknown prefixes, missing space after `#`, no-digit IDs, section headers).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.
- Docs workflow gates run locally for the `docs/src/configuration.md` change: `mdbook-lint lint --config .mdbook-lint.toml src/configuration.md` produces output byte-identical to `main` (no new findings), and `mdbook build` exits 0.

## Not addressed here

The issue also notes the wider count disagreement between `rules --detailed` (96, excluding the 4 ADR collection rules) and README/CLAUDE.md's "100 total rules", and the related question of whether collection rules should appear in the `rules` table. That is a separate CLI-display concern from the `init` message; the issue itself suggests it can be split out.
