### PR TITLE
ci: bump bump-homebrew-formula-action to v4 to fix HTTP 303 on formula bump

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Update Homebrew formula
         if: ${{ steps.parse.outputs.version != '' }}
-        uses: mislav/bump-homebrew-formula-action@v3.1
+        uses: mislav/bump-homebrew-formula-action@v4
         with:
           formula-name: mdbook-lint
           formula-path: Formula/mdbook-lint.rb


### PR DESCRIPTION
Closes #449.

## What

Bump `mislav/bump-homebrew-formula-action` from `@v3.1` to `@v4` in `.github/workflows/release-plz.yml` (`update-homebrew` job).

## Why

`v3.1` downloads the source tarball with the `COMMITTER_TOKEN` attached to compute its SHA256. For authenticated archive requests GitHub responds with `303 See Other` (dropping the Authorization header on the cross-host redirect to `codeload.github.com`), and `v3.1` does not follow the `303`, failing immediately with `unexpected HTTP 303 response`. See #449 for the full analysis, including that the same failure occurred on both v0.14.4 and v0.15.0. `v4` follows the redirect.

Uses the `@v4` major-version tag to match how the other actions in these workflows are pinned (`actions/checkout@v4`, `release-plz/action@v0.5`, etc.).

## Validation

This job only runs in the release flow (`push` to `main` that produces a release), so PR CI does not exercise it; the change can only be fully confirmed on the next release. The tap has already been manually bumped to v0.15.0 out of band, so Homebrew is current in the meantime and the next release is the first automated test of this fix.

`release-plz.yml` parses cleanly (`yaml.safe_load`). No other keys changed.