### PR TITLE
fix(md030): do not treat a long emphasis span as a list marker

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md030.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md030.rs
@@ -337,14 +337,12 @@ impl MD030 {
             // If there's immediately non-whitespace after the *, it's likely emphasis
             let chars: Vec<char> = trimmed.chars().collect();
             if chars.len() > 1 && !chars[1].is_whitespace() && chars[1] != '*' {
-                // Look for closing * after position 2
-                let remaining: String = chars.iter().skip(2).collect();
-                if let Some(closing_pos) = remaining.find('*') {
-                    // Make sure it's not just another list item with * in the text
-                    if closing_pos < 50 && !remaining[..closing_pos].contains('\n') {
-                        // Likely emphasis if reasonably short and no newlines
-                        return true;
-                    }
+                // Look for a closing * after position 2. Its distance from the opening
+                // marker says nothing about whether the span is emphasis: an emphasized
+                // sentence is as valid as an emphasized word, and CommonMark requires a
+                // space after a bullet, so `*text*` is never a list item.
+                if chars.iter().skip(2).any(|&c| c == '*') {
+                    return true;
                 }
             }
         }
@@ -1271,6 +1269,59 @@ $$
         let violations = rule.check(&document).unwrap();
 
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md030_long_emphasis_spans_not_flagged() {
+        // Regression for #438: an emphasized sentence at line start was flagged as a
+        // zero-space list marker once the closing '*' sat more than 50 characters in.
+        // The first paragraph below escaped (closing '*' at offset 46), the other two
+        // did not, which is why the false positive looked like it came and went.
+        let content = r#"# Title
+
+*Rejected — socket peer address (`ConnectInfo`).* Non-spoofable, but behind Cloudflare/Render every
+external client collapses onto the proxy IP, so the per-client limiter is meaningless.
+
+*Rejected — rightmost `X-Forwarded-For` with N trusted hops.* Generic, but calibrating the hop count
+across two proxies is fragile and error-prone; `CF-Connecting-IP` is exact for this topology.
+
+*Rejected — per-interface pre-auth limiters (one per nest).* Gives interface-correct error bodies
+natively, but splits the IP budget across `/api` and `/ocpi`.
+"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD030::new();
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(
+            violations.len(),
+            0,
+            "emphasis spans should not be read as list markers, got {violations:?}"
+        );
+    }
+
+    #[test]
+    fn test_md030_emphasis_length_does_not_decide() {
+        let rule = MD030::new();
+
+        // Short and long emphasis spans are classified the same way.
+        assert!(rule.is_emphasis_syntax("*word*", '*'));
+        assert!(rule.is_emphasis_syntax(
+            "*Rejected — rightmost `X-Forwarded-For` with N trusted hops.* Generic, but calibrating",
+            '*'
+        ));
+        assert_eq!(
+            rule.get_unordered_marker(
+                "*Rejected — rightmost `X-Forwarded-For` with N trusted hops.* Generic, but calibrating"
+            ),
+            None
+        );
+
+        // A marker with no closing '*' is still a missing-space list marker.
+        assert!(!rule.is_emphasis_syntax("*text with no closing", '*'));
+        assert_eq!(
+            rule.get_unordered_marker("*No space after marker"),
+            Some('*')
+        );
     }
 
     #[test]


### PR DESCRIPTION
Addresses the MD030 half of #438. The MD032 case in that issue is separate and is not touched here, so this does not close it.

## Problem

`MD030::is_emphasis_syntax` treated a line starting with `*` as emphasis only when the closing `*` fell within the first 50 characters:

```rust
if let Some(closing_pos) = remaining.find('*') {
    if closing_pos < 50 && !remaining[..closing_pos].contains('\n') {
        return true;
    }
}
```

An emphasized sentence longer than that fell through to `get_unordered_marker`, which returned `'*'`, and MD030 reported a list marker with zero spaces after it.

Reproduced against the current binary with the document from the issue:

```console
$ mdbook-lint lint --enable MD030,MD032 emphasis.md
warning[MD030]: Unordered list marker spacing: expected 1 space(s) after '*', found 0
  --> emphasis.md:6:2
warning[MD030]: Unordered list marker spacing: expected 1 space(s) after '*', found 0
  --> emphasis.md:9:2
```

The threshold explains both details the reporter noticed. The first paragraph's closing `*` sits at offset 46 and is accepted; the next two sit past 50 and are flagged. And because the offset depends on the text ahead of the closing marker, editing unrelated words moves a paragraph across the boundary, so the warning appears to come and go.

One correction to the issue's diagnosis: this is not shared list parsing. MD030 is entirely line-based and does not use the AST, and `--enable MD030` alone reproduces the warnings on the current build. The 50-character window is local to MD030.

## Change

`crates/mdbook-lint-rulesets/src/standard/md030.rs`: drop the distance threshold. Distance from the opening marker says nothing about whether a span is emphasis, so the check is now whether a closing `*` exists anywhere later on the line. The `contains('\n')` guard went with it; `trimmed` is a single line, so it was always false.

This only affects lines matching `*<non-space>`, since a line with whitespace after the marker never reaches the emphasis check. CommonMark requires a space after a bullet, so `*text*` is never a list item, which makes the new classification the correct one.

Behavior that does not change: a line with no closing `*`, such as `*No space after marker`, is still reported as a missing space after a list marker, and its autofix is unchanged.

## Test

Two tests in the MD030 test module:

- `test_md030_long_emphasis_spans_not_flagged` runs the issue's document and asserts no violations. Before the change it produced 2, on lines 6 and 9.
- `test_md030_emphasis_length_does_not_decide` asserts short and long spans classify the same, and pins the zero-space list marker case so the fix cannot silently widen into it.

End-to-end with the CLI on the issue's file: the fixed binary reports `No issues found`.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` (20 suites, 0 failures, including the 36 pre-existing MD030 tests) all pass.
