### PR TITLE
fix: preserve hashes in ATX heading content

### DIFF
--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -719,108 +719,6 @@ fn filter_ignored_paths(files: &mut Vec<PathBuf>, patterns: &[String]) {
     files.retain(|path| !path_is_ignored(path, patterns));
 }
 
-/// Apply fixes to file content, returning the fixed content if any fixes were applied
-fn apply_fixes_to_content(
-    content: &str,
-    violations: &[&mdbook_lint_core::violation::Violation],
-) -> Result<Option<String>> {
-    use mdbook_lint_core::violation::Position;
-
-    if violations.is_empty() {
-        return Ok(None);
-    }
-
-    // Collect all fixes from violations that have them
-    let mut fixes_with_violations: Vec<(&mdbook_lint_core::violation::Fix, &str)> = violations
-        .iter()
-        .filter_map(|v| v.fix.as_ref().map(|f| (f, v.rule_id.as_str())))
-        .collect();
-
-    if fixes_with_violations.is_empty() {
-        return Ok(None);
-    }
-
-    // Sort fixes by position (descending) to avoid offset issues when applying
-    // Sort by line first (descending), then by column (descending)
-    fixes_with_violations.sort_by(|a, b| {
-        let line_cmp = b.0.start.line.cmp(&a.0.start.line);
-        if line_cmp == std::cmp::Ordering::Equal {
-            b.0.start.column.cmp(&a.0.start.column)
-        } else {
-            line_cmp
-        }
-    });
-
-    // Convert content to a mutable string for applying fixes
-    let mut result = content.to_string();
-    let mut fixes_applied = 0;
-
-    // Helper function to convert line/column position to byte offset
-    let position_to_offset = |text: &str, pos: &Position| -> Option<usize> {
-        let mut current_line = 1;
-        let mut current_col = 1;
-
-        for (offset, ch) in text.char_indices() {
-            if current_line == pos.line && current_col == pos.column {
-                return Some(offset);
-            }
-
-            if ch == '\n' {
-                current_line += 1;
-                current_col = 1;
-            } else {
-                current_col += 1;
-            }
-        }
-
-        // Handle position at end of content
-        if current_line == pos.line && current_col == pos.column {
-            Some(text.len())
-        } else {
-            None
-        }
-    };
-
-    // Apply each fix
-    for (fix, _rule_id) in fixes_with_violations {
-        // Convert positions to byte offsets
-        let start_offset = match position_to_offset(&result, &fix.start) {
-            Some(offset) => offset,
-            None => {
-                eprintln!(
-                    "Warning: Could not find start position for fix at {}:{}",
-                    fix.start.line, fix.start.column
-                );
-                continue;
-            }
-        };
-
-        let end_offset = match position_to_offset(&result, &fix.end) {
-            Some(offset) => offset,
-            None => {
-                eprintln!(
-                    "Warning: Could not find end position for fix at {}:{}",
-                    fix.end.line, fix.end.column
-                );
-                continue;
-            }
-        };
-
-        // Apply the fix based on the operation type
-        if start_offset <= end_offset && end_offset <= result.len() {
-            let replacement = fix.replacement.as_deref().unwrap_or("");
-            result.replace_range(start_offset..end_offset, replacement);
-            fixes_applied += 1;
-        }
-    }
-
-    if fixes_applied > 0 && result != content {
-        Ok(Some(result))
-    } else {
-        Ok(None)
-    }
-}
-
 /// Check if a file is tracked by git
 fn is_git_tracked(path: &PathBuf) -> Result<bool> {
     use std::process::Command;
@@ -1134,6 +1032,7 @@ fn run_cli_mode(
             let fixable_violations: Vec<_> = violations
                 .iter()
                 .filter(|v| v.fix.is_some() && config.should_auto_fix_rule(&v.rule_id))
+                .cloned()
                 .collect();
 
             if !fixable_violations.is_empty() {
@@ -1147,15 +1046,21 @@ fn run_cli_mode(
                     ))
                 })?;
 
-                if let Some(fixed_content) =
-                    apply_fixes_to_content(&original_content, &fixable_violations)?
-                {
+                let (fixed_content, unfixed) =
+                    engine.apply_fixes(&original_content, &fixable_violations);
+                let applied_count = fixable_violations.len() - unfixed.len();
+
+                if !unfixed.is_empty() {
+                    eprintln!(
+                        "Skipped {} conflicting or invalid fix(es) in {}",
+                        unfixed.len(),
+                        file_path
+                    );
+                }
+
+                if applied_count > 0 && fixed_content != original_content {
                     if dry_run {
-                        println!(
-                            "Would fix {} issue(s) in {}",
-                            fixable_violations.len(),
-                            file_path
-                        );
+                        println!("Would fix {} issue(s) in {}", applied_count, file_path);
                         // TODO: Show diff preview
                     } else {
                         // Create backup if requested and not using git
@@ -1171,12 +1076,8 @@ fn run_cli_mode(
                             ))
                         })?;
 
-                        println!(
-                            "Fixed {} issue(s) in {}",
-                            fixable_violations.len(),
-                            file_path
-                        );
-                        fixes_applied += fixable_violations.len();
+                        println!("Fixed {} issue(s) in {}", applied_count, file_path);
+                        fixes_applied += applied_count;
                         files_modified += 1;
                     }
                 }

--- a/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
+++ b/crates/mdbook-lint-cli/tests/fix_functionality_tests.rs
@@ -57,6 +57,47 @@ fn test_fix_flag_applies_fixes() {
 }
 
 #[test]
