### PR TITLE
fix(adr): honor ADR007 valid-statuses configuration

### DIFF
--- a/crates/mdbook-lint-cli/src/rule_config_test.rs
+++ b/crates/mdbook-lint-cli/src/rule_config_test.rs
@@ -4,7 +4,7 @@
 mod tests {
     use crate::config::Config;
     use mdbook_lint_core::{Document, PluginRegistry};
-    use mdbook_lint_rulesets::StandardRuleProvider;
+    use mdbook_lint_rulesets::{AdrRuleProvider, StandardRuleProvider};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -226,6 +226,138 @@ style = "dash"
 
         let md004_config = config.core.rule_configs.get("MD004").unwrap();
         assert_eq!(md004_config.get("style").unwrap().as_str(), Some("dash"));
+    }
+
+    /// Regression test for #437: `[ADR007] valid-statuses` was parsed into
+    /// `rule_configs` but never reached the rule, because `AdrRuleProvider`
+    /// registered `Adr007::default()` unconditionally.
+    #[test]
+    fn test_adr007_valid_statuses_configuration_works() {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(AdrRuleProvider))
+            .unwrap();
+
+        // The MADR document from the issue: a status the defaults reject.
+        let content = r#"---
+status: foo
+date: 2026-07-13
+---
+
+# ADR-0002: Reproduce Issue
+
+## Context and Problem Statement
+
+Sample context and problem statement.
+"#;
+        let document = Document::new(
+            content.to_string(),
+            PathBuf::from("docs/adr/0002-reproduce-issue.md"),
+        )
+        .unwrap();
+
+        // Without configuration the default status list applies, so "foo" is invalid.
+        let config_default = Config::from_toml_str("enabled-rules = [\"ADR007\"]\n").unwrap();
+        let engine_default = registry
+            .create_engine_with_config(Some(&config_default.core))
+            .unwrap();
+        let violations_default = engine_default
+            .lint_document_with_config(&document, &config_default.core)
+            .unwrap();
+        assert_eq!(
+            violations_default.len(),
+            1,
+            "Expected ADR007 to reject 'foo' under the default status list, found: {violations_default:?}"
+        );
+
+        // With "foo" configured as valid, ADR007 must not fire.
+        let config_toml = r#"
+enabled-rules = ["ADR007"]
+[ADR007]
+valid-statuses = ["foo"]
+"#;
+        let config = Config::from_toml_str(config_toml).unwrap();
+        let engine = registry
+            .create_engine_with_config(Some(&config.core))
+            .unwrap();
+        let violations = engine
+            .lint_document_with_config(&document, &config.core)
+            .unwrap();
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected no ADR007 violation with valid-statuses = [\"foo\"], found: {violations:?}"
+        );
+
+        // The message reports the configured list, not the built-in defaults.
+        let config_other_toml = r#"
+enabled-rules = ["ADR007"]
+[ADR007]
+valid-statuses = ["bar", "baz"]
+"#;
+        let config_other = Config::from_toml_str(config_other_toml).unwrap();
+        let engine_other = registry
+            .create_engine_with_config(Some(&config_other.core))
+            .unwrap();
+        let violations_other = engine_other
+            .lint_document_with_config(&document, &config_other.core)
+            .unwrap();
+        assert_eq!(violations_other.len(), 1);
+        assert!(
+            violations_other[0].message.contains("bar, baz"),
+            "Expected the configured statuses in the message, got: {}",
+            violations_other[0].message
+        );
+        assert!(
+            !violations_other[0].message.contains("proposed"),
+            "Expected the default statuses to be replaced, got: {}",
+            violations_other[0].message
+        );
+    }
+
+    /// The snake_case spelling is accepted too, matching the treatment other
+    /// rule options get (see #419).
+    #[test]
+    fn test_adr007_valid_statuses_accepts_snake_case() {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(AdrRuleProvider))
+            .unwrap();
+
+        let content = r#"---
+status: foo
+date: 2026-07-13
+---
+
+# ADR-0002: Reproduce Issue
+
+## Context and Problem Statement
+
+Sample context and problem statement.
+"#;
+        let document = Document::new(
+            content.to_string(),
+            PathBuf::from("docs/adr/0002-reproduce-issue.md"),
+        )
+        .unwrap();
+
+        let config_toml = r#"
+enabled-rules = ["ADR007"]
+[ADR007]
+valid_statuses = ["foo"]
+"#;
+        let config = Config::from_toml_str(config_toml).unwrap();
+        let engine = registry
+            .create_engine_with_config(Some(&config.core))
+            .unwrap();
+        let violations = engine
+            .lint_document_with_config(&document, &config.core)
+            .unwrap();
+        assert_eq!(
+            violations.len(),
+            0,
+            "Expected valid_statuses to be honored, found: {violations:?}"
+        );
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/adr/adr007.rs
+++ b/crates/mdbook-lint-rulesets/src/adr/adr007.rs
@@ -51,9 +51,12 @@ impl Default for Adr007 {
 impl Adr007 {
     /// Create an instance from rule configuration.
     ///
-    /// Recognized key:
+    /// Recognized keys:
     /// - `format`: `"auto"`, `"nygard"`, or `"madr"`. Overrides the
     ///   per-document format auto-detection. Unrecognized values are ignored.
+    /// - `valid-statuses` (also accepted as `valid_statuses`): replaces the
+    ///   default status list. A non-array or empty value leaves the defaults
+    ///   in place.
     pub fn from_config(config: &toml::Value) -> Self {
         let mut rule = Self::default();
         if let Some(format) = config
@@ -62,6 +65,19 @@ impl Adr007 {
             .and_then(|s| s.parse::<AdrFormat>().ok())
         {
             rule.format = format;
+        }
+        if let Some(statuses) = config
+            .get("valid-statuses")
+            .or_else(|| config.get("valid_statuses"))
+            .and_then(|v| v.as_array())
+        {
+            let statuses: Vec<String> = statuses
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                .collect();
+            if !statuses.is_empty() {
+                rule.valid_statuses = statuses;
+            }
         }
         rule
     }


### PR DESCRIPTION
Closes #437.

## Problem

`[ADR007] valid-statuses = ["foo"]` had no effect. The key parsed into `Config::rule_configs` without error, but `Adr007::from_config` only read `format`, so the rule was always constructed with the built-in status list:

```toml
enabled-rules = ["ADR007"]
[ADR007]
valid-statuses = ["foo"]
```

```console
$ mdbook-lint lint --config .mdbook-lint.toml docs/adr/
warning[ADR007]: Invalid status 'foo'. Valid values: proposed, accepted, deprecated, superseded, rejected, draft
```

The second half of the issue follows from the same cause: the "Valid values" list in the message is `self.valid_statuses`, so it listed the built-in statuses rather than the configured ones.

`docs/src/rules/adr/adr007.md` and `docs/src/rules/adr/index.md` already document `valid-statuses`, so this makes the documented behavior true rather than adding a new option.

## Change

`crates/mdbook-lint-rulesets/src/adr/adr007.rs`: `from_config` now reads `valid-statuses` (and the `valid_statuses` spelling, matching how other rule options are handled since #419) and replaces the default list when the value is a non-empty array. A missing, non-array, or empty value leaves the defaults in place. Values are lowercased on read, as `with_statuses` already did; comparison was already case-insensitive.

Registration needed no change. `AdrRuleProvider::register_rules_with_config` already routes the `[ADR007]` table (falling back to a provider-level `[ADR]` table) into `Adr007::from_config`; the value was being dropped one level further in.

## Test

Two tests in `crates/mdbook-lint-cli/src/rule_config_test.rs`, both driving the full path from TOML through `create_engine_with_config` to `lint_document_with_config` on the MADR document from the issue:

- `test_adr007_valid_statuses_configuration_works` asserts the default list still rejects `foo`, that `valid-statuses = ["foo"]` produces no violation, and that with `valid-statuses = ["bar", "baz"]` the message names the configured statuses and not the defaults.
- `test_adr007_valid_statuses_accepts_snake_case` covers the `valid_statuses` spelling.

Both fail against the current `from_config` with exactly the output reported in the issue, and pass with the change.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` (20 suites, 0 failures) all pass. No `docs/**` changes, so the docs.yml gate does not apply.

## Not addressed

The provider-level fallback means `[ADR] valid-statuses = [...]` also reaches ADR007. That follows the existing `[ADR]`-applies-to-all-ADR-rules design rather than being introduced here, but it is worth knowing: the only ADR rule that reads the key is ADR007.
