### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-07-31
+
+### Bug Fixes
+- *(mdbook)* Wire real config options for MDBOOK002, MDBOOK003, MDBOOK004 ([#451](https://github.com/joshrotenberg/mdbook-lint/pull/451)) ([9c4ab51](https://github.com/joshrotenberg/mdbook-lint/commit/9c4ab51116668abe042d6e8b64ad4220e14a1f05))
+- Preserve hashes in ATX heading content ([#453](https://github.com/joshrotenberg/mdbook-lint/pull/453)) ([62f08a9](https://github.com/joshrotenberg/mdbook-lint/commit/62f08a9d38f47e023791674be5fbf3d8dd2a902b))
+
+
+### Documentation
+- Replace fictional config guidance with validated examples ([#455](https://github.com/joshrotenberg/mdbook-lint/pull/455)) ([7718046](https://github.com/joshrotenberg/mdbook-lint/commit/77180460eddeabe658a7aa4cd3d687e0c74d1721))
+
+
+
 ## [0.15.0] - 2026-07-27
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -41,8 +41,8 @@ walkdir = "2.3"
 glob = "0.3"
 
 # Internal workspace crates
-mdbook-lint-core = { version = "0.15.0", path = "crates/mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.15.0", path = "crates/mdbook-lint-rulesets" }
+mdbook-lint-core = { version = "0.15.1", path = "crates/mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.15.1", path = "crates/mdbook-lint-rulesets" }
 
 # Dev dependencies
 tempfile = "3.0"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-lint-core`: 0.15.0 -> 0.15.1 (✓ API compatible changes)
* `mdbook-lint-rulesets`: 0.15.0 -> 0.15.1 (✓ API compatible changes)
* `mdbook-lint`: 0.15.0 -> 0.15.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `mdbook-lint`

<blockquote>

## [0.15.1] - 2026-07-31

### Bug Fixes
- *(mdbook)* Wire real config options for MDBOOK002, MDBOOK003, MDBOOK004 ([#451](https://github.com/joshrotenberg/mdbook-lint/pull/451)) ([9c4ab51](https://github.com/joshrotenberg/mdbook-lint/commit/9c4ab51116668abe042d6e8b64ad4220e14a1f05))
- Preserve hashes in ATX heading content ([#453](https://github.com/joshrotenberg/mdbook-lint/pull/453)) ([62f08a9](https://github.com/joshrotenberg/mdbook-lint/commit/62f08a9d38f47e023791674be5fbf3d8dd2a902b))


### Documentation
- Replace fictional config guidance with validated examples ([#455](https://github.com/joshrotenberg/mdbook-lint/pull/455)) ([7718046](https://github.com/joshrotenberg/mdbook-lint/commit/77180460eddeabe658a7aa4cd3d687e0c74d1721))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).