+fn test_fix_preserves_heading_content_ending_in_hash() {
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    let original_content = "# T\n\n## S\n\n### Java\n\n### C#\n\ntext\n";
+    fs::write(&test_file, original_content).unwrap();
+
+    cli_command()
+        .arg("lint")
+        .arg("--standard-only")
+        .arg("--fix")
+        .arg("--no-backup")
+        .arg(&test_file)
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&test_file).unwrap(),
+        original_content,
+        "C# must remain heading content, not be treated as a closing hash sequence"
+    );
+}
+
+#[test]
+fn test_fix_deduplicates_closed_heading_spacing_edits() {
+    let temp_dir = TempDir::new().unwrap();
+    let test_file = temp_dir.path().join("test.md");
+    fs::write(&test_file, "#Title#\n").unwrap();
+
+    cli_command()
+        .arg("lint")
+        .arg("--standard-only")
+        .arg("--fix")
+        .arg("--no-backup")
+        .arg(&test_file)
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&test_file).unwrap(), "# Title #\n");
+}
+
+#[test]
 fn test_fix_with_remaining_violations() {
     // Test fix behavior when some violations cannot be fixed
     let temp_dir = TempDir::new().unwrap();
@@ -100,11 +141,11 @@ fn test_fix_with_fail_on_warnings() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = temp_dir.path().join("test.md");
 
-    fs::write(
-        &test_file,
-        "# Test Document  \n\n\n\nThis has trailing spaces.   \n",
-    )
-    .unwrap();
+    let long_line = concat!(
+        "This deliberately long line remains after trailing spaces are fixed because MD013 does not have an automatic fix. ",
+        "It is intentionally longer than the repository's configured one-hundred-and-fifty-character limit so the warning remains."
+    );
+    fs::write(&test_file, format!("# Test Document\n\n{long_line}   \n")).unwrap();
 
     let assert = cli_command()
         .arg("lint")
@@ -484,7 +525,11 @@ fn test_fix_exit_codes() {
 
     // Test 2: Some violations remain after fix - should exit 0 (warnings don't fail by default)
     let test_file2 = temp_dir.path().join("mixed.md");
-    fs::write(&test_file2, "# Test\n\n\n\nTrailing spaces.   \n").unwrap();
+    let long_line = concat!(
+        "This deliberately long line remains after trailing spaces are fixed because MD013 does not have an automatic fix. ",
+        "It is intentionally longer than the repository's configured one-hundred-and-fifty-character limit so the warning remains."
+    );
+    fs::write(&test_file2, format!("# Test\n\n{long_line}   \n")).unwrap();
 
     let assert = cli_command()
         .arg("lint")
@@ -497,7 +542,7 @@ fn test_fix_exit_codes() {
 
     // Test 3: Remaining violations with --fail-on-warnings - should exit 1
     let test_file3 = temp_dir.path().join("mixed2.md");
-    fs::write(&test_file3, "# Test\n\n\n\nTrailing spaces.   \n").unwrap();
+    fs::write(&test_file3, format!("# Test\n\n{long_line}   \n")).unwrap();
 
     let assert = cli_command()
         .arg("lint")

--- a/crates/mdbook-lint-core/src/engine.rs
+++ b/crates/mdbook-lint-core/src/engine.rs
@@ -273,58 +273,87 @@ impl LintEngine {
         content: &str,
         violations: &[crate::Violation],
     ) -> (String, Vec<crate::Violation>) {
-        use std::cmp::Ordering;
-
         if violations.is_empty() {
             return (content.to_string(), Vec::new());
         }
 
-        // Collect violations with fixes, along with their index for tracking unfixed ones
-        let mut fixable: Vec<(usize, &crate::Violation)> = violations
-            .iter()
-            .enumerate()
-            .filter(|(_, v)| v.fix.is_some())
-            .collect();
-
-        if fixable.is_empty() {
-            return (content.to_string(), violations.to_vec());
+        struct PlannedFix<'a> {
+            violation_index: usize,
+            start: usize,
+            end: usize,
+            replacement: &'a str,
         }
 
-        // Sort by position (descending) to avoid offset issues when applying
-        fixable.sort_by(|a, b| {
-            let fix_a = a.1.fix.as_ref().unwrap();
-            let fix_b = b.1.fix.as_ref().unwrap();
-            match fix_b.start.line.cmp(&fix_a.start.line) {
-                Ordering::Equal => fix_b.start.column.cmp(&fix_a.start.column),
-                other => other,
+        // Resolve every source position against the original content. Resolving
+        // positions after earlier edits can shift or invalidate later ranges.
+        let mut planned = Vec::new();
+        for (violation_index, violation) in violations.iter().enumerate() {
+            let Some(fix) = violation.fix.as_ref() else {
+                continue;
+            };
+            let (Some(start), Some(mut end)) = (
+                position_to_offset(content, &fix.start),
+                position_to_offset(content, &fix.end),
+            ) else {
+                continue;
+            };
+
+            let replacement = fix.replacement.as_deref().unwrap_or("");
+            if replacement.ends_with('\n') && content.as_bytes().get(end) == Some(&b'\n') {
+                end += 1;
             }
-        });
+
+            if start <= end && end <= content.len() {
+                planned.push(PlannedFix {
+                    violation_index,
+                    start,
+                    end,
+                    replacement,
+                });
+            }
+        }
+
+        // Conflicting edits are unsafe to compose. Exact duplicates are safe and
+        // are applied once while marking every associated violation as fixed.
+        let mut conflicted = vec![false; planned.len()];
+        for left in 0..planned.len() {
+            for right in (left + 1)..planned.len() {
+                let a = &planned[left];
+                let b = &planned[right];
+                let duplicate =
+                    a.start == b.start && a.end == b.end && a.replacement == b.replacement;
+                let overlap = (a.start < b.end && b.start < a.end) || a.start == b.start;
+
+                if !duplicate && overlap {
+                    conflicted[left] = true;
+                    conflicted[right] = true;
+                }
+            }
+        }
+
+        let mut unique_edits: Vec<&PlannedFix<'_>> = Vec::new();
+        let mut applied_indices = std::collections::HashSet::new();
+        for (planned_index, edit) in planned.iter().enumerate() {
+            if conflicted[planned_index] {
+                continue;
+            }
+
+            applied_indices.insert(edit.violation_index);
+            if !unique_edits.iter().any(|existing| {
+                existing.start == edit.start
+                    && existing.end == edit.end
+                    && existing.replacement == edit.replacement
+            }) {
+                unique_edits.push(edit);
+            }
+        }
+
+        // Descending byte offsets keep all original ranges valid while editing.
+        unique_edits.sort_by(|a, b| b.start.cmp(&a.start).then_with(|| b.end.cmp(&a.end)));
 
         let mut result = content.to_string();
-        let mut applied_indices = std::collections::HashSet::new();
-
-        for (idx, violation) in &fixable {
-            let fix = violation.fix.as_ref().unwrap();
-
-            let start = position_to_offset(&result, &fix.start);
-            let mut end = position_to_offset(&result, &fix.end);
-
-            // Handle newline duplication (see apply_fix for details)
-            let replacement = fix.replacement.as_deref().unwrap_or("");
-            if let Some(end_offset) = end
-                && replacement.ends_with('\n')
-                && result.as_bytes().get(end_offset) == Some(&b'\n')
-            {
-                end = Some(end_offset + 1);
-            }
-
-            if let (Some(start), Some(end)) = (start, end)
-                && start <= end
-                && end <= result.len()
-            {
-                result.replace_range(start..end, replacement);
-                applied_indices.insert(*idx);
-            }
+        for edit in unique_edits {
+            result.replace_range(edit.start..edit.end, edit.replacement);
         }
 
         // Collect violations that weren't fixed
@@ -866,5 +895,70 @@ mod tests {
         let result = engine.apply_fix(content, &violation);
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "hello rust");
+    }
+
+    #[test]
+    fn test_apply_fixes_skips_conflicting_ranges() {
+        let engine = LintEngine::new();
+        let content = "### C#\ntext\n";
+        let violations = vec![
+            crate::Violation {
+                rule_id: "MD003".to_string(),
+                rule_name: "heading-style".to_string(),
+                message: "test".to_string(),
+                line: 1,
+                column: 1,
+                severity: crate::Severity::Error,
+                fix: Some(crate::violation::Fix {
+                    description: "First whole-line replacement".to_string(),
+                    replacement: Some("### C\n".to_string()),
+                    start: crate::violation::Position { line: 1, column: 1 },
+                    end: crate::violation::Position { line: 1, column: 7 },
+                }),
+            },
+            crate::Violation {
+                rule_id: "MD020".to_string(),
+                rule_name: "no-missing-space-closed-atx".to_string(),
+                message: "test".to_string(),
+                line: 1,
+                column: 1,
+                severity: crate::Severity::Warning,
+                fix: Some(crate::violation::Fix {
+                    description: "Second whole-line replacement".to_string(),
+                    replacement: Some("###C#\n".to_string()),
+                    start: crate::violation::Position { line: 1, column: 1 },
+                    end: crate::violation::Position { line: 1, column: 7 },
+                }),
+            },
+        ];
+
+        let (fixed, unfixed) = engine.apply_fixes(content, &violations);
+        assert_eq!(fixed, content);
+        assert_eq!(unfixed.len(), 2);
+    }
+
+    #[test]
+    fn test_apply_fixes_deduplicates_identical_ranges() {
+        let engine = LintEngine::new();
+        let content = "#Bad#\nnext\n";
+        let make_violation = |rule_id: &str| crate::Violation {
+            rule_id: rule_id.to_string(),
+            rule_name: "test".to_string(),
+            message: "test".to_string(),
+            line: 1,
+            column: 1,
+            severity: crate::Severity::Warning,
+            fix: Some(crate::violation::Fix {
+                description: "Normalize heading".to_string(),
+                replacement: Some("# Bad #\n".to_string()),
+                start: crate::violation::Position { line: 1, column: 1 },
+                end: crate::violation::Position { line: 1, column: 6 },
+            }),
+        };
+        let violations = vec![make_violation("TEST1"), make_violation("TEST2")];
+
+        let (fixed, unfixed) = engine.apply_fixes(content, &violations);
+        assert_eq!(fixed, "# Bad #\nnext\n");
+        assert!(unfixed.is_empty());
     }
 }

--- a/crates/mdbook-lint-rulesets/src/lib.rs
+++ b/crates/mdbook-lint-rulesets/src/lib.rs
@@ -92,7 +92,7 @@
 //! - **MD012**: Remove multiple consecutive blank lines
 //! - **MD018**: Add space after hash in ATX headings
 //! - **MD019**: Fix multiple spaces after hash
-//! - **MD020**: Remove spaces inside closed ATX headings
+//! - **MD020**: Add missing spaces inside closed ATX headings
 //! - **MD021**: Fix multiple spaces inside closed ATX headings
 //! - **MD023**: Remove indentation from headings
 //! - **MD027**: Fix multiple spaces after blockquote symbol

--- a/crates/mdbook-lint-rulesets/src/standard/atx.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/atx.rs
@@ -1,0 +1,69 @@
+//! Helpers for recognizing ATX heading delimiters.
+
+/// Return the byte range of an unescaped trailing hash sequence, ignoring
+/// spaces and tabs after it.
+pub(crate) fn trailing_hash_sequence(line: &str) -> Option<(usize, usize)> {
+    let end = line.trim_end_matches([' ', '\t']).len();
+    let before_hashes = line[..end].trim_end_matches('#');
+    let start = before_hashes.len();
+
+    if start == end {
+        return None;
+    }
+
+    // A backslash immediately before the sequence escapes its first hash, so
+    // the run cannot be a CommonMark closing sequence.
+    let backslash_count = line[..start]
+        .chars()
+        .rev()
+        .take_while(|&ch| ch == '\\')
+        .count();
+    if backslash_count % 2 == 1 {
+        return None;
+    }
+
+    Some((start, end))
+}
+
+/// Return the part of a line before a valid CommonMark closing hash sequence.
+///
+/// CommonMark requires the closing sequence to be preceded by a space or tab.
+pub(crate) fn before_closing_hash_sequence(line: &str) -> Option<&str> {
+    let (start, _) = trailing_hash_sequence(line)?;
+    let preceding = line[..start].chars().next_back()?;
+
+    if matches!(preceding, ' ' | '\t') {
+        Some(&line[..start])
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_commonmark_closing_sequences() {
+        assert_eq!(
+            before_closing_hash_sequence("### Heading ###"),
+            Some("### Heading ")
+        );
+        assert_eq!(
+            before_closing_hash_sequence("### Heading ###  "),
+            Some("### Heading ")
+        );
+        assert_eq!(
+            before_closing_hash_sequence("### Heading\t#"),
+            Some("### Heading\t")
+        );
+    }
+
+    #[test]
+    fn rejects_content_hashes_and_escaped_hashes() {
+        assert_eq!(before_closing_hash_sequence("### C#"), None);
+        assert_eq!(before_closing_hash_sequence("### F##"), None);
+        assert_eq!(before_closing_hash_sequence("### C\\#"), None);
+        assert_eq!(before_closing_hash_sequence("### Heading"), None);
+    }
+}

--- a/crates/mdbook-lint-rulesets/src/standard/md003.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md003.rs
@@ -10,6 +10,8 @@ use mdbook_lint_core::rule::{RuleCategory, RuleMetadata};
 use mdbook_lint_core::violation::{Fix, Position, Severity, Violation};
 use serde::{Deserialize, Serialize};
 
+use super::atx::before_closing_hash_sequence;
+
 /// Configuration for MD003 heading style consistency
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Md003Config {
@@ -168,10 +170,11 @@ impl MD003 {
 
         // Check if it's ATX style (starts with #)
         if trimmed.starts_with('#') {
-            // Check if it's ATX closed (ends with #)
-            if trimmed.ends_with('#') && trimmed.len() > 1 {
-                // Make sure it's not just a line of # characters
-                let content = trimmed.trim_start_matches('#').trim_end_matches('#').trim();
+            // A CommonMark closing hash sequence must be preceded by a space or
+            // tab. A content-adjacent hash, as in `### C#`, is heading text.
+            if let Some(before_closing) = before_closing_hash_sequence(trimmed) {
+                // Make sure it's not just a line of hash characters.
+                let content = before_closing.trim_start_matches('#').trim();
                 if !content.is_empty() {
                     return HeadingStyle::AtxClosed;
                 }
@@ -332,10 +335,11 @@ impl MD003 {
                 trimmed.trim_start_matches('#').trim().to_string()
             }
             HeadingStyle::AtxClosed => {
-                // Remove leading and trailing # and spaces
-                trimmed
+                // Remove only a valid closing hash sequence. Content-adjacent
+                // hashes are part of the heading text.
+                before_closing_hash_sequence(trimmed)
+                    .unwrap_or(trimmed)
                     .trim_start_matches('#')
-                    .trim_end_matches('#')
                     .trim()
                     .to_string()
             }
@@ -415,6 +419,35 @@ mod tests {
             violations.len(),
             0,
             "Consistent ATX style should not trigger violations"
+        );
+    }
+
+    #[test]
+    fn test_md003_content_hashes_are_atx_text() {
+        let content = "# Languages\n\n## C#\n\n## F##\n\n## C\\#\n";
+        let doc = create_test_document(content);
+        let rule = MD003::new();
+        let violations = rule.check(&doc).unwrap();
+
+        assert!(
+            violations.is_empty(),
+            "Content-adjacent and escaped hashes must not be classified as closing sequences"
+        );
+    }
+
+    #[test]
+    fn test_md003_fix_preserves_content_hash() {
+        let doc = create_test_document("### C#\n");
+        let config = Md003Config {
+            style: "atx_closed".to_string(),
+        };
+        let rule = MD003::with_config(config);
+        let violations = rule.check(&doc).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].fix.as_ref().unwrap().replacement,
+            Some("### C# ###\n".to_string())
         );
     }
 

--- a/crates/mdbook-lint-rulesets/src/standard/md018.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md018.rs
@@ -9,6 +9,8 @@ use mdbook_lint_core::{
     violation::{Fix, Position, Severity, Violation},
 };
 
+use super::atx::trailing_hash_sequence;
+
 /// Rule to check for missing space after hash on ATX style headings
 pub struct MD018;
 
@@ -73,7 +75,16 @@ impl Rule for MD018 {
                         // Create fixed line by adding a space after the hashes
                         let indent = &line[..line.len() - trimmed.len()];
                         let hashes = &trimmed[..hash_count];
-                        let fixed_line = format!("{}{} {}\n", indent, hashes, after_hashes.trim());
+                        let fixed_line = if let Some((closing_start, closing_end)) =
+                            trailing_hash_sequence(trimmed)
+                        {
+                            let content =
+                                trimmed[hash_count..closing_start].trim_matches([' ', '\t']);
+                            let closing_hashes = &trimmed[closing_start..closing_end];
+                            format!("{indent}{hashes} {content} {closing_hashes}\n")
+                        } else {
+                            format!("{indent}{hashes} {}\n", after_hashes.trim())
+                        };
 
                         let fix = Fix {
                             description: "Add space after hash on atx style heading".to_string(),
@@ -84,7 +95,7 @@ impl Rule for MD018 {
                             },
                             end: Position {
                                 line: line_num,
-                                column: line.len() + 1,
+                                column: line.chars().count() + 1,
                             },
                         };
 
@@ -309,7 +320,7 @@ def foo():
 
         assert_eq!(violations.len(), 1);
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "## Closed Heading##\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "## Closed Heading ##\n");
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md020.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md020.rs
@@ -1,7 +1,7 @@
-//! MD020: No space inside hashes on closed ATX heading
+//! MD020: Missing space inside hashes on a closed ATX heading
 //!
-//! This rule checks for spaces inside hash characters on closed ATX style headings.
-//! Closed ATX headings should not have spaces between the content and the closing hashes.
+//! Closed ATX headings should have a single separator between their opening and
+//! closing hash sequences and the heading content.
 
 use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
@@ -10,7 +10,9 @@ use mdbook_lint_core::{
     violation::{Fix, Position, Severity, Violation},
 };
 
-/// Rule to check for spaces inside hashes on closed ATX style headings
+use super::atx::trailing_hash_sequence;
+
+/// Rule to check for missing spaces inside closed ATX style headings.
 pub struct MD020;
 
 impl Rule for MD020 {
@@ -19,11 +21,11 @@ impl Rule for MD020 {
     }
 
     fn name(&self) -> &'static str {
-        "no-space-inside-atx"
+        "no-missing-space-closed-atx"
     }
 
     fn description(&self) -> &'static str {
-        "No space inside hashes on closed atx style heading"
+        "Missing space inside hashes on closed atx style heading"
     }
 
     fn metadata(&self) -> RuleMetadata {
@@ -42,62 +44,70 @@ impl Rule for MD020 {
         let mut violations = Vec::new();
 
         for (line_number, line) in document.lines.iter().enumerate() {
-            let line_num = line_number + 1; // Convert to 1-based line numbers
+            let line_num = line_number + 1;
 
-            // Check if this is an ATX-style heading (starts with #)
-            // Skip shebang lines (#!/...)
+            // Check if this is an ATX-style heading candidate (starts with
+            // between one and six hashes). Skip shebang lines (#!/...).
             let trimmed = line.trim_start();
-            if trimmed.starts_with('#') && !trimmed.starts_with("#!") {
-                // Check if this is a closed ATX heading (ends with #)
-                if trimmed.ends_with('#') {
-                    let opening_hash_count = trimmed.chars().take_while(|&c| c == '#').count();
-                    let closing_hash_count =
-                        trimmed.chars().rev().take_while(|&c| c == '#').count();
-
-                    // Extract the content between opening and closing hashes
-                    if trimmed.len() > opening_hash_count + closing_hash_count {
-                        let content_with_spaces =
-                            &trimmed[opening_hash_count..trimmed.len() - closing_hash_count];
-
-                        // Check for whitespace at the beginning or end of the content
-                        if content_with_spaces.starts_with(|c: char| c.is_whitespace())
-                            || content_with_spaces.ends_with(|c: char| c.is_whitespace())
-                        {
-                            // Create fixed line by removing spaces inside hashes
-                            let indent = &line[..line.len() - trimmed.len()];
-                            let opening_hashes = &trimmed[..opening_hash_count];
-                            let closing_hashes = &trimmed[trimmed.len() - closing_hash_count..];
-                            let content = content_with_spaces.trim();
-                            let fixed_line = format!(
-                                "{}{}{}{}\n",
-                                indent, opening_hashes, content, closing_hashes
-                            );
-
-                            let fix = Fix {
-                                description: "Remove spaces inside hashes on closed ATX heading"
-                                    .to_string(),
-                                replacement: Some(fixed_line),
-                                start: Position {
-                                    line: line_num,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: line_num,
-                                    column: line.len() + 1,
-                                },
-                            };
-
-                            violations.push(self.create_violation_with_fix(
-                                "Whitespace found inside hashes on closed ATX heading".to_string(),
-                                line_num,
-                                1,
-                                Severity::Warning,
-                                fix,
-                            ));
-                        }
-                    }
-                }
+            if !trimmed.starts_with('#') || trimmed.starts_with("#!") {
+                continue;
             }
+
+            let opening_hash_count = trimmed.chars().take_while(|&c| c == '#').count();
+            if !(1..=6).contains(&opening_hash_count) {
+                continue;
+            }
+
+            let Some((closing_start, closing_end)) = trailing_hash_sequence(trimmed) else {
+                continue;
+            };
+            if closing_start <= opening_hash_count {
+                continue;
+            }
+
+            let between = &trimmed[opening_hash_count..closing_start];
+            let left_missing = !matches!(between.chars().next(), Some(' ' | '\t'));
+            let right_missing = !matches!(between.chars().next_back(), Some(' ' | '\t'));
+
+            // If the opening separator is already present, a content-adjacent
+            // trailing hash is ordinary heading text (`### C#`), not evidence
+            // of a closing sequence. This intentionally avoids markdownlint's
+            // ambiguous C#/F# false positive.
+            let unambiguous_closed_candidate = !right_missing || left_missing;
+            if !(unambiguous_closed_candidate && (left_missing || right_missing)) {
+                continue;
+            }
+
+            let content = between.trim_matches([' ', '\t']);
+            if content.is_empty() {
+                continue;
+            }
+
+            let indent = &line[..line.len() - trimmed.len()];
+            let opening_hashes = &trimmed[..opening_hash_count];
+            let closing_hashes = &trimmed[closing_start..closing_end];
+            let fixed_line = format!("{indent}{opening_hashes} {content} {closing_hashes}\n");
+
+            let fix = Fix {
+                description: "Add missing spaces inside closed ATX heading".to_string(),
+                replacement: Some(fixed_line),
+                start: Position {
+                    line: line_num,
+                    column: 1,
+                },
+                end: Position {
+                    line: line_num,
+                    column: line.chars().count() + 1,
+                },
+            };
+
+            violations.push(self.create_violation_with_fix(
+                "Missing space inside hashes on closed ATX heading".to_string(),
+                line_num,
+                1,
+                Severity::Warning,
+                fix,
+            ));
         }
 
         Ok(violations)
@@ -107,403 +117,85 @@ impl Rule for MD020 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mdbook_lint_core::Document;
     use mdbook_lint_core::rule::Rule;
     use std::path::PathBuf;
 
-    #[test]
-    fn test_md020_no_violations() {
-        let content = r#"# Open ATX heading (not checked)
-
-## Another open heading
-
-#No spaces inside#
-
-##No spaces here either##
-
-###Content without spaces###
-
-####Multiple words but no spaces####
-
-#####Another valid closed heading#####
-
-######Level 6 valid######
-
-Regular paragraph text.
-
-Not a heading: # this has text before it #
-
-Shebang line should be ignored:
-#!/bin/bash
-"#;
+    fn check(content: &str) -> Vec<Violation> {
         let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 0);
+        MD020.check(&document).unwrap()
     }
 
     #[test]
-    fn test_md020_space_at_beginning() {
-        let content = r#"# Open heading is fine
-
-## Space at beginning of closed heading ##
-
-### Another violation ###
-
-Regular text.
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 2);
-        assert_eq!(violations[0].line, 3);
-        assert_eq!(violations[1].line, 5);
-        assert!(
-            violations[0]
-                .message
-                .contains("Whitespace found inside hashes")
+    fn accepts_valid_closed_headings() {
+        let violations = check(
+            "# Heading #\n## Another heading ##\n### Tab separated\t###\n#### Asymmetric #\n",
         );
-        assert!(
-            violations[1]
-                .message
-                .contains("Whitespace found inside hashes")
-        );
+        assert!(violations.is_empty());
     }
 
     #[test]
-    fn test_md020_space_at_end() {
-        let content = r#"# Open heading is fine
-
-##Content with space at end ##
-
-###Another space at end ###
-
-Regular text.
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 2);
-        assert_eq!(violations[0].line, 3);
-        assert_eq!(violations[1].line, 5);
+    fn content_adjacent_hashes_are_heading_text() {
+        let violations = check("### C#\n### F#\n### Rust##\n### C\\#\n### Heading###\n");
+        assert!(violations.is_empty());
     }
 
     #[test]
-    fn test_md020_spaces_both_sides() {
-        let content = r#"# Open heading is fine
-
-## Spaces on both sides ##
-
-### More spaces on both sides ###
-
-####  Even more spaces  ####
-
-Regular text.
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 3);
-        assert_eq!(violations[0].line, 3);
-        assert_eq!(violations[1].line, 5);
-        assert_eq!(violations[2].line, 7);
-    }
-
-    #[test]
-    fn test_md020_mixed_valid_invalid() {
-        let content = r#"#Valid closed heading#
-
-## Invalid with spaces ##
-
-###Another valid###
-
-#### Another invalid ####
-
-#####Valid again#####
-
-###### Final invalid ######
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 3);
-        assert_eq!(violations[0].line, 3);
-        assert_eq!(violations[1].line, 7);
-        assert_eq!(violations[2].line, 11);
-    }
-
-    #[test]
-    fn test_md020_asymmetric_hashes() {
-        let content = r#"# Open heading with one hash
-
-##Content##
-
-###More content####
-
-####Even more#####
-
-Regular text.
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        // Should detect closed headings regardless of hash count symmetry
-        assert_eq!(violations.len(), 0);
-    }
-
-    #[test]
-    fn test_md020_empty_closed_heading() {
-        let content = r#"# Valid open heading
-
-##Empty closed##
-
-###Another empty###
-
-####Content####
-
-Regular text.
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        // Empty closed headings should not trigger violations (no spaces to check)
-        assert_eq!(violations.len(), 0);
-    }
-
-    #[test]
-    fn test_md020_indented_headings() {
-        let content = r#"# Valid open heading
-
-    ## Indented with spaces ##
-
-Regular text.
-
-  ### Another indented ###
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        // Should detect spaces in indented closed headings
-        assert_eq!(violations.len(), 2);
-        assert_eq!(violations[0].line, 3);
-        assert_eq!(violations[1].line, 7);
-    }
-
-    #[test]
-    fn test_md020_only_closing_hash() {
-        let content = r#"# Valid open heading
-
-This is not a heading #
-
-##This is valid##
-
-Regular text ending with hash #
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        // Should only check actual headings (lines starting with #)
-        assert_eq!(violations.len(), 0);
-    }
-
-    #[test]
-    fn test_md020_all_heading_levels() {
-        let content = r#"# Content with spaces #
-## Content with spaces ##
-### Content with spaces ###
-#### Content with spaces ####
-##### Content with spaces #####
-###### Content with spaces ######
-"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 6);
-        for (i, violation) in violations.iter().enumerate() {
-            assert_eq!(violation.line, i + 1);
-            assert!(violation.message.contains("Whitespace found inside hashes"));
-        }
-    }
-
-    #[test]
-    fn test_md020_tabs_inside_hashes() {
-        let content = "#\tContent with tab\t#\n\n##\tAnother tab\t##\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        // Should detect tabs as whitespace inside hashes
-        assert_eq!(violations.len(), 2);
-    }
-
-    #[test]
-    fn test_md020_fix_space_at_beginning() {
-        let content = "## Space at beginning ##\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
+    fn reports_missing_spaces_on_both_sides() {
+        let violations = check("##Heading##\n");
         assert_eq!(violations.len(), 1);
-        assert!(violations[0].fix.is_some());
-
-        let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(
-            fix.description,
-            "Remove spaces inside hashes on closed ATX heading"
-        );
-        assert_eq!(
-            fix.replacement,
-            Some("##Space at beginning##\n".to_string())
-        );
-        assert_eq!(fix.start.line, 1);
-        assert_eq!(fix.start.column, 1);
-    }
-
-    #[test]
-    fn test_md020_fix_space_at_end() {
-        let content = "##Content with space at end ##\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].fix.is_some());
-
-        let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(
-            fix.replacement,
-            Some("##Content with space at end##\n".to_string())
-        );
-    }
-
-    #[test]
-    fn test_md020_fix_spaces_both_sides() {
-        let content = "## Spaces on both sides ##\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].fix.is_some());
-
-        let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(
-            fix.replacement,
-            Some("##Spaces on both sides##\n".to_string())
-        );
-    }
-
-    #[test]
-    fn test_md020_fix_multiple_spaces() {
-        let content = "###   Multiple spaces here   ###\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].fix.is_some());
-
-        let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(
-            fix.replacement,
-            Some("###Multiple spaces here###\n".to_string())
-        );
-    }
-
-    #[test]
-    fn test_md020_fix_tabs() {
-        let content = "#\tContent with tab\t#\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].fix.is_some());
-
-        let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement, Some("#Content with tab#\n".to_string()));
-    }
-
-    #[test]
-    fn test_md020_fix_preserves_indentation() {
-        let content = "    ## Indented with spaces ##\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 1);
-        assert!(violations[0].fix.is_some());
-
-        let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(
-            fix.replacement,
-            Some("    ##Indented with spaces##\n".to_string())
-        );
-    }
-
-    #[test]
-    fn test_md020_fix_all_levels() {
-        let content = r#"# Heading 1 #
-## Heading 2 ##
-### Heading 3 ###
-#### Heading 4 ####
-##### Heading 5 #####
-###### Heading 6 ######"#;
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
-        assert_eq!(violations.len(), 6);
-
-        // Check fixes for each level
         assert_eq!(
             violations[0].fix.as_ref().unwrap().replacement,
-            Some("#Heading 1#\n".to_string())
-        );
-        assert_eq!(
-            violations[1].fix.as_ref().unwrap().replacement,
-            Some("##Heading 2##\n".to_string())
-        );
-        assert_eq!(
-            violations[2].fix.as_ref().unwrap().replacement,
-            Some("###Heading 3###\n".to_string())
-        );
-        assert_eq!(
-            violations[3].fix.as_ref().unwrap().replacement,
-            Some("####Heading 4####\n".to_string())
-        );
-        assert_eq!(
-            violations[4].fix.as_ref().unwrap().replacement,
-            Some("#####Heading 5#####\n".to_string())
-        );
-        assert_eq!(
-            violations[5].fix.as_ref().unwrap().replacement,
-            Some("######Heading 6######\n".to_string())
+            Some("## Heading ##\n".to_string())
         );
     }
 
     #[test]
-    fn test_md020_fix_asymmetric_hashes() {
-        let content = "### Content ####\n";
-        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
-        let rule = MD020;
-        let violations = rule.check(&document).unwrap();
-
+    fn reports_missing_opening_space_when_closing_sequence_is_clear() {
+        let violations = check("###Heading ###\n");
         assert_eq!(violations.len(), 1);
-        assert!(violations[0].fix.is_some());
+        assert_eq!(
+            violations[0].fix.as_ref().unwrap().replacement,
+            Some("### Heading ###\n".to_string())
+        );
+    }
 
+    #[test]
+    fn preserves_indentation_in_fix() {
+        let violations = check("  ##Heading ##\n");
+        assert_eq!(
+            violations[0].fix.as_ref().unwrap().replacement,
+            Some("  ## Heading ##\n".to_string())
+        );
+    }
+
+    #[test]
+    fn allows_multiple_spaces_for_md021() {
+        let violations = check("#  Heading  #\n##\tHeading\t##\n");
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_candidates() {
+        let violations = check(
+            "# Open heading\nRegular text #\n#!/bin/bash\n####### Too many hashes #######\n###\n",
+        );
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn handles_trailing_whitespace() {
+        let violations = check("##Heading ##  \n");
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].fix.as_ref().unwrap().replacement,
+            Some("## Heading ##\n".to_string())
+        );
+    }
+
+    #[test]
+    fn fix_range_uses_character_columns() {
+        let violations = check("##Résumé ##\n");
         let fix = violations[0].fix.as_ref().unwrap();
-        // Should preserve the asymmetric hash count but remove spaces
-        assert_eq!(fix.replacement, Some("###Content####\n".to_string()));
+        assert_eq!(fix.end.column, "##Résumé ##".chars().count() + 1);
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md021.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md021.rs
@@ -342,7 +342,7 @@ Regular text.
         let rule = MD021;
         let violations = rule.check(&document).unwrap();
 
-        // No spaces inside is handled by MD020, not this rule
+        // Missing spaces inside are handled by MD020, not this rule
         assert_eq!(violations.len(), 0);
     }
 

--- a/crates/mdbook-lint-rulesets/src/standard/mod.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/mod.rs
@@ -3,6 +3,8 @@
 //! This module contains implementations of the standard markdown linting rules
 //! as defined by the markdownlint specification.
 
+mod atx;
+
 // Standard markdownlint rules (MD001-MD059)
 pub mod md001;
 pub mod md002;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -24,7 +24,7 @@
     - [MD003 - Heading Style](./rules/standard/md003.md)
     - [MD018 - No Space After Hash](./rules/standard/md018.md)
     - [MD019 - Multiple Spaces After Hash](./rules/standard/md019.md)
-    - [MD020 - No Space in Closed Headings](./rules/standard/md020.md)
+    - [MD020 - Missing Space in Closed Headings](./rules/standard/md020.md)
     - [MD021 - Multiple Spaces in Closed Headings](./rules/standard/md021.md)
     - [MD022 - Blanks Around Headings](./rules/standard/md022.md)
     - [MD023 - Headings Start at Beginning](./rules/standard/md023.md)

--- a/docs/src/api-documentation.md
+++ b/docs/src/api-documentation.md
@@ -121,7 +121,7 @@ Many rules support automatic fixing to correct violations:
 - **MD012**: Remove excessive consecutive blank lines
 - **MD018**: Add space after hash in headings
 - **MD019**: Remove multiple spaces after hash in headings
-- **MD020**: Remove spaces inside hash-surrounded headings  
+- **MD020**: Add missing spaces inside closed ATX headings
 - **MD021**: Remove multiple spaces inside hash-surrounded headings
 - **MD023**: Remove indentation from headings
 - **MD027**: Remove spaces after blockquote markers
@@ -216,7 +216,7 @@ Ensures code blocks have language tags for proper syntax highlighting in mdBook.
 | MD012 | Multiple blank lines | ✓ |
 | MD018 | No space after hash | ✓ |
 | MD019 | Multiple spaces after hash | ✓ |
-| MD020 | No space in closed headings | ✓ |
+| MD020 | Missing space in closed headings | ✓ |
 | MD021 | Multiple spaces in closed headings | ✓ |
 | MD023 | Headings start at beginning | ✓ |
 | MD027 | Multiple spaces after blockquote | ✓ |

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -54,7 +54,7 @@ The following rules can automatically fix violations:
 - **MD012** - Remove multiple consecutive blank lines
 - **MD018** - Add space after hash in ATX headings
 - **MD019** - Fix multiple spaces after hash
-- **MD020** - Remove spaces inside closed ATX headings
+- **MD020** - Add missing spaces inside closed ATX headings
 - **MD021** - Fix multiple spaces inside closed ATX headings
 - **MD023** - Remove indentation from headings
 - **MD027** - Fix multiple spaces after blockquote symbol

--- a/docs/src/rules/standard/headings.md
+++ b/docs/src/rules/standard/headings.md
@@ -11,7 +11,7 @@ Heading rules ensure proper document structure, hierarchy, and formatting for ma
 | [MD003](./md003.md) | Heading style (ATX vs Setext) | ❌ |
 | [MD018](./md018.md) | No space after hash on ATX style heading | ✅ |
 | [MD019](./md019.md) | Multiple spaces after hash on ATX style heading | ✅ |
-| [MD020](./md020.md) | No space inside hashes on closed ATX style heading | ✅ |
+| [MD020](./md020.md) | Missing space inside hashes on closed ATX style heading | ✅ |
 | [MD021](./md021.md) | Multiple spaces inside hashes on closed ATX style heading | ✅ |
 | [MD022](./md022.md) | Headings should be surrounded by blank lines | ❌ |
 | [MD023](./md023.md) | Headings must start at the beginning of the line | ✅ |

--- a/docs/src/rules/standard/index.md
+++ b/docs/src/rules/standard/index.md
@@ -51,7 +51,7 @@ Rules for bold, italic, and other emphasis formatting.
 | MD017 | blanks-around-headings | Blank lines around headings | ❌ |
 | MD018 | no-missing-space-atx | No space after hash on atx style heading | ✅ |
 | MD019 | no-multiple-space-atx | Multiple spaces after hash on atx style heading | ✅ |
-| MD020 | no-missing-space-closed-atx | No space inside hashes on closed atx style heading | ✅ |
+| MD020 | no-missing-space-closed-atx | Missing space inside hashes on closed ATX style heading | ✅ |
 | MD021 | no-multiple-space-closed-atx | Multiple spaces inside hashes on closed atx style heading | ✅ |
 | MD022 | blanks-around-headings | Headings should be surrounded by blank lines | ❌ |
 | MD023 | heading-start-left | Headings must start at the beginning of the line | ✅ |

--- a/docs/src/rules/standard/md018.md
+++ b/docs/src/rules/standard/md018.md
@@ -86,7 +86,7 @@ disabled_rules = ["MD018"]
 ## Related Rules
 
 - [MD019](./md019.html) - Multiple spaces after hash on ATX heading
-- [MD020](./md020.html) - No space inside hashes on closed ATX heading
+- [MD020](./md020.html) - Missing space inside hashes on closed ATX heading
 - [MD021](./md021.html) - Multiple spaces inside hashes on closed ATX heading
 - [MD022](./md022.html) - Headings should be surrounded by blank lines
 - [MD023](./md023.html) - Headings must start at the beginning of the line

--- a/docs/src/rules/standard/md019.md
+++ b/docs/src/rules/standard/md019.md
@@ -86,7 +86,7 @@ disabled_rules = ["MD019"]
 ## Related Rules
 
 - [MD018](./md018.html) - No space after hash on ATX heading
-- [MD020](./md020.html) - No space inside hashes on closed ATX heading
+- [MD020](./md020.html) - Missing space inside hashes on closed ATX heading
 - [MD021](./md021.html) - Multiple spaces inside hashes on closed ATX heading
 - [MD022](./md022.html) - Headings should be surrounded by blank lines
 - [MD023](./md023.html) - Headings must start at the beginning of the line

--- a/docs/src/rules/standard/md020.md
+++ b/docs/src/rules/standard/md020.md
@@ -1,4 +1,4 @@
-# MD020 - No Space Inside Hashes on Closed ATX Style Heading
+# MD020 - Missing Space Inside Hashes on Closed ATX Style Headings
 
 **Severity**: Warning  
 **Category**: Headings  
@@ -6,43 +6,36 @@
 
 ## Rule Description
 
-This rule ensures closed ATX-style headings have no spaces inside the closing hashes. Closed ATX headings use trailing hash characters for symmetry, and spaces inside these markers are incorrect.
+This rule checks heading-like closed ATX syntax for missing separators between
+the heading text and its opening or closing hash sequence. A closed ATX heading
+uses spaces or tabs inside both sets of hashes.
 
-## Why This Rule Exists
-
-Proper closed heading format is important because:
-
-- Follows the ATX heading specification
-- Maintains consistent heading style
-- Prevents parsing issues with some markdown processors
-- Ensures visual symmetry in closed headings
+Per CommonMark, a trailing hash sequence is a closing delimiter only when it is
+preceded by a space or tab. Content-adjacent hashes in headings such as `C#` and
+`F#` are ordinary heading text and do not trigger this rule.
 
 ## Examples
 
-### ❌ Incorrect (violates rule)
+### ❌ Incorrect
 
 ```markdown
-#Heading with space before closing#
-
-
-## Another heading ##  
-### Heading with spaces ### 
+#Heading 1#
+##Heading 2 ##
 ```
 
 ### ✅ Correct
 
 ```markdown
-#Heading with proper closing#
+# Heading 1 #
+## Heading 2 ##
 
-
-##Another heading##
-
-
-###Correctly closed heading###
-
-
-# Open heading is also fine
+# Open headings are also valid
+### C#
+### F#
 ```
+
+`### Heading#` is an open ATX heading whose text ends in `#`. MD020 does not
+guess that the final hash was intended as a closing delimiter.
 
 ## Configuration
 
@@ -50,53 +43,31 @@ This rule has no configuration options.
 
 ## Automatic Fix
 
-This rule supports automatic fixing with `--fix`. The fix will:
+The fix adds missing separators where closed-heading intent is unambiguous:
 
-- Remove spaces between heading content and closing hashes
-- Preserve the heading level and content
-- Maintain the closed heading style
+```text
+##Heading##  ->  ## Heading ##
+##Heading ## ->  ## Heading ##
+```
 
-### Apply Fix
+Content-adjacent hashes are never removed or converted into delimiters.
 
 ```bash
-# Fix closed heading spacing
+# Apply fixes
 mdbook-lint lint --fix docs/
 
-# Preview what would be fixed
+# Preview fixes
 mdbook-lint lint --fix --dry-run docs/
-```
-
-## When to Disable
-
-Consider disabling this rule if:
-
-- You prefer open ATX headings (without closing hashes)
-- Your markdown processor has different requirements for closed headings
-
-### Disable in Config
-
-```toml
-# .mdbook-lint.toml
-disabled_rules = ["MD020"]
-```
-
-### Disable Inline
-
-```markdown
-<!-- mdbook-lint-disable MD020 -->
-# Heading with space # 
-<!-- mdbook-lint-enable MD020 -->
 ```
 
 ## Related Rules
 
-- [MD018](./md018.html) - No space after hash on ATX heading
-- [MD019](./md019.html) - Multiple spaces after hash on ATX heading
-- [MD021](./md021.html) - Multiple spaces inside hashes on closed ATX heading
-- [MD022](./md022.html) - Headings should be surrounded by blank lines
 - [MD003](./md003.html) - Heading style
+- [MD018](./md018.html) - Missing space after hashes on ATX headings
+- [MD019](./md019.html) - Multiple spaces after hashes on ATX headings
+- [MD021](./md021.html) - Multiple spaces inside closed ATX headings
 
 ## References
 
-- [Original markdownlint rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md020)
-- [CommonMark Specification - ATX Headings](https://spec.commonmark.org/0.30/#atx-headings)
+- [Original markdownlint rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/md020.md)
+- [CommonMark Specification - ATX Headings](https://spec.commonmark.org/0.31.2/#atx-headings)

--- a/docs/src/rules/standard/md021.md
+++ b/docs/src/rules/standard/md021.md
@@ -98,7 +98,7 @@ disabled_rules = ["MD021"]
 
 - [MD018](./md018.html) - No space after hash on ATX heading
 - [MD019](./md019.html) - Multiple spaces after hash on ATX heading
-- [MD020](./md020.html) - No space inside hashes on closed ATX heading
+- [MD020](./md020.html) - Missing space inside hashes on closed ATX heading
 - [MD022](./md022.html) - Headings should be surrounded by blank lines
 - [MD003](./md003.html) - Heading style
 

--- a/docs/src/tool-comparison.md
+++ b/docs/src/tool-comparison.md
@@ -43,7 +43,7 @@ These standard markdown rules are caught by mdbook-lint but not markdownlint in 
 - **MD014** (1): Dollar signs in shell code
 - **MD018** (8): No space after hash in headings
 - **MD019** (10): Multiple spaces after hash
-- **MD020** (14): No space in closed headings
+- **MD020** (14): Missing space in closed headings
 - **MD021** (8): Multiple spaces in closed headings
 - **MD023** (12): Headings not at line beginning
 - **MD027** (4): Multiple spaces after blockquote


### PR DESCRIPTION
## Summary

- recognize closed ATX hash sequences using CommonMark's whitespace and escaping rules
- treat content-adjacent hashes in headings such as `C#` and `F#` as heading text
- correct MD020 to add missing separators instead of removing required spaces
- plan fixes against the original content, deduplicate identical edits, and skip conflicting overlaps
- route CLI fixing through the shared core implementation and report accurate applied counts
- update MD020 documentation and add rule, engine, and CLI regressions

## Root cause

MD003 and MD020 classified any heading line ending in `#` as closed ATX syntax. Their whole-line fixes therefore stripped or reinterpreted content hashes. The CLI then applied overlapping fixes using source positions from already-mutated text, which could silently drop content and duplicate newlines.

## User impact

`### C#`, `### F#`, and escaped content hashes are now preserved byte-for-byte by `--fix`. Ambiguous content-adjacent hashes are not treated as closing delimiters. Conflicting edits are left unapplied rather than composed unsafely.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features`
- `cargo test --test '*' --all-features`
- `cargo test --doc --all-features`
- `mdbook build docs`

Fixes #452