### PR TITLE
fix(mdbook): wire real config options for MDBOOK002, MDBOOK003, MDBOOK004

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -367,15 +367,20 @@
 
 # MDBOOK002 - Internal link validation
 # [MDBOOK002]
-# No configuration options
+# check_anchors = false  # Validate same-document anchors (#section) against headings
+# allow_external = true  # Skip external URLs; false reports them instead
+# check_images = false  # Also validate image paths
 
 # MDBOOK003 - SUMMARY.md structure validation
 # [MDBOOK003]
-# No configuration options
+# allow_draft_chapters = true  # Allow chapters without links
+# require_part_headers = false  # Require at least one part header
+# max_depth = 3  # Maximum nesting depth (unset means unlimited)
 
 # MDBOOK004 - No duplicate chapter titles
 # [MDBOOK004]
-# No configuration options
+# case_sensitive = true  # Case-sensitive comparison
+# ignore_prefixes = ["Chapter", "Part"]  # Prefixes stripped before comparing
 
 # MDBOOK005 - Orphaned files detection
 # [MDBOOK005]

--- a/crates/mdbook-lint-rulesets/src/mdbook/anchors.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/anchors.rs
@@ -1,0 +1,137 @@
+//! Shared heading-anchor helpers for the mdBook rules.
+//!
+//! MDBOOK002 (same-document anchors) and MDBOOK006 (cross-file anchors) both need
+//! the anchor ids mdBook generates for a markdown file's headings. The generation
+//! has to stay identical between the two, so it lives here.
+
+use std::collections::HashMap;
+
+/// Generate an anchor ID from heading text (matching mdBook 0.5.x behavior)
+///
+/// The algorithm:
+/// - Alphanumeric characters become lowercase
+/// - Hyphens and underscores are preserved as-is
+/// - Whitespace becomes hyphens
+/// - Other characters (punctuation) are removed
+/// - Leading/trailing hyphens are trimmed
+/// - Consecutive hyphens are NOT collapsed (mdBook preserves them)
+pub(super) fn generate_anchor_id(heading_text: &str) -> String {
+    let mut fragment = String::new();
+
+    for ch in heading_text.chars() {
+        if ch.is_alphanumeric() {
+            fragment.extend(ch.to_lowercase());
+        } else if ch == '-' || ch == '_' {
+            // Preserve hyphens and underscores as-is
+            fragment.push(ch);
+        } else if ch.is_whitespace() {
+            // Replace whitespace (spaces, tabs) with hyphens
+            fragment.push('-');
+        }
+        // Other characters (punctuation like +, &, etc.) are removed/ignored
+    }
+
+    // Remove leading/trailing hyphens only
+    // Do NOT consolidate multiple consecutive hyphens - mdBook preserves them
+    fragment.trim_matches('-').to_string()
+}
+
+/// Extract heading text from an ATX heading line
+pub(super) fn extract_atx_heading(line: &str) -> Option<String> {
+    if !line.starts_with('#') {
+        return None;
+    }
+
+    // Count leading hashes
+    let hash_count = line.chars().take_while(|&c| c == '#').count();
+    if hash_count == 0 || hash_count > 6 {
+        return None; // Invalid heading level
+    }
+
+    // Extract text after hashes
+    let rest = &line[hash_count..];
+    let text = if let Some(stripped) = rest.strip_prefix(' ') {
+        stripped
+    } else {
+        rest
+    };
+
+    // Remove trailing hashes if present (closed ATX style)
+    let text = text.trim_end_matches(['#', ' ']);
+
+    if text.is_empty() {
+        return None;
+    }
+
+    Some(text.to_string())
+}
+
+/// Extract all heading anchors from markdown content, in document order
+///
+/// Duplicate headings get the same unique ids mdBook generates: the bare anchor
+/// first, then `-1`, `-2`, and so on.
+pub(super) fn extract_heading_anchors(content: &str) -> Vec<String> {
+    let mut anchors = Vec::new();
+    let mut anchor_counts: HashMap<String, usize> = HashMap::new();
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        if let Some(heading_text) = extract_atx_heading(line) {
+            let base_anchor = generate_anchor_id(&heading_text);
+            if !base_anchor.is_empty() {
+                let count = anchor_counts.entry(base_anchor.clone()).or_insert(0);
+                let anchor = if *count == 0 {
+                    base_anchor.clone()
+                } else {
+                    format!("{base_anchor}-{count}")
+                };
+                *count += 1;
+                anchors.push(anchor);
+            }
+        }
+    }
+
+    // TODO: Handle Setext headings (underlined with = or -)
+    // This is less common in mdBook but could be added for completeness
+
+    anchors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_anchor_id_basic() {
+        assert_eq!(generate_anchor_id("Getting Started"), "getting-started");
+        assert_eq!(generate_anchor_id("API Reference"), "api-reference");
+        // Punctuation is dropped, but the hyphens it leaves behind are not collapsed
+        assert_eq!(generate_anchor_id("C++ & Rust"), "c--rust");
+        assert_eq!(generate_anchor_id("snake_case-name"), "snake_case-name");
+    }
+
+    #[test]
+    fn test_extract_atx_heading_variants() {
+        assert_eq!(
+            extract_atx_heading("## Getting Started"),
+            Some("Getting Started".to_string())
+        );
+        assert_eq!(
+            extract_atx_heading("### Closed ###"),
+            Some("Closed".to_string())
+        );
+        assert_eq!(extract_atx_heading("####### Too deep"), None);
+        assert_eq!(extract_atx_heading("Not a heading"), None);
+        assert_eq!(extract_atx_heading("## "), None);
+    }
+
+    #[test]
+    fn test_extract_heading_anchors_dedupes() {
+        let content = "# Intro\n\n## Setup\n\n## Setup\n\n## Setup\n";
+        assert_eq!(
+            extract_heading_anchors(content),
+            vec!["intro", "setup", "setup-1", "setup-2"]
+        );
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook002.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook002.rs
@@ -11,7 +11,57 @@ use mdbook_lint_core::{
 use std::path::{Path, PathBuf};
 
 /// Rule to check that internal links resolve to existing files
-pub struct MDBOOK002;
+///
+/// Configuration:
+/// - `check_anchors` (default false): also validate same-document anchor links
+///   (`[text](#section)`) against the headings in the file. Cross-file anchors
+///   (`file.md#section`) are MDBOOK006's job and are not checked here.
+/// - `allow_external` (default true): skip external URLs. Set to false to report
+///   them instead, for books that must not link off-site.
+/// - `check_images` (default false): also validate image paths (`![alt](path)`).
+pub struct MDBOOK002 {
+    /// Whether same-document anchor links are validated against the file's headings
+    check_anchors: bool,
+    /// Whether external URLs are skipped (true) or reported (false)
+    allow_external: bool,
+    /// Whether image paths are validated in addition to links
+    check_images: bool,
+}
+
+impl Default for MDBOOK002 {
+    fn default() -> Self {
+        Self {
+            check_anchors: false,
+            allow_external: true,
+            check_images: false,
+        }
+    }
+}
+
+impl MDBOOK002 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `check_anchors`: validate same-document anchor links (default false).
+    /// - `allow_external`: skip external URLs (default true).
+    /// - `check_images`: validate image paths as well as links (default false).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let get = |snake: &str, kebab: &str| config.get(snake).or_else(|| config.get(kebab));
+        let defaults = Self::default();
+
+        Self {
+            check_anchors: get("check_anchors", "check-anchors")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(defaults.check_anchors),
+            allow_external: get("allow_external", "allow-external")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(defaults.allow_external),
+            check_images: get("check_images", "check-images")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(defaults.check_images),
+        }
+    }
+}
 
 impl AstRule for MDBOOK002 {
     fn id(&self) -> &'static str {
@@ -47,30 +97,79 @@ impl MDBOOK002 {
         ast: &'a comrak::nodes::AstNode<'a>,
     ) -> mdbook_lint_core::error::Result<Vec<Violation>> {
         let mut violations = Vec::new();
+        // Only built when check_anchors is on, since it re-scans the document.
+        let mut document_anchors: Option<Vec<String>> = None;
 
         // Walk through all nodes in the AST
         for node in ast.descendants() {
-            if let NodeValue::Link(link) = &node.data.borrow().value {
-                let url = &link.url;
+            let (url, is_image) = match &node.data.borrow().value {
+                NodeValue::Link(link) => (link.url.clone(), false),
+                NodeValue::Image(image) if self.check_images => (image.url.clone(), true),
+                _ => continue,
+            };
 
-                // Skip external links (http/https/mailto/etc)
-                if is_external_link(url) {
-                    continue;
+            // External links (http/https/mailto/etc) are skipped unless the book
+            // has opted out of allowing them at all.
+            if is_external_link(&url) {
+                if !self.allow_external {
+                    let (line, column) = document.node_position(node).unwrap_or((1, 1));
+                    violations.push(self.create_violation(
+                        format!("External link '{url}' is not allowed (allow_external = false)"),
+                        line,
+                        column,
+                        Severity::Error,
+                    ));
                 }
+                continue;
+            }
 
-                // Skip anchor-only links (same document)
-                if url.starts_with('#') {
-                    continue;
+            // Anchor-only links point within the same document
+            if url.starts_with('#') {
+                if self.check_anchors && !is_image {
+                    let anchors = document_anchors.get_or_insert_with(|| {
+                        super::anchors::extract_heading_anchors(&document.content)
+                    });
+                    if let Some(violation) =
+                        self.validate_document_anchor(document, node, &url, anchors)
+                    {
+                        violations.push(violation);
+                    }
                 }
+                continue;
+            }
 
-                // Check if the internal link resolves
-                if let Some(violation) = validate_internal_link(document, node, url)? {
-                    violations.push(violation);
-                }
+            // Check if the internal link resolves
+            if let Some(violation) = validate_internal_link(self, document, node, &url, is_image)? {
+                violations.push(violation);
             }
         }
 
         Ok(violations)
+    }
+
+    /// Validate a same-document anchor link (`#section`) against the document's headings
+    ///
+    /// Cross-file anchors (`file.md#section`) are validated by MDBOOK006; this only
+    /// covers the same-document case, which that rule skips.
+    fn validate_document_anchor<'a>(
+        &self,
+        document: &Document,
+        node: &'a comrak::nodes::AstNode<'a>,
+        url: &str,
+        anchors: &[String],
+    ) -> Option<Violation> {
+        let anchor = url.strip_prefix('#').unwrap_or(url);
+        if anchor.is_empty() || anchors.iter().any(|a| a == anchor) {
+            return None;
+        }
+
+        let (line, column) = document.node_position(node).unwrap_or((1, 1));
+        Some(self.create_violation(
+            format!("Anchor '{url}' does not match any heading in this document"),
+            line,
+            column,
+            Severity::Error,
+        ))
     }
 }
 
@@ -83,11 +182,13 @@ fn is_external_link(url: &str) -> bool {
         || url.starts_with("tel:")
 }
 
-/// Validate an internal link and return a violation if it doesn't resolve
+/// Validate an internal link or image path and return a violation if it doesn't resolve
 fn validate_internal_link<'a>(
+    rule: &MDBOOK002,
     document: &Document,
     node: &'a comrak::nodes::AstNode<'a>,
     url: &str,
+    is_image: bool,
 ) -> mdbook_lint_core::error::Result<Option<Violation>> {
     // Remove anchor fragment if present (e.g., "file.md#section" -> "file.md")
     let path_part = url.split('#').next().unwrap_or(url);
@@ -129,9 +230,14 @@ fn validate_internal_link<'a>(
 
     if !file_exists {
         let (line, column) = document.node_position(node).unwrap_or((1, 1));
+        let message = if is_image {
+            format!("Image path '{url}' does not resolve to an existing file")
+        } else {
+            format!("Internal link '{url}' does not resolve to an existing file")
+        };
 
-        return Ok(Some(MDBOOK002.create_violation(
-            format!("Internal link '{url}' does not resolve to an existing file"),
+        return Ok(Some(rule.create_violation(
+            message,
             line,
             column,
             Severity::Error,
@@ -275,7 +381,7 @@ mod tests {
 "#;
 
         let document = create_test_document(content, "test.md", &temp_dir)?;
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         assert_eq!(violations.len(), 0);
@@ -294,7 +400,7 @@ mod tests {
 "#;
 
         let document = create_test_document(content, "test.md", &temp_dir)?;
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         assert_eq!(violations.len(), 2);
@@ -319,12 +425,117 @@ mod tests {
 "#;
 
         let document = create_test_document(content, "test.md", &temp_dir)?;
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         assert_eq!(violations.len(), 1);
         assert!(violations[0].message.contains("nonexistent.md#section"));
         Ok(())
+    }
+
+    #[test]
+    fn test_mdbook002_defaults_match_unconfigured_behavior() {
+        let rule = MDBOOK002::from_config(&toml::Value::Table(Default::default()));
+        assert!(!rule.check_anchors);
+        assert!(rule.allow_external);
+        assert!(!rule.check_images);
+    }
+
+    #[test]
+    fn test_mdbook002_check_images() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        fs::write(temp_dir.path().join("real.png"), "not really a png")?;
+
+        let content = r#"# Test Document
+
+![Present](./real.png)
+![Missing](./missing.png)
+![External](https://example.com/logo.png)
+"#;
+        let document = create_test_document(content, "test.md", &temp_dir)?;
+
+        // Images are not checked by default
+        assert_eq!(MDBOOK002::default().check(&document)?.len(), 0);
+
+        let rule = MDBOOK002::from_config(&toml::toml! { check_images = true });
+        let violations = rule.check(&document)?;
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("Image path './missing.png'"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_mdbook002_allow_external() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+
+        let content = r#"# Test Document
+
+[External](https://example.com)
+[Mail](mailto:someone@example.com)
+"#;
+        let document = create_test_document(content, "test.md", &temp_dir)?;
+
+        // External links are skipped by default
+        assert_eq!(MDBOOK002::default().check(&document)?.len(), 0);
+
+        let rule = MDBOOK002::from_config(&toml::toml! { allow_external = false });
+        let violations = rule.check(&document)?;
+        assert_eq!(violations.len(), 2);
+        assert!(violations[0].message.contains("is not allowed"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_mdbook002_check_anchors() -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+
+        let content = r#"# Test Document
+
+## Getting Started
+
+[Good anchor](#getting-started)
+[Bad anchor](#no-such-heading)
+"#;
+        let document = create_test_document(content, "test.md", &temp_dir)?;
+
+        // Same-document anchors are not checked by default
+        assert_eq!(MDBOOK002::default().check(&document)?.len(), 0);
+
+        let rule = MDBOOK002::from_config(&toml::toml! { check_anchors = true });
+        let violations = rule.check(&document)?;
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("Anchor '#no-such-heading' does not match any heading")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_mdbook002_check_anchors_leaves_cross_file_anchors_to_mdbook006()
+    -> mdbook_lint_core::error::Result<()> {
+        let temp_dir = TempDir::new()?;
+        fs::write(temp_dir.path().join("target.md"), "# Target\n")?;
+
+        let content = "# Test Document\n\n[Cross file](./target.md#not-a-heading)\n";
+        let document = create_test_document(content, "test.md", &temp_dir)?;
+
+        let rule = MDBOOK002::from_config(&toml::toml! { check_anchors = true });
+        assert_eq!(rule.check(&document)?.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_mdbook002_kebab_case_config_keys() {
+        let rule = MDBOOK002::from_config(&toml::toml! {
+            "check-anchors" = true
+            "allow-external" = false
+            "check-images" = true
+        });
+        assert!(rule.check_anchors);
+        assert!(!rule.allow_external);
+        assert!(rule.check_images);
     }
 
     #[test]
@@ -451,7 +662,7 @@ mod tests {
         fs::write(&doc_path, content)?;
         let document = Document::new(content.to_string(), doc_path)?;
 
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         // Should only have one violation for the nonexistent file
@@ -494,7 +705,7 @@ mod tests {
         fs::write(&doc_path, content)?;
         let document = Document::new(content.to_string(), doc_path)?;
 
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         // Should only flag ./missing.md (inside book but missing)
@@ -532,7 +743,7 @@ mod tests {
         fs::write(&doc_path, content)?;
         let document = Document::new(content.to_string(), doc_path)?;
 
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         // Should only report invalid internal links
@@ -569,7 +780,7 @@ mod tests {
         fs::write(&doc_path, content)?;
         let document = Document::new(content.to_string(), doc_path)?;
 
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         // Should only report the invalid internal link, not the external doc links
@@ -662,7 +873,7 @@ mod tests {
         fs::write(&doc_path, content)?;
         let document = Document::new(content.to_string(), doc_path)?;
 
-        let rule = MDBOOK002;
+        let rule = MDBOOK002::default();
         let violations = rule.check(&document)?;
 
         // Should only report the invalid html link (no corresponding .md file)

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook003.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook003.rs
@@ -18,7 +18,57 @@ use mdbook_lint_core::violation::{Severity, Violation};
 /// - Valid link syntax for chapters
 /// - Draft chapters use empty parentheses
 /// - Separators contain only dashes (minimum 3)
-pub struct MDBOOK003;
+///
+/// Configuration:
+/// - `allow_draft_chapters` (default true): whether `[Title]()` draft entries are allowed.
+/// - `require_part_headers` (default false): whether the summary must declare at least
+///   one part header (`# Part title`).
+/// - `max_depth` (default unset, meaning unlimited): deepest chapter nesting level
+///   allowed, counting top-level chapters as depth 1.
+pub struct MDBOOK003 {
+    /// Whether draft chapters (entries with an empty link target) are allowed
+    allow_draft_chapters: bool,
+    /// Whether at least one part header is required
+    require_part_headers: bool,
+    /// Maximum chapter nesting depth, or None for unlimited
+    max_depth: Option<usize>,
+}
+
+impl Default for MDBOOK003 {
+    fn default() -> Self {
+        Self {
+            allow_draft_chapters: true,
+            require_part_headers: false,
+            max_depth: None,
+        }
+    }
+}
+
+impl MDBOOK003 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `allow_draft_chapters`: allow `[Title]()` entries (default true).
+    /// - `require_part_headers`: require at least one `# Part title` (default false).
+    /// - `max_depth`: deepest chapter nesting level allowed (default unlimited).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let get = |snake: &str, kebab: &str| config.get(snake).or_else(|| config.get(kebab));
+        let defaults = Self::default();
+
+        Self {
+            allow_draft_chapters: get("allow_draft_chapters", "allow-draft-chapters")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(defaults.allow_draft_chapters),
+            require_part_headers: get("require_part_headers", "require-part-headers")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(defaults.require_part_headers),
+            max_depth: get("max_depth", "max-depth")
+                .and_then(|v| v.as_integer())
+                .and_then(|v| usize::try_from(v).ok())
+                .filter(|depth| *depth > 0),
+        }
+    }
+}
 
 impl Rule for MDBOOK003 {
     fn id(&self) -> &'static str {
@@ -51,6 +101,19 @@ impl Rule for MDBOOK003 {
 
         let mut checker = SummaryChecker::new(self);
         checker.validate(document, &mut violations);
+
+        // A book that requires part headers must declare at least one before its chapters
+        if self.require_part_headers
+            && checker.part_title_lines.is_empty()
+            && checker.seen_numbered_chapters
+        {
+            violations.push(self.create_violation(
+                "SUMMARY.md must declare at least one part header (# Part title)".to_string(),
+                1,
+                1,
+                Severity::Error,
+            ));
+        }
 
         Ok(violations)
     }
@@ -258,6 +321,22 @@ impl<'a> SummaryChecker<'a> {
     ) {
         let expected_max_level = self.current_nesting_level + 1;
 
+        // Nesting depth counts top-level chapters as depth 1
+        if let Some(max_depth) = self.rule.max_depth
+            && chapter.indent_level + 1 > max_depth
+        {
+            violations.push(self.rule.create_violation(
+                format!(
+                    "Chapter nesting depth {} exceeds the configured max_depth of {}",
+                    chapter.indent_level + 1,
+                    max_depth
+                ),
+                line_num,
+                1,
+                Severity::Error,
+            ));
+        }
+
         if chapter.indent_level > expected_max_level {
             violations.push(self.rule.create_violation(
                 format!(
@@ -333,7 +412,18 @@ impl<'a> SummaryChecker<'a> {
 
                 // Draft chapters should have empty path
                 if path.is_empty() {
-                    // This is a draft chapter, which is valid
+                    // This is a draft chapter, valid unless the book disallows drafts
+                    if !self.rule.allow_draft_chapters {
+                        violations.push(
+                            self.rule.create_violation(
+                                "Draft chapters are not allowed; give the chapter a file path"
+                                    .to_string(),
+                                line_num,
+                                bracket_end + 3,
+                                Severity::Error,
+                            ),
+                        );
+                    }
                 } else {
                     // Validate path format (basic checks)
                     if path.contains("\\") {
@@ -415,7 +505,7 @@ mod tests {
 [Contributors](misc/contributors.md)
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
         assert_eq!(
             violations.len(),
@@ -425,10 +515,91 @@ mod tests {
     }
 
     #[test]
+    fn test_mdbook003_defaults_match_unconfigured_behavior() {
+        let rule = MDBOOK003::from_config(&toml::Value::Table(Default::default()));
+        assert!(rule.allow_draft_chapters);
+        assert!(!rule.require_part_headers);
+        assert_eq!(rule.max_depth, None);
+    }
+
+    #[test]
+    fn test_mdbook003_draft_chapters_allowed_by_default() {
+        let content = "# Summary\n\n- [Draft Chapter]()\n";
+        let doc = create_test_document(content, "SUMMARY.md");
+        let violations = MDBOOK003::default().check(&doc).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_mdbook003_draft_chapters_rejected_when_disallowed() {
+        let content = "# Summary\n\n- [Draft Chapter]()\n";
+        let doc = create_test_document(content, "SUMMARY.md");
+        let rule = MDBOOK003::from_config(&toml::toml! { allow_draft_chapters = false });
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(
+            violations[0]
+                .message
+                .contains("Draft chapters are not allowed")
+        );
+        assert_eq!(violations[0].line, 3);
+    }
+
+    #[test]
+    fn test_mdbook003_part_headers_required() {
+        let content = "- [Installation](guide/installation.md)\n";
+        let doc = create_test_document(content, "SUMMARY.md");
+
+        assert_eq!(MDBOOK003::default().check(&doc).unwrap().len(), 0);
+
+        let rule = MDBOOK003::from_config(&toml::toml! { require_part_headers = true });
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("part header"));
+    }
+
+    #[test]
+    fn test_mdbook003_part_headers_requirement_satisfied() {
+        let content = "# User Guide\n\n- [Installation](guide/installation.md)\n";
+        let doc = create_test_document(content, "SUMMARY.md");
+        let rule = MDBOOK003::from_config(&toml::toml! { require_part_headers = true });
+        assert_eq!(rule.check(&doc).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_mdbook003_max_depth() {
+        let content =
+            "# Summary\n\n- [One](one.md)\n    - [Two](two.md)\n        - [Three](three.md)\n";
+        let doc = create_test_document(content, "SUMMARY.md");
+
+        // Unlimited by default
+        assert_eq!(MDBOOK003::default().check(&doc).unwrap().len(), 0);
+
+        let rule = MDBOOK003::from_config(&toml::toml! { max_depth = 2 });
+        let violations = rule.check(&doc).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].message.contains("depth 3"));
+        assert!(violations[0].message.contains("max_depth of 2"));
+        assert_eq!(violations[0].line, 5);
+    }
+
+    #[test]
+    fn test_mdbook003_kebab_case_config_keys() {
+        let rule = MDBOOK003::from_config(&toml::toml! {
+            "allow-draft-chapters" = false
+            "require-part-headers" = true
+            "max-depth" = 3
+        });
+        assert!(!rule.allow_draft_chapters);
+        assert!(rule.require_part_headers);
+        assert_eq!(rule.max_depth, Some(3));
+    }
+
+    #[test]
     fn test_not_summary_file() {
         let content = "# Some Random File\n\n- [Link](file.md)";
         let doc = create_test_document(content, "README.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
         assert_eq!(
             violations.len(),
@@ -446,7 +617,7 @@ mod tests {
 - [Third](third.md)
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
 
         let delimiter_violations: Vec<_> = violations
@@ -472,7 +643,7 @@ mod tests {
 - [Another](another.md)
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
 
         let part_title_violations: Vec<_> = violations
@@ -496,7 +667,7 @@ mod tests {
 - [Chapter](chapter.md)
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
 
         let nesting_violations: Vec<_> = violations
@@ -517,7 +688,7 @@ mod tests {
         - [Skip Level](skip.md)
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
 
         let hierarchy_violations: Vec<_> = violations
@@ -539,7 +710,7 @@ mod tests {
 - Missing Link Format
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
 
         let link_violations: Vec<_> = violations
@@ -560,7 +731,7 @@ mod tests {
 - [Draft Chapter]()
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
 
         // Draft chapters should not generate violations
@@ -586,7 +757,7 @@ mod tests {
 [Suffix](suffix.md)
 "#;
         let doc = create_test_document(content, "SUMMARY.md");
-        let rule = MDBOOK003;
+        let rule = MDBOOK003::default();
         let violations = rule.check(&doc).unwrap();
 
         let separator_violations: Vec<_> = violations

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook004.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook004.rs
@@ -15,7 +15,94 @@ use std::collections::HashMap;
 /// This rule checks that each chapter has a unique title within the book.
 /// Note: This rule is designed to work with individual chapters and will
 /// need cross-file coordination to detect duplicates across the entire book.
-pub struct MDBOOK004;
+///
+/// Configuration:
+/// - `case_sensitive` (default true): whether titles differing only in case count
+///   as duplicates.
+/// - `ignore_prefixes` (default empty): leading prefixes stripped from a title
+///   before comparison, so "Chapter Setup" and "Setup" compare equal.
+pub struct MDBOOK004 {
+    /// Whether title comparison is case-sensitive
+    case_sensitive: bool,
+    /// Prefixes stripped from a title before comparison
+    ignore_prefixes: Vec<String>,
+}
+
+impl Default for MDBOOK004 {
+    fn default() -> Self {
+        Self {
+            case_sensitive: true,
+            ignore_prefixes: Vec::new(),
+        }
+    }
+}
+
+impl MDBOOK004 {
+    /// Create an instance from rule configuration.
+    ///
+    /// Recognized keys (both `snake_case` and `kebab-case` accepted):
+    /// - `case_sensitive`: compare titles case-sensitively (default true).
+    /// - `ignore_prefixes`: array of prefixes to strip before comparing (default none).
+    pub fn from_config(config: &toml::Value) -> Self {
+        let get = |snake: &str, kebab: &str| config.get(snake).or_else(|| config.get(kebab));
+        let defaults = Self::default();
+
+        Self {
+            case_sensitive: get("case_sensitive", "case-sensitive")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(defaults.case_sensitive),
+            ignore_prefixes: get("ignore_prefixes", "ignore-prefixes")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or(defaults.ignore_prefixes),
+        }
+    }
+
+    /// Reduce a title to the key used for duplicate comparison
+    ///
+    /// The first matching prefix is stripped (with any whitespace that follows it),
+    /// then the result is case-folded when `case_sensitive` is off.
+    fn comparison_key(&self, title: &str) -> String {
+        let mut key = title;
+
+        for prefix in &self.ignore_prefixes {
+            if let Some(rest) = strip_prefix(key, prefix, self.case_sensitive) {
+                key = rest.trim_start();
+                break;
+            }
+        }
+
+        if self.case_sensitive {
+            key.to_string()
+        } else {
+            key.to_lowercase()
+        }
+    }
+}
+
+/// Strip `prefix` from the front of `key`, comparing case-insensitively when asked
+///
+/// Works on char boundaries so a prefix whose case mapping changes byte length
+/// cannot produce an invalid slice.
+fn strip_prefix<'a>(key: &'a str, prefix: &str, case_sensitive: bool) -> Option<&'a str> {
+    if case_sensitive {
+        return key.strip_prefix(prefix);
+    }
+
+    let mut key_chars = key.char_indices();
+    for prefix_char in prefix.chars() {
+        match key_chars.next() {
+            Some((_, key_char)) if key_char.to_lowercase().eq(prefix_char.to_lowercase()) => {}
+            _ => return None,
+        }
+    }
+
+    Some(key_chars.next().map(|(i, _)| &key[i..]).unwrap_or(""))
+}
 
 impl AstRule for MDBOOK004 {
     fn id(&self) -> &'static str {
@@ -50,8 +137,10 @@ impl AstRule for MDBOOK004 {
                 let title = document.node_text(node).trim().to_string();
 
                 if !title.is_empty() {
+                    let key = self.comparison_key(&title);
+
                     // Check for duplicates within the same document
-                    if let Some((prev_line, _)) = title_positions.get(&title) {
+                    if let Some((prev_line, _)) = title_positions.get(&key) {
                         violations.push(self.create_violation(
                             format!(
                                 "Duplicate chapter title '{title}' found (also at line {prev_line})"
@@ -61,7 +150,7 @@ impl AstRule for MDBOOK004 {
                             Severity::Error,
                         ));
                     } else {
-                        title_positions.insert(title, (line, column));
+                        title_positions.insert(key, (line, column));
                     }
                 }
             }
@@ -95,7 +184,7 @@ mod tests {
             .paragraph("Advanced material.")
             .build();
 
-        assert_no_violations(MDBOOK004, &content);
+        assert_no_violations(MDBOOK004::default(), &content);
     }
 
     #[test]
@@ -114,7 +203,7 @@ mod tests {
             .paragraph("Second introduction - duplicate!")
             .build();
 
-        let violations = assert_violation_count(MDBOOK004, &content, 1);
+        let violations = assert_violation_count(MDBOOK004::default(), &content, 1);
         assert_violation_contains_message(&violations, "Duplicate chapter title 'Introduction'");
         assert_violation_contains_message(&violations, "also at line 1");
         assert_violation_at_line(&violations, 9);
@@ -131,7 +220,70 @@ mod tests {
             .build();
 
         // These should be treated as different titles (case-sensitive)
-        assert_no_violations(MDBOOK004, &content);
+        assert_no_violations(MDBOOK004::default(), &content);
+    }
+
+    #[test]
+    fn test_mdbook004_defaults_match_unconfigured_behavior() {
+        let rule = MDBOOK004::from_config(&toml::Value::Table(Default::default()));
+        assert!(rule.case_sensitive);
+        assert!(rule.ignore_prefixes.is_empty());
+    }
+
+    #[test]
+    fn test_mdbook004_case_insensitive_when_configured() {
+        let content = MarkdownBuilder::new()
+            .heading(1, "Introduction")
+            .blank_line()
+            .heading(1, "introduction")
+            .build();
+
+        let rule = MDBOOK004::from_config(&toml::toml! { case_sensitive = false });
+        let violations = assert_violation_count(rule, &content, 1);
+        assert_violation_contains_message(&violations, "Duplicate chapter title 'introduction'");
+    }
+
+    #[test]
+    fn test_mdbook004_ignore_prefixes() {
+        let content = MarkdownBuilder::new()
+            .heading(1, "Chapter Setup")
+            .blank_line()
+            .heading(1, "Setup")
+            .build();
+
+        // Without the prefix configured these are distinct titles
+        assert_no_violations(MDBOOK004::default(), &content);
+
+        let rule = MDBOOK004::from_config(&toml::toml! { ignore_prefixes = ["Chapter", "Part"] });
+        let violations = assert_violation_count(rule, &content, 1);
+        assert_violation_contains_message(&violations, "Duplicate chapter title 'Setup'");
+    }
+
+    #[test]
+    fn test_mdbook004_ignore_prefixes_respect_case_sensitivity() {
+        let case_sensitive = MDBOOK004::from_config(&toml::toml! { ignore_prefixes = ["Chapter"] });
+        // A prefix that differs in case is not stripped when comparison is case-sensitive
+        assert_eq!(
+            case_sensitive.comparison_key("chapter Setup"),
+            "chapter Setup"
+        );
+        assert_eq!(case_sensitive.comparison_key("Chapter Setup"), "Setup");
+
+        let case_insensitive = MDBOOK004::from_config(&toml::toml! {
+            ignore_prefixes = ["Chapter"]
+            case_sensitive = false
+        });
+        assert_eq!(case_insensitive.comparison_key("chapter Setup"), "setup");
+    }
+
+    #[test]
+    fn test_mdbook004_kebab_case_config_keys() {
+        let rule = MDBOOK004::from_config(&toml::toml! {
+            "case-sensitive" = false
+            "ignore-prefixes" = ["Ch."]
+        });
+        assert!(!rule.case_sensitive);
+        assert_eq!(rule.ignore_prefixes, vec!["Ch.".to_string()]);
     }
 
     #[test]
@@ -145,7 +297,7 @@ mod tests {
             .build();
 
         // Even different heading levels should be considered duplicates
-        let violations = assert_violation_count(MDBOOK004, &content, 2);
+        let violations = assert_violation_count(MDBOOK004::default(), &content, 2);
         assert_violation_contains_message(&violations, "Duplicate chapter title 'Setup'");
     }
 
@@ -160,7 +312,7 @@ mod tests {
             .build();
 
         // Empty headings should be ignored
-        assert_no_violations(MDBOOK004, &content);
+        assert_no_violations(MDBOOK004::default(), &content);
     }
 
     #[test]
@@ -171,7 +323,7 @@ mod tests {
             .line("# Intro link")
             .build();
 
-        let violations = assert_violation_count(MDBOOK004, &content, 1);
+        let violations = assert_violation_count(MDBOOK004::default(), &content, 1);
         assert_violation_contains_message(&violations, "Duplicate chapter title 'Intro link'");
         assert_violation_contains_message(&violations, "also at line 1");
         assert_violation_at_line(&violations, 3);
@@ -188,7 +340,7 @@ mod tests {
             .build();
 
         // Only the last line is a real heading node.
-        assert_no_violations(MDBOOK004, &content);
+        assert_no_violations(MDBOOK004::default(), &content);
     }
 
     #[test]
@@ -206,7 +358,7 @@ mod tests {
             .build();
 
         // Whitespace should be trimmed, so these are duplicates
-        let violations = assert_violation_count(MDBOOK004, &content, 3);
+        let violations = assert_violation_count(MDBOOK004::default(), &content, 3);
         assert_violation_contains_message(&violations, "Duplicate chapter title 'Introduction'");
     }
 
@@ -218,13 +370,13 @@ mod tests {
             .line("# Introductio\\u006E")
             .build();
 
-        assert_violation_count(MDBOOK004, &content, 0);
+        assert_violation_count(MDBOOK004::default(), &content, 0);
     }
 
     #[test]
     fn test_mdbook004_rule_metadata() {
         use mdbook_lint_core::rule::AstRule;
-        let rule = MDBOOK004;
+        let rule = MDBOOK004::default();
         assert_eq!(AstRule::id(&rule), "MDBOOK004");
         assert_eq!(AstRule::name(&rule), "no-duplicate-chapter-titles");
         assert!(AstRule::description(&rule).contains("unique"));

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook006.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook006.rs
@@ -224,95 +224,23 @@ impl MDBOOK006 {
     }
 
     /// Extract heading anchors from markdown content
+    ///
+    /// Shared with MDBOOK002's same-document anchor check, so both rules agree on
+    /// what anchors a file provides.
     fn extract_heading_anchors(&self, content: &str) -> Vec<String> {
-        let mut anchors = Vec::new();
-        // Counter of how many times each base anchor has been seen, so duplicate
-        // headings get the same unique ids mdBook generates (bare, then "-1", "-2", ...).
-        let mut anchor_counts: HashMap<String, usize> = HashMap::new();
-
-        for line in content.lines() {
-            let line = line.trim();
-
-            // Match ATX headings (# ## ### etc)
-            if let Some(heading_text) = self.extract_atx_heading(line) {
-                let base_anchor = self.generate_anchor_id(&heading_text);
-                if !base_anchor.is_empty() {
-                    let count = anchor_counts.entry(base_anchor.clone()).or_insert(0);
-                    let anchor = if *count == 0 {
-                        base_anchor.clone()
-                    } else {
-                        format!("{base_anchor}-{count}")
-                    };
-                    *count += 1;
-                    anchors.push(anchor);
-                }
-            }
-        }
-
-        // TODO: Handle Setext headings (underlined with = or -)
-        // This is less common in mdBook but could be added for completeness
-
-        anchors
+        super::anchors::extract_heading_anchors(content)
     }
 
     /// Extract heading text from ATX heading line
+    #[cfg(test)]
     fn extract_atx_heading(&self, line: &str) -> Option<String> {
-        if !line.starts_with('#') {
-            return None;
-        }
-
-        // Count leading hashes
-        let hash_count = line.chars().take_while(|&c| c == '#').count();
-        if hash_count == 0 || hash_count > 6 {
-            return None; // Invalid heading level
-        }
-
-        // Extract text after hashes
-        let rest = &line[hash_count..];
-        let text = if let Some(stripped) = rest.strip_prefix(' ') {
-            stripped
-        } else {
-            rest
-        };
-
-        // Remove trailing hashes if present (closed ATX style)
-        let text = text.trim_end_matches(['#', ' ']);
-
-        if text.is_empty() {
-            return None;
-        }
-
-        Some(text.to_string())
+        super::anchors::extract_atx_heading(line)
     }
 
     /// Generate anchor ID from heading text (matching mdBook 0.5.x behavior)
-    ///
-    /// The algorithm:
-    /// - Alphanumeric characters become lowercase
-    /// - Hyphens and underscores are preserved as-is
-    /// - Whitespace becomes hyphens
-    /// - Other characters (punctuation) are removed
-    /// - Leading/trailing hyphens are trimmed
-    /// - Consecutive hyphens are NOT collapsed (mdBook preserves them)
+    #[cfg(test)]
     fn generate_anchor_id(&self, heading_text: &str) -> String {
-        let mut fragment = String::new();
-
-        for ch in heading_text.chars() {
-            if ch.is_alphanumeric() {
-                fragment.extend(ch.to_lowercase());
-            } else if ch == '-' || ch == '_' {
-                // Preserve hyphens and underscores as-is
-                fragment.push(ch);
-            } else if ch.is_whitespace() {
-                // Replace whitespace (spaces, tabs) with hyphens
-                fragment.push('-');
-            }
-            // Other characters (punctuation like +, &, etc.) are removed/ignored
-        }
-
-        // Remove leading/trailing hyphens only
-        // Do NOT consolidate multiple consecutive hyphens - mdBook preserves them
-        fragment.trim_matches('-').to_string()
+        super::anchors::generate_anchor_id(heading_text)
     }
 
     /// Suggest similar anchor that might be what the user intended

--- a/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains implementations of mdBook-specific linting rules
 //! that extend standard markdown linting for mdBook projects.
 
+mod anchors;
 mod mdbook001;
 mod mdbook002;
 mod mdbook003;
@@ -43,9 +44,9 @@ impl RuleProvider for MdBookRuleProvider {
 
     fn register_rules(&self, registry: &mut RuleRegistry) {
         registry.register(Box::new(mdbook001::MDBOOK001));
-        registry.register(Box::new(mdbook002::MDBOOK002));
-        registry.register(Box::new(mdbook003::MDBOOK003));
-        registry.register(Box::new(mdbook004::MDBOOK004));
+        registry.register(Box::new(mdbook002::MDBOOK002::default()));
+        registry.register(Box::new(mdbook003::MDBOOK003::default()));
+        registry.register(Box::new(mdbook004::MDBOOK004::default()));
         registry.register(Box::new(mdbook005::MDBOOK005::default()));
         registry.register(Box::new(mdbook006::MDBOOK006::default()));
         registry.register(Box::new(mdbook007::MDBOOK007::default()));
@@ -64,9 +65,28 @@ impl RuleProvider for MdBookRuleProvider {
 
     fn register_rules_with_config(&self, registry: &mut RuleRegistry, config: Option<&Config>) {
         registry.register(Box::new(mdbook001::MDBOOK001));
-        registry.register(Box::new(mdbook002::MDBOOK002));
-        registry.register(Box::new(mdbook003::MDBOOK003));
-        registry.register(Box::new(mdbook004::MDBOOK004));
+
+        // MDBOOK002 - internal links (supports check_anchors/allow_external/check_images)
+        let mdbook002 = match config.and_then(|c| c.rule_configs.get("MDBOOK002")) {
+            Some(cfg) => mdbook002::MDBOOK002::from_config(cfg),
+            None => mdbook002::MDBOOK002::default(),
+        };
+        registry.register(Box::new(mdbook002));
+
+        // MDBOOK003 - SUMMARY.md structure
+        // (supports allow_draft_chapters/require_part_headers/max_depth)
+        let mdbook003 = match config.and_then(|c| c.rule_configs.get("MDBOOK003")) {
+            Some(cfg) => mdbook003::MDBOOK003::from_config(cfg),
+            None => mdbook003::MDBOOK003::default(),
+        };
+        registry.register(Box::new(mdbook003));
+
+        // MDBOOK004 - duplicate chapter titles (supports case_sensitive/ignore_prefixes)
+        let mdbook004 = match config.and_then(|c| c.rule_configs.get("MDBOOK004")) {
+            Some(cfg) => mdbook004::MDBOOK004::from_config(cfg),
+            None => mdbook004::MDBOOK004::default(),
+        };
+        registry.register(Box::new(mdbook004));
 
         // MDBOOK005 - orphaned files (supports ignore_patterns/exclude_readme/check_nested)
         let mdbook005 = match config.and_then(|c| c.rule_configs.get("MDBOOK005")) {
@@ -118,5 +138,92 @@ impl RuleProvider for MdBookRuleProvider {
             "MDBOOK023",
             "MDBOOK025",
         ]
+    }
+}
+
+#[cfg(test)]
+mod provider_tests {
+    use super::MdBookRuleProvider;
+    use mdbook_lint_core::{Config, Document, PluginRegistry};
+    use std::path::PathBuf;
+
+    /// Lint `doc` through the mdBook provider with `toml` as the config, counting
+    /// the violations reported by `rule_id`.
+    fn violations_for(doc: &Document, toml: &str, rule_id: &str) -> usize {
+        let config: Config = toml::from_str(toml).unwrap();
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(MdBookRuleProvider))
+            .unwrap();
+        let engine = registry.create_engine_with_config(Some(&config)).unwrap();
+        engine
+            .lint_document_with_config(doc, &config)
+            .unwrap()
+            .into_iter()
+            .filter(|v| v.rule_id == rule_id)
+            .count()
+    }
+
+    #[test]
+    fn test_mdbook002_config_threads_through_provider() {
+        let content = "# Doc\n\n![Missing](./missing.png)\n";
+        let doc = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+
+        assert_eq!(
+            violations_for(&doc, "enabled-rules = [\"MDBOOK002\"]", "MDBOOK002"),
+            0,
+            "image paths should not be checked by default"
+        );
+        assert_eq!(
+            violations_for(
+                &doc,
+                "enabled-rules = [\"MDBOOK002\"]\n[MDBOOK002]\ncheck_images = true",
+                "MDBOOK002"
+            ),
+            1,
+            "check_images must thread through the provider"
+        );
+    }
+
+    #[test]
+    fn test_mdbook003_config_threads_through_provider() {
+        let content = "# Summary\n\n- [One](one.md)\n    - [Two](two.md)\n";
+        let doc = Document::new(content.to_string(), PathBuf::from("SUMMARY.md")).unwrap();
+
+        assert_eq!(
+            violations_for(&doc, "enabled-rules = [\"MDBOOK003\"]", "MDBOOK003"),
+            0,
+            "nesting depth should be unlimited by default"
+        );
+        assert_eq!(
+            violations_for(
+                &doc,
+                "enabled-rules = [\"MDBOOK003\"]\n[MDBOOK003]\nmax_depth = 1",
+                "MDBOOK003"
+            ),
+            1,
+            "max_depth must thread through the provider"
+        );
+    }
+
+    #[test]
+    fn test_mdbook004_config_threads_through_provider() {
+        let content = "# Introduction\n\n# introduction\n";
+        let doc = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+
+        assert_eq!(
+            violations_for(&doc, "enabled-rules = [\"MDBOOK004\"]", "MDBOOK004"),
+            0,
+            "title comparison should be case-sensitive by default"
+        );
+        assert_eq!(
+            violations_for(
+                &doc,
+                "enabled-rules = [\"MDBOOK004\"]\n[MDBOOK004]\ncase_sensitive = false",
+                "MDBOOK004"
+            ),
+            1,
+            "case_sensitive must thread through the provider"
+        );
     }
 }

--- a/docs/src/rules/mdbook/mdbook002.md
+++ b/docs/src/rules/mdbook/mdbook002.md
@@ -60,10 +60,18 @@ Visit [Rust website](https://www.rust-lang.org)
 
 ```toml
 [MDBOOK002]
-check_anchors = true     # Validate heading anchors (default: true)
+check_anchors = false    # Validate same-document anchors (default: false)
 allow_external = true    # Skip external URLs (default: true)
 check_images = false     # Also validate image paths (default: false)
 ```
+
+- `check_anchors`: when enabled, same-document anchor links (`[text](#section)`) are
+  checked against the headings in the file. Anchors that point at another file
+  (`other.md#section`) are validated by [MDBOOK006](./mdbook006.md), not here.
+- `allow_external`: external URLs (`http`, `https`, `mailto`, `ftp`, `tel`) are skipped.
+  Set it to `false` to report them instead, for books that must not link off-site.
+- `check_images`: when enabled, image paths (`![alt](path)`) are resolved the same way
+  link paths are.
 
 ## Common Issues and Solutions
 

--- a/docs/src/rules/mdbook/mdbook003.md
+++ b/docs/src/rules/mdbook/mdbook003.md
@@ -105,8 +105,15 @@ Proper SUMMARY.md structure is essential because:
 [MDBOOK003]
 allow_draft_chapters = true    # Allow chapters without links (default: true)
 require_part_headers = false   # Require part headers (default: false)
-max_depth = 3                   # Maximum nesting depth (default: 3)
+max_depth = 3                  # Maximum nesting depth (default: unlimited)
 ```
+
+- `allow_draft_chapters`: draft entries are written `[Title]()` with an empty link.
+  Set it to `false` to require every chapter to point at a file.
+- `require_part_headers`: when enabled, a summary that lists chapters must also
+  declare at least one part header (`# Part title`).
+- `max_depth`: deepest chapter nesting allowed, counting top-level chapters as
+  depth 1. Leave it unset for unlimited nesting.
 
 ## Common Issues and Solutions
 

--- a/docs/src/rules/mdbook/mdbook004.md
+++ b/docs/src/rules/mdbook/mdbook004.md
@@ -32,7 +32,16 @@ title.
 
 ## Configuration
 
-This rule has no configuration options.
+```toml
+[MDBOOK004]
+case_sensitive = true                  # Case-sensitive comparison (default: true)
+ignore_prefixes = ["Chapter", "Part"]  # Prefixes stripped before comparing (default: none)
+```
+
+- `case_sensitive`: with the default, "Setup" and "setup" are different titles. Set it
+  to `false` to treat them as duplicates.
+- `ignore_prefixes`: the first matching prefix is stripped from a title (along with the
+  whitespace after it) before comparison, so "Chapter Setup" and "Setup" compare equal.
 
 ## When to Disable
 


### PR DESCRIPTION
Closes #416.

MDBOOK002, MDBOOK003 and MDBOOK004 were unit structs with no fields, so the six per-rule options documented for them had nowhere to be stored and did nothing. Each rule now has backing fields, a `from_config` that reads both `snake_case` and `kebab-case` keys, and an entry in `register_rules_with_config`, following the MDBOOK005/MDBOOK022 pattern from #413.

## Defaults match the previous hardcoded behavior

Per the operator note on the issue, each documented default was checked against what the rule actually did, so a config that sets only defaults is a no-op. Two of them did not match the old example config:

| Option | Old example config | Actual behavior | Default now |
| --- | --- | --- | --- |
| `MDBOOK002.check_anchors` | `true` | the rule stripped the fragment and never validated anchors | `false` |
| `MDBOOK004.case_sensitive` | `false` | comparison was case-sensitive (`test_mdbook004_case_sensitive` asserts it) | `true` |
| `MDBOOK003.max_depth` | `3` | no depth limit at all | unset (unlimited) |

The rest were already accurate: `allow_external = true`, `check_images = false`, `allow_draft_chapters = true`, `require_part_headers = false`, `ignore_prefixes` empty.

## Behavior added behind the options

- `MDBOOK002.check_anchors`: validates same-document anchors (`[text](#section)`) against the file's headings. Cross-file anchors (`file.md#section`) are left to MDBOOK006, which already covers them; this fills the same-document case both rules previously skipped.
- `MDBOOK002.allow_external`: `false` reports external URLs instead of skipping them, for books that must not link off-site. There is no network validation.
- `MDBOOK002.check_images`: resolves `![alt](path)` targets the same way link paths are resolved.
- `MDBOOK003.allow_draft_chapters`: `false` flags `[Title]()` entries.
- `MDBOOK003.require_part_headers`: `true` requires a summary that lists chapters to also declare at least one `# Part title`.
- `MDBOOK003.max_depth`: caps chapter nesting, counting top-level chapters as depth 1.
- `MDBOOK004.case_sensitive` / `ignore_prefixes`: the first matching prefix is stripped (with the whitespace after it) before comparison, then the key is case-folded when `case_sensitive` is off.

The anchor-id generation MDBOOK002 and MDBOOK006 both need moved to a shared `mdbook::anchors` module. MDBOOK006 delegates to it; its behavior is unchanged.

## Also updated

- `crates/mdbook-lint-cli/example-mdbook-lint.toml`: the real option blocks replace the `# No configuration options` placeholders #448 left for these three rules, with the corrected defaults. This file is embedded via `include_str!` and written by `mdbook-lint init`.
- `docs/src/rules/mdbook/mdbook002.md`, `mdbook003.md`, `mdbook004.md`: configuration sections corrected and expanded with per-option descriptions.

## Tests

Per-rule unit tests cover each option in both states plus kebab-case keys, and a new `mdbook::provider_tests` module lints through the provider end-to-end to prove each rule's config actually reaches it (the same shape as the CONTENT009 guard from #415). Existing tests are unchanged apart from `MDBOOK00X` becoming `MDBOOK00X::default()`.

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

## Follow-ups not in this PR

#417 (MDBOOK006/007/008/009) and #418 (MDBOOK010/011/012) are the remaining batches of the same remediation.