### PR TITLE
fix: accept snake_case global config keys instead of silently ignoring them

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -14,13 +14,10 @@
 # fail-on-warnings = false
 
 # List of rules to disable globally
-# disabled_rules = ["MD013", "MD033"]
-
-# Default severity level for all rules (error, warning, info)
-# default_severity = "warning"
+# disabled-rules = ["MD013", "MD033"]
 
 # Paths to ignore when linting
-# ignore_paths = ["target/", "vendor/", "*.backup.md"]
+# ignore-paths = ["target/", "vendor/", "*.backup.md"]
 
 # ============================================================================
 # STANDARD MARKDOWN RULES (MD001-MD059)
@@ -463,5 +460,5 @@
 
 # Configuration for mdBook preprocessor mode
 # [preprocessor]
-# fail_on_warnings = true  # Fail the build on warnings
+# fail-on-warnings = true  # Fail the build on warnings
 # renderer = ["html", "pdf"]  # Run for specific renderers

--- a/crates/mdbook-lint-cli/src/config.rs
+++ b/crates/mdbook-lint-cli/src/config.rs
@@ -13,15 +13,19 @@ pub struct Config {
     pub core: mdbook_lint_core::Config,
 
     /// Whether to fail builds on warnings (CLI-specific)
-    #[serde(rename = "fail-on-warnings", default)]
+    #[serde(rename = "fail-on-warnings", alias = "fail_on_warnings", default)]
     pub fail_on_warnings: bool,
 
     /// Whether to fail builds on errors (CLI-specific)
-    #[serde(rename = "fail-on-errors", default = "default_fail_on_errors")]
+    #[serde(
+        rename = "fail-on-errors",
+        alias = "fail_on_errors",
+        default = "default_fail_on_errors"
+    )]
     pub fail_on_errors: bool,
 
     /// How to handle malformed markdown (CLI-specific)
-    #[serde(rename = "malformed-markdown", default)]
+    #[serde(rename = "malformed-markdown", alias = "malformed_markdown", default)]
     pub malformed_markdown: MalformedMarkdownAction,
 }
 
@@ -792,6 +796,74 @@ ignore-code-blocks = true
         assert_eq!(
             md013_config.get("ignore-code-blocks").unwrap().as_bool(),
             Some(true)
+        );
+    }
+
+    /// Every global key accepts both the canonical kebab-case spelling and the
+    /// snake_case spelling. Without the aliases a snake_case key is swallowed by
+    /// `rule_configs`'s `flatten` and silently does nothing (#419).
+    #[test]
+    fn test_global_keys_accept_snake_case_and_kebab_case() {
+        let kebab = r#"
+fail-on-warnings = true
+fail-on-errors = false
+malformed-markdown = "skip"
+enabled-rules = ["MD001"]
+disabled-rules = ["MD009"]
+enabled-categories = ["structure"]
+disabled-categories = ["code"]
+deprecated-warning = "silent"
+markdownlint-compatible = true
+auto-fix = false
+ignore-paths = ["target/"]
+"#;
+        let snake = r#"
+fail_on_warnings = true
+fail_on_errors = false
+malformed_markdown = "skip"
+enabled_rules = ["MD001"]
+disabled_rules = ["MD009"]
+enabled_categories = ["structure"]
+disabled_categories = ["code"]
+deprecated_warning = "silent"
+markdownlint_compatible = true
+auto_fix = false
+ignore_paths = ["target/"]
+"#;
+
+        let kebab = Config::from_toml_str(kebab).unwrap();
+        let snake = Config::from_toml_str(snake).unwrap();
+
+        assert_eq!(kebab.fail_on_warnings, snake.fail_on_warnings);
+        assert_eq!(kebab.fail_on_errors, snake.fail_on_errors);
+        assert_eq!(
+            format!("{:?}", kebab.malformed_markdown),
+            format!("{:?}", snake.malformed_markdown)
+        );
+        assert_eq!(kebab.core.enabled_rules, snake.core.enabled_rules);
+        assert_eq!(kebab.core.disabled_rules, snake.core.disabled_rules);
+        assert_eq!(kebab.core.enabled_categories, snake.core.enabled_categories);
+        assert_eq!(
+            kebab.core.disabled_categories,
+            snake.core.disabled_categories
+        );
+        assert_eq!(
+            format!("{:?}", kebab.core.deprecated_warning),
+            format!("{:?}", snake.core.deprecated_warning)
+        );
+        assert_eq!(
+            kebab.core.markdownlint_compatible,
+            snake.core.markdownlint_compatible
+        );
+        assert_eq!(kebab.core.auto_fix, snake.core.auto_fix);
+        assert_eq!(kebab.core.ignore_paths, snake.core.ignore_paths);
+
+        // Neither spelling may leak into per-rule config.
+        assert!(kebab.core.rule_configs.is_empty());
+        assert!(
+            snake.core.rule_configs.is_empty(),
+            "snake_case globals leaked into rule_configs: {:?}",
+            snake.core.rule_configs.keys().collect::<Vec<_>>()
         );
     }
 

