### PR TITLE
fix(md004): account for frontmatter line offset when reading list markers

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md004.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md004.rs
@@ -122,6 +122,11 @@ impl AstRule for MD004 {
             expected_style = Some(configured_style);
         }
 
+        // comrak renumbers nodes after YAML frontmatter as if the document began
+        // at line 1. Add the frontmatter offset back so the marker is read from
+        // the item's real source line rather than from inside the frontmatter.
+        let frontmatter_offset = document.frontmatter_ast_offset(ast);
+
         // Find all unordered list items
         for node in ast.descendants() {
             if let NodeValue::List(list_info) = &node.data.borrow().value {
@@ -130,7 +135,8 @@ impl AstRule for MD004 {
                     // Check each list item in this list
                     for child in node.children() {
                         if let NodeValue::Item(_) = &child.data.borrow().value
-                            && let Some((line, column)) = document.node_position(child)
+                            && let Some((ast_line, column)) = document.node_position(child)
+                            && let line = ast_line + frontmatter_offset
                             && let Some(detected_style) =
                                 self.detect_list_marker_style(document, line)
                         {
@@ -603,5 +609,82 @@ More text without any lists.
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 0);
+    }
+
+    /// Regression test for #441. comrak renumbers nodes after YAML frontmatter
+    /// as if the document began at line 1, so the AST line for a list item is
+    /// short by the folded frontmatter lines. Reading the marker from that line
+    /// landed inside the frontmatter, where the YAML block sequence `  - DM 1`
+    /// looks like a dash-style marker.
+    #[test]
+    fn test_md004_frontmatter_does_not_shift_marker_detection() {
+        let content = r#"---
+status: accepted
+date: 2026-07-20
+decision-makers:
+  - DM 1
+  - DM 2
+consulted:
+  - First Consult
+informed:
+  - First Informed
+---
+# ADR-0002: Adopt a CONTRIBUTING.md
+
+## Context and Problem Statement
+
+Contribution rules are currently tribal knowledge.
+
+## Considered Options
+
+* Adopt a `CONTRIBUTING.md` at the repository root
+* Document rules in confluence
+* Leave rules implicit and enforce via review
+* Extra item
+"#;
+        let document =
+            Document::new(content.to_string(), PathBuf::from("docs/adr/0002-test.md")).unwrap();
+        let rule = MD004::with_style(ListStyleConfig::Asterisk);
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(
+            violations.len(),
+            0,
+            "asterisk list under frontmatter should satisfy style = asterisk, got: {violations:?}"
+        );
+    }
+
+    /// The offset must not over-correct: a real violation under frontmatter is
+    /// still reported, and at the true source line.
+    #[test]
+    fn test_md004_reports_real_violation_under_frontmatter_at_correct_line() {
+        let content = r#"---
+status: accepted
+date: 2026-07-20
+decision-makers:
+  - DM 1
+---
+# Title
+
+## Considered Options
+
+* Correct marker
+- Wrong marker
+"#;
+        let document =
+            Document::new(content.to_string(), PathBuf::from("docs/adr/0003-test.md")).unwrap();
+        let rule = MD004::with_style(ListStyleConfig::Asterisk);
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(
+            violations.len(),
+            1,
+            "expected the dash marker to be flagged"
+        );
+        assert_eq!(
+            violations[0].line, 12,
+            "violation should point at the dash marker's real source line"
+        );
+        assert!(violations[0].message.contains("expected '*' but found '-'"));
     }
 }


### PR DESCRIPTION
Closes #441.

## Problem

comrak folds leading YAML frontmatter into a `FrontMatter` node and renumbers every following node as if the document began at line 1. #430 added `Document::frontmatter_ast_offset` for exactly this and applied it to MD041, MD022 and MD007. MD004 was not updated, so this is the MD004 cascade that #406 predicted.

MD004 takes a list item's line from the AST via `document.node_position(child)` and then indexes `document.lines` directly to read the marker character. With frontmatter present that index lands inside the frontmatter block, where a YAML block sequence (`  - DM 1`) reads as a dash marker, and so does the closing `---` delimiter.

Reproduced with the config and document from the issue, against the current binary:

```console
$ mdbook-lint lint --config .mdbook-lint.toml docs/adr/0002-contributing-guidelines.md
warning[MD004]: Inconsistent list style: expected '*' but found '-'
  --> docs/adr/0002-contributing-guidelines.md:11:1
     |
  11 | ---
     | ^^^ ul-style
```

Line 11 is the closing frontmatter delimiter. The document's actual list is all asterisks.

This also explains the reporter's observation that the warning disappears after adding a paragraph or deleting a section: those edits change how far the shifted line lands, not anything about the list.

The autofix was affected too. Running with fixes enabled would have rewritten the `---` delimiter to `***`, corrupting the frontmatter block.

## Change

`crates/mdbook-lint-rulesets/src/standard/md004.rs`: read `document.frontmatter_ast_offset(ast)` once and add it to the AST line before the marker is read, matching what MD022 does. Violation positions and the generated fixes then refer to real source lines. No behavior change for documents without frontmatter, where the offset is 0.

## Test

Two tests in the MD004 test module:

- `test_md004_frontmatter_does_not_shift_marker_detection` uses the MADR document from the issue with `style = "asterisk"` and asserts no violations. Before the change it produced 2 violations, on lines 10 and 11, both inside the frontmatter.
- `test_md004_reports_real_violation_under_frontmatter_at_correct_line` guards against over-correcting: a genuine dash marker under frontmatter is still flagged, and at its true source line.

End-to-end check with the CLI on the issue's exact config and document: the unfixed binary reproduces the output above, the fixed binary reports `No issues found`.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` (20 suites, 0 failures, including the 15 pre-existing MD004 tests) all pass.

## Note

Other rules that pair `node_position` with direct `document.lines` indexing may have the same latent bug. I have not audited them as part of this change; #438 covers a separate set of list-parsing false positives (MD030 and MD032), and MD030 does not use the AST at all.