--- a/crates/mdbook-lint-core/src/config.rs
+++ b/crates/mdbook-lint-core/src/config.rs
@@ -2,6 +2,12 @@
 //!
 //! This module contains the minimal configuration types needed by the core
 //! linting engine. The full configuration is handled by the CLI crate.
+//!
+//! Every global key is written in kebab-case (`disabled-rules`), which is the
+//! canonical spelling emitted by serialization. The snake_case spelling
+//! (`disabled_rules`) is also accepted on input via serde aliases: without one,
+//! a snake_case key falls through `rule_configs`'s `flatten` and is silently
+//! ignored rather than rejected.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -10,32 +16,36 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// List of enabled rule categories
-    #[serde(rename = "enabled-categories", default)]
+    #[serde(rename = "enabled-categories", alias = "enabled_categories", default)]
     pub enabled_categories: Vec<String>,
 
     /// List of disabled rule categories
-    #[serde(rename = "disabled-categories", default)]
+    #[serde(rename = "disabled-categories", alias = "disabled_categories", default)]
     pub disabled_categories: Vec<String>,
 
     /// List of explicitly enabled rules
-    #[serde(rename = "enabled-rules", default)]
+    #[serde(rename = "enabled-rules", alias = "enabled_rules", default)]
     pub enabled_rules: Vec<String>,
 
     /// List of explicitly disabled rules
-    #[serde(rename = "disabled-rules", default)]
+    #[serde(rename = "disabled-rules", alias = "disabled_rules", default)]
     pub disabled_rules: Vec<String>,
 
     /// How to handle deprecated rule warnings
-    #[serde(rename = "deprecated-warning", default)]
+    #[serde(rename = "deprecated-warning", alias = "deprecated_warning", default)]
     pub deprecated_warning: DeprecatedWarningLevel,
 
     /// Enable markdownlint compatibility mode (disables rules that are disabled by default in markdownlint)
-    #[serde(rename = "markdownlint-compatible", default)]
+    #[serde(
+        rename = "markdownlint-compatible",
+        alias = "markdownlint_compatible",
+        default
+    )]
     pub markdownlint_compatible: bool,
 
     /// Global auto-fix setting (default: true when --fix is used)
     /// Can be overridden per-rule in rule-specific configuration
-    #[serde(rename = "auto-fix", default = "default_auto_fix")]
+    #[serde(rename = "auto-fix", alias = "auto_fix", default = "default_auto_fix")]
     pub auto_fix: bool,
 
     /// Glob patterns for paths to skip entirely when linting.

--- a/docs/.mdbook-lint.toml
+++ b/docs/.mdbook-lint.toml
@@ -27,11 +27,8 @@ disabled-rules = [
     # "CONTENT004", # Heading capitalization - we use title case for headings
 ]
 
-# Default severity for all rules
-# default_severity = "warning"
-
 # Paths to ignore when linting
-# ignore_paths = ["target/", "drafts/"]
+# ignore-paths = ["target/", "drafts/"]
 
 # ============================================================================
 # HEADING RULES
@@ -287,8 +284,8 @@ max_line = 10
 # Override rules for specific files or patterns
 # [[overrides]]
 # path = "SUMMARY.md"
-# disabled_rules = ["MD025"]  # Allow multiple H1 in SUMMARY.md
+# disabled-rules = ["MD025"]  # Allow multiple H1 in SUMMARY.md
 
 # [[overrides]]
 # path = "rules/**/*.md"
-# disabled_rules = ["CONTENT003"]  # Rule pages can be brief
+# disabled-rules = ["CONTENT003"]  # Rule pages can be brief

--- a/docs/src/example-configuration.md
+++ b/docs/src/example-configuration.md
@@ -23,7 +23,7 @@ For most projects, a minimal configuration is sufficient:
 ```toml
 # .mdbook-lint.toml
 fail-on-warnings = true
-disabled_rules = ["MD013"]  # Disable line length if not needed
+disabled-rules = ["MD013"]  # Disable line length if not needed
 ```
 
 ### Strict Configuration
@@ -81,7 +81,7 @@ For blogs or content-heavy sites:
 
 ```toml
 # Relaxed rules for content
-disabled_rules = [
+disabled-rules = [
     "MD013",  # No line length limit
     "MD033",  # Allow inline HTML
     "MD041"   # First line doesn't need to be H1
@@ -112,7 +112,7 @@ fail-on-warnings = true
 
 ```toml
 [preprocessor]
-fail_on_warnings = false  # Warning but don't fail build
+fail-on-warnings = false  # Warning but don't fail build
 renderer = ["html"]  # Only run for HTML output
 ```
 
@@ -122,19 +122,19 @@ renderer = ["html"]  # Only run for HTML output
 
 ```toml
 # Disable all heading rules
-disabled_rules = [
+disabled-rules = [
     "MD001", "MD002", "MD003", "MD018", "MD019",
     "MD020", "MD021", "MD022", "MD023", "MD024",
     "MD025", "MD026"
 ]
 
 # Disable all whitespace rules
-disabled_rules = [
+disabled-rules = [
     "MD009", "MD010", "MD012", "MD027", "MD028", "MD047"
 ]
 
 # Disable all list rules
-disabled_rules = [
+disabled-rules = [
     "MD004", "MD005", "MD006", "MD007", "MD029",
     "MD030", "MD032"
 ]


### PR DESCRIPTION
Closes #419.

## Problem

Every global field on `mdbook_lint_core::Config` and the CLI `Config` was deserialized with an explicit kebab-case `rename` and no `alias`. Because `rule_configs` is `#[serde(flatten)]` into a `HashMap<String, toml::Value>`, a snake_case key did not error. It landed in `rule_configs` under that name and had no effect, with no warning:

```toml
# What a user copies from example-mdbook-lint.toml today:
disabled_rules = ["MD013", "MD033"]

# What actually works:
disabled-rules = ["MD013", "MD033"]
```

Several first-party example files wrote the keys in snake_case, so the shipped examples taught a spelling that silently did nothing.

## Change

Option 1 from the issue: add `alias` for the snake_case spelling on every global field, matching the treatment `ignore-paths` already had from #413. Kebab-case remains canonical and is what serialization emits.

- `crates/mdbook-lint-core/src/config.rs`: aliases on `enabled-categories`, `disabled-categories`, `enabled-rules`, `disabled-rules`, `deprecated-warning`, `markdownlint-compatible`, `auto-fix`.
- `crates/mdbook-lint-cli/src/config.rs`: aliases on `fail-on-warnings`, `fail-on-errors`, `malformed-markdown`.
- Example files normalized to kebab-case: `crates/mdbook-lint-cli/example-mdbook-lint.toml`, `docs/src/example-configuration.md`, `docs/.mdbook-lint.toml`.
- `default_severity` removed from `example-mdbook-lint.toml` and `docs/.mdbook-lint.toml`. It does not correspond to any field on `Config` under any spelling, so it was a phantom option rather than a spelling mismatch.

## Test

`test_global_keys_accept_snake_case_and_kebab_case` in `crates/mdbook-lint-cli/src/config.rs` parses the full set of global keys twice, once in each spelling, and asserts the two `Config` values agree field by field. It also asserts `rule_configs` is empty for both, which is the assertion that fails today: without the aliases the snake_case keys leak into `rule_configs`.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` all pass. Because `docs/` changed, the docs.yml gate was run locally as well: `mdbook build` in `docs/` with the release binary on PATH exits 0.

## Not addressed

- `docs/src/mdbook-integration.md:114` also writes `fail_on_warnings`, but it sits inside a fictional `[core]` table tracked by #420, so it is left for that issue.
- Roughly 20 pages under `docs/src/rules/` use `disabled_rules` in their examples. Those spellings now work because of the aliases, so they are correct but not canonical. Left out of this change to keep the diff reviewable.
- The `[preprocessor]` block at the end of `example-mdbook-lint.toml` had its key spelling normalized, but that table is read from mdBook's preprocessor JSON context rather than from `.mdbook-lint.toml`, so its presence in that file looks questionable independent of spelling.
