### PR TITLE
docs: replace fictional config guidance with validated examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ mdbook-lint.toml
 !cliff.toml
 !dist-workspace.toml
 !crates/mdbook-lint-cli/example-mdbook-lint.toml
+!examples/*.toml
 !.release-please-manifest.json
 !release-please-config.json
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ mdbook-lint init --include-all
 
 - [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all 84 rules documented
 - [docs/.mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/docs/.mdbook-lint.toml) - Real-world example used by this project's documentation
+- [Strict](examples/strict.mdbook-lint.toml) - Publication and CI gates
+- [Relaxed](examples/relaxed.mdbook-lint.toml) - Personal projects and early drafts
+- [API documentation](examples/api-docs.mdbook-lint.toml) - Generated and hand-written API references
+- [Tutorial](examples/tutorial.mdbook-lint.toml) - Step-by-step learning material
 
 ## Rules
 

--- a/crates/mdbook-lint-cli/tests/config_examples_tests.rs
+++ b/crates/mdbook-lint-cli/tests/config_examples_tests.rs
@@ -1,0 +1,49 @@
+mod common;
+
+use common::cli_command;
+use std::{fs, path::PathBuf};
+use tempfile::TempDir;
+
+const EXAMPLES: &[&str] = &[
+    "strict.mdbook-lint.toml",
+    "relaxed.mdbook-lint.toml",
+    "api-docs.mdbook-lint.toml",
+    "tutorial.mdbook-lint.toml",
+];
+
+fn example_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples")
+        .join(name)
+}
+
+#[test]
+fn example_configurations_are_valid_and_loadable() {
+    let temp_dir = TempDir::new().unwrap();
+    let markdown = temp_dir.path().join("example.md");
+    fs::write(&markdown, "# Example\n").unwrap();
+
+    for name in EXAMPLES {
+        let config = example_path(name);
+
+        cli_command()
+            .arg("check")
+            .arg(&config)
+            .assert()
+            .success()
+            .stderr("");
+
+        // Loading the configuration through lint exercises rule constructors,
+        // while the single enabled rule keeps the fixture independent of the
+        // policy choices made by each example.
+        cli_command()
+            .arg("lint")
+            .arg("--enable")
+            .arg("MD003")
+            .arg("--config")
+            .arg(&config)
+            .arg(&markdown)
+            .assert()
+            .success();
+    }
+}

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -315,6 +315,10 @@ For real-world configuration examples:
 
 - [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all rules documented and commented
 - [docs/.mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/docs/.mdbook-lint.toml) - Real-world example used by this project's own documentation
+- [Strict](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/strict.mdbook-lint.toml) - Publication and CI gates
+- [Relaxed](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/relaxed.mdbook-lint.toml) - Personal projects and early drafts
+- [API documentation](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/api-docs.mdbook-lint.toml) - Generated and hand-written API references
+- [Tutorial](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/tutorial.mdbook-lint.toml) - Step-by-step learning material
 
 ## Configuration Validation
 

--- a/docs/src/mdbook-integration.md
+++ b/docs/src/mdbook-integration.md
@@ -110,7 +110,7 @@ values overriding earlier values:
 
 1. Built-in defaults.
 2. The first configuration file discovered from the book root upward.
-3. `[preprocessor.lint]` or `[preprocessor.mdbook-lint]` in `book.toml`.
+3. `[preprocessor.lint]` in `book.toml`.
 
 The discovery order at each directory is:
 

--- a/docs/src/mdbook-integration.md
+++ b/docs/src/mdbook-integration.md
@@ -1,566 +1,259 @@
 # mdBook Integration
 
-mdbook-lint integrates seamlessly with mdBook as a preprocessor, automatically checking your markdown files during the build process. This guide provides comprehensive documentation for configuring and using mdbook-lint with mdBook projects.
+mdbook-lint can run as an mdBook preprocessor, so every chapter is checked as
+part of `mdbook build` and `mdbook serve`. The preprocessor reports diagnostics
+without changing chapter content.
 
-## Table of Contents
-
-- [Installation](#installation)
-- [Basic Setup](#basic-setup)
-- [Configuration Options](#configuration-options)
-- [Advanced Configuration](#advanced-configuration)
-- [GitHub Actions Integration](#github-actions-integration)
-- [Troubleshooting](#troubleshooting)
-- [Common Scenarios](#common-scenarios)
-
-> **Note:** If you're unsure whether to use mdbook-lint as a preprocessor or standalone in CI, see our [CI vs Preprocessor](./ci-vs-preprocessor.md) guide.
+If you are deciding between build-time checks and a separate CI lint step, see
+[CI vs Preprocessor](./ci-vs-preprocessor.md).
 
 ## Installation
 
-### Using Cargo (Recommended)
+Install mdbook-lint where mdBook can find it on `PATH`:
 
 ```bash
 cargo install mdbook-lint
 ```
 
-### Using Pre-built Binaries
+Prebuilt binaries are also available from
+[GitHub Releases](https://github.com/joshrotenberg/mdbook-lint/releases).
 
-Download the latest release from [GitHub Releases](https://github.com/joshrotenberg/mdbook-lint/releases):
+Verify the installation before configuring the book:
 
 ```bash
-# Linux/macOS
-curl -L https://github.com/joshrotenberg/mdbook-lint/releases/latest/download/mdbook-lint-$(uname -s)-$(uname -m).tar.gz | tar xz
-sudo mv mdbook-lint /usr/local/bin/
-
-# Windows (PowerShell)
-Invoke-WebRequest -Uri https://github.com/joshrotenberg/mdbook-lint/releases/latest/download/mdbook-lint-Windows-x86_64.zip -OutFile mdbook-lint.zip
-Expand-Archive mdbook-lint.zip -DestinationPath .
+mdbook-lint --version
+mdbook --version
 ```
 
-### Using GitHub Action
+## Basic setup
 
-```yaml
-- name: Install mdbook-lint
-  uses: joshrotenberg/mdbook-lint-action@v1
-```
-
-## Basic Setup
-
-### Minimal Configuration
-
-Add mdbook-lint to your `book.toml`:
+Add the preprocessor to `book.toml`:
 
 ```toml
 [preprocessor.lint]
 ```
 
-This enables mdbook-lint with default settings. It will:
+mdBook derives the `mdbook-lint` command from the `lint` preprocessor name. You
+can make the command explicit if needed:
 
-- Run all standard markdown rules (MD001-MD059)
-- Run all mdBook-specific rules (MDBOOK001-MDBOOK025)
-- Report violations as warnings (won't fail the build)
+```toml
+[preprocessor.lint]
+command = "mdbook-lint"
+```
 
-### Running mdBook with Linting
+The preprocessor now runs during normal mdBook commands:
 
 ```bash
-# Build with linting
 mdbook build
-
-# Serve with live reload and linting
 mdbook serve
-
-# Test to verify everything works
 mdbook test
 ```
 
-## Configuration Options
+By default, warnings are reported without failing the build. Errors fail the
+build.
 
-### Complete Configuration Example
+## Configuration
 
-```toml
-[preprocessor.lint]
-# Control build behavior
-fail-on-warnings = false  # Set to true to fail builds on any violation
+There are two supported configuration sources for preprocessor mode:
 
-# Rule configuration
-disabled-rules = ["MD013", "MD033", "MD041"]  # Disable specific rules
-enabled-rules = []  # If set, ONLY these rules will run
+1. A discovered mdbook-lint configuration file, preferably
+   `.mdbook-lint.toml`.
+2. Supported keys in `[preprocessor.lint]` in `book.toml`.
 
-# Rule categories (groups of rules)
-disabled-categories = ["whitespace", "html"]  # Disable entire categories
-enabled-categories = []  # If set, ONLY these categories will run
-
-# File filtering
-include = ["src/**/*.md"]  # Only lint these files (glob patterns)
-exclude = ["src/drafts/**", "src/archive/**"]  # Exclude these files
-
-# Output configuration
-output = "concise"  # Options: "concise", "detailed", "json"
-
-# Rule-specific configuration
-[preprocessor.lint.rules]
-# Configure individual rules
-MD013 = { line_length = 100 }
-MD024 = { siblings_only = true }
-MD026 = { punctuation = ".,;:!" }
-```
-
-### Configuration Through External File
-
-You can also use a separate `.mdbook-lint.toml` file in your project root:
+The external file is the place for rule-specific settings and the broader CLI
+configuration surface:
 
 ```toml
 # .mdbook-lint.toml
-[core]
-fail_on_warnings = true
+fail-on-warnings = false
+disabled-rules = ["MD013", "MD033"]
 
-[rules]
-# Default state for all rules
-default = true
+[MD024]
+siblings_only = true
 
-[rules.disabled]
-MD013 = true  # Line length
-MD033 = true  # Inline HTML
-MD041 = true  # First line heading
-
-[rules.config]
-MD013 = { line_length = 100 }
-MD024 = { siblings_only = true }
+[MD040]
+language_optional = false
 ```
 
-## Advanced Configuration
+See [Configuration](./configuration.md) for all global settings and
+rule-specific syntax.
 
-### Rule Categories
+### Supported `book.toml` keys
 
-Rules are organized into categories for easier management:
+The `[preprocessor.lint]` table accepts these mdbook-lint settings:
+
+| Setting | Type | Purpose |
+|---------|------|---------|
+| `fail-on-warnings` | boolean | Fail the mdBook build when warnings are found |
+| `fail-on-errors` | boolean | Fail the mdBook build when errors are found |
+| `enabled-rules` | array | Run only the listed rule IDs |
+| `disabled-rules` | array | Skip the listed rule IDs |
+| `enabled-categories` | array | Enable the listed rule categories |
+| `disabled-categories` | array | Disable the listed rule categories |
+
+For example:
 
 ```toml
 [preprocessor.lint]
-# Disable all whitespace-related rules
+fail-on-warnings = true
+disabled-rules = ["MD013", "MD041"]
 disabled-categories = ["whitespace"]
-
-# Or enable only specific categories
-enabled-categories = ["headings", "links", "code"]
 ```
 
-Available categories:
+Rule-specific tables and options such as `ignore-paths` belong in the external
+configuration file. They are not read from `book.toml`.
 
-- `headings` - Heading structure and formatting
-- `lists` - List formatting and consistency
-- `whitespace` - Spacing, indentation, line breaks
-- `code` - Code blocks and inline code
-- `links` - Link validation and formatting
-- `html` - HTML usage in markdown
-- `mdbook` - mdBook-specific rules
+### Configuration precedence
 
-### Custom Rule Sets
+Preprocessor configuration is resolved in this order, with later supported
+values overriding earlier values:
 
-Define different rule sets for different environments:
+1. Built-in defaults.
+2. The first configuration file discovered from the book root upward.
+3. `[preprocessor.lint]` or `[preprocessor.mdbook-lint]` in `book.toml`.
+
+The discovery order at each directory is:
+
+1. `.mdbook-lint.toml`
+2. `mdbook-lint.toml`
+3. `.mdbook-lint.yaml`
+4. `.mdbook-lint.yml`
+5. `.mdbook-lint.json`
+
+The CLI `--config` option applies to standalone commands such as
+`mdbook-lint lint`; mdBook does not pass it to the preprocessor.
+
+### Environment variables
+
+mdbook-lint does not provide environment-variable configuration overrides.
+Set build behavior in `book.toml`, use a discovered configuration file, or run
+the standalone CLI with explicit flags in CI.
+
+## Common workflows
+
+### Strict CI and informational local builds
+
+Keep the preprocessor informational for local builds:
 
 ```toml
-# Development: Lenient settings
 [preprocessor.lint]
 fail-on-warnings = false
-disabled-rules = ["MD013", "MD033", "MD041"]
-
-# For CI, use environment variables to override:
-# MDBOOK_PREPROCESSOR__MDBOOK_LINT__FAIL_ON_WARNINGS=true mdbook build
 ```
 
-### Per-File Rule Overrides
+Run a separate strict lint step in CI:
 
-Use HTML comments in your markdown files to disable rules:
-
-```markdown
-<!-- mdbook-lint-disable MD013 MD033 -->
-This content won't be checked for line length or HTML usage.
-<!-- mdbook-lint-enable MD013 MD033 -->
-
-<!-- mdbook-lint-disable-next-line MD001 -->
-### This heading can skip levels
+```bash
+mdbook-lint lint --config .mdbook-lint.toml --fail-on-warnings src/
+mdbook build
 ```
 
-## GitHub Actions Integration
+This avoids relying on an environment-variable override and gives CI direct
+control over paths and output format.
 
-### Basic Workflow
+### Progressive adoption
+
+Start with a small allow-list and expand it over time:
+
+```toml
+[preprocessor.lint]
+enabled-rules = ["MD001", "MD003", "MD009", "MD040", "MD047"]
+```
+
+Remove `enabled-rules` when the book is ready to use the default rule set.
+
+### Rule-specific configuration
+
+Keep rule behavior in `.mdbook-lint.toml`:
+
+```toml
+[MD003]
+style = "atx"
+
+[MD013]
+line_length = 100
+code_blocks = false
+
+[MD033]
+allowed_elements = ["details", "summary"]
+```
+
+Validate the file before building:
+
+```bash
+mdbook-lint check .mdbook-lint.toml
+```
+
+## GitHub workflows
+
+The most predictable CI setup runs the CLI explicitly and then builds the book:
 
 ```yaml
 name: Documentation
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
-  lint-and-build:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-      
-      - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
-      
-      - name: Install mdbook and mdbook-lint
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install documentation tools
         run: |
           cargo install mdbook
           cargo install mdbook-lint
-      
+
+      - name: Validate lint configuration
+        run: mdbook-lint check .mdbook-lint.toml
+
+      - name: Lint documentation
+        run: mdbook-lint lint --fail-on-warnings --output github src/
+
       - name: Build documentation
         run: mdbook build
-        env:
-# Override settings for CI
-
-          MDBOOK_PREPROCESSOR__MDBOOK_LINT__FAIL_ON_WARNINGS: true
-      
-      - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book
 ```
 
-### Using mdbook-lint-action
+Use `--config <FILE>` on the lint command if the configuration is not named for
+automatic discovery.
 
-```yaml
-name: Lint Documentation
+## Limitations
 
-on: [push, pull_request]
-
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Lint markdown files
-        uses: joshrotenberg/mdbook-lint-action@v1
-        with:
-          format: sarif
-          output-file: results.sarif
-          config: .mdbook-lint.toml
-      
-      - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: results.sarif
-```
-
-### Matrix Testing with Different Configurations
-
-```yaml
-name: Test Documentation
-
-on: [push, pull_request]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        lint-config:
-          - strict
-          - standard
-          - lenient
-    
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install dependencies
-        run: |
-          cargo install mdbook
-          cargo install mdbook-lint
-      
-      - name: Test with ${{ matrix.lint-config }} configuration
-        run: mdbook build
-        env:
-          MDBOOK_PREPROCESSOR__MDBOOK_LINT__CONFIG: .mdbook-lint.${{ matrix.lint-config }}.toml
-```
+- Preprocessor mode checks every chapter mdBook supplies. It does not support
+  `include` or `exclude` chapter globs.
+- Inline HTML comments cannot enable or disable rules for a portion of a file.
+- Preprocessor diagnostics do not have selectable concise, detailed, or JSON
+  formats. The standalone `lint` command supports `default`, `json`, and
+  `github` output.
+- mdbook-lint does not consume `RUST_LOG`; use `--verbose` with standalone CLI
+  commands and `mdbook build -v` for mdBook diagnostics.
 
 ## Troubleshooting
 
-### Common Issues and Solutions
-
-#### Preprocessor Not Running
-
-**Problem**: mdbook-lint doesn't seem to run during builds.
-
-**Solutions**:
-
-1. Verify installation:
-
-   ```bash
-   mdbook-lint --version
-   which mdbook-lint
-   ```
-
-2. Check `book.toml` has the preprocessor section:
-
-   ```toml
-   [preprocessor.lint]
-   ```
-
-3. Run with verbose output:
-
-   ```bash
-   mdbook build -v 2>&1 | grep mdbook-lint
-   ```
-
-4. Ensure mdbook-lint is in PATH:
-
-   ```bash
-
-   export PATH="$HOME/.cargo/bin:$PATH"
-   ```
-
-#### Configuration Not Applied
-
-**Problem**: Settings in `book.toml` aren't being used.
-
-**Configuration Precedence** (highest to lowest):
-
-1. Environment variables (e.g., `MDBOOK_PREPROCESSOR**MDBOOK_LINT**FAIL_ON_WARNINGS`)
-
-2. `book.toml` preprocessor settings
-3. `.mdbook-lint.toml` file in project root
-4. Built-in defaults
-
-**Debug Configuration**:
+If the preprocessor does not run, first check that both executables are on
+`PATH` and that `book.toml` contains `[preprocessor.lint]`:
 
 ```bash
-# Check what configuration is being used
-mdbook-lint lint --debug-config src/chapter1.md
-
-# Test with explicit config
-mdbook-lint lint --config .mdbook-lint.toml src/
+command -v mdbook
+command -v mdbook-lint
+mdbook build -v
 ```
 
-#### Build Fails Unexpectedly
-
-**Problem**: Build fails even with `fail-on-warnings = false`.
-
-**Check for**:
-
-1. Syntax errors in configuration files
-2. Invalid rule IDs in enabled/disabled lists
-3. Conflicting configuration sources
-
-**Debug Steps**:
+For configuration problems, validate the external file and compare standalone
+behavior:
 
 ```bash
-# Run linter standalone to see all issues
-mdbook-lint lint src/
-
-# Check preprocessor output
-mdbook build 2>&1 | grep -A 5 "mdbook-lint"
+mdbook-lint check .mdbook-lint.toml
+mdbook-lint --verbose lint --config .mdbook-lint.toml src/
 ```
 
-#### Performance Issues
+See the [Troubleshooting Guide](./troubleshooting.md) for more diagnostic steps.
 
-**Problem**: Builds are slow with mdbook-lint enabled.
+## Next steps
 
-**Solutions**:
-
-1. Exclude unnecessary files:
-
-   ```toml
-   [preprocessor.lint]
-   exclude = ["src/generated/**", "src/vendor/**"]
-   ```
-
-2. Disable expensive rules:
-
-   ```toml
-   disabled-rules = ["MD013", "MD053"]  # Line length checks can be slow
-   ```
-
-3. Use caching in CI:
-
-   ```yaml
-
-   - uses: actions/cache@v3
-     with:
-       path: ~/.cargo
-       key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-   ```
-
-## Common Scenarios
-
-### Scenario 1: Strict CI, Lenient Local Development
-
-**Local `book.toml`**:
-
-```toml
-[preprocessor.lint]
-fail-on-warnings = false
-disabled-rules = ["MD013"]  # Allow long lines locally
-```
-
-**CI Override**:
-
-```yaml
-- name: Build with strict linting
-  run: mdbook build
-  env:
-    MDBOOK_PREPROCESSOR__MDBOOK_LINT__FAIL_ON_WARNINGS: true
-    MDBOOK_PREPROCESSOR__MDBOOK_LINT__DISABLED_RULES: ""
-```
-
-### Scenario 2: Different Rules for Different Chapters
-
-**book.toml**:
-
-```toml
-# Strict rules for main content
-[preprocessor.lint]
-include = ["src/chapters/**"]
-fail-on-warnings = true
-
-# Separate preprocessor for examples (lenient)
-[preprocessor.mdbook-lint-examples]
-command = "mdbook-lint"
-renderer = ["html"]
-include = ["src/examples/**"]
-disabled-rules = ["MD013", "MD033", "MD041"]
-```
-
-### Scenario 3: Progressive Rule Adoption
-
-Start lenient and gradually enable more rules:
-
-```toml
-# Phase 1: Critical rules only
-[preprocessor.lint]
-enabled-rules = ["MDBOOK001", "MDBOOK002", "MDBOOK003", "MD040", "MD041"]
-
-# Phase 2: Add formatting rules
-# enabled-rules = ["MDBOOK001", "MDBOOK002", "MDBOOK003", "MD040", "MD041", "MD001", "MD003", "MD009"]
-
-# Phase 3: Full rule set
-# Comment out enabled-rules to run all rules
-```
-
-### Scenario 4: Integration with Code Quality Tools
-
-```yaml
-name: Documentation Quality
-
-on: [push, pull_request]
-
-jobs:
-  quality-checks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-# Markdown linting
-
-      - name: Lint markdown
-        uses: joshrotenberg/mdbook-lint-action@v1
-        with:
-          format: sarif
-          output-file: mdbook-lint.sarif
-      
-# Spell checking
-
-      - name: Spell check
-        uses: streetsidesoftware/cspell-action@v2
-      
-# Link checking
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@v1
-        with:
-          args: --verbose --no-progress './book/**/*.html'
-      
-# Upload all results
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: mdbook-lint.sarif
-```
-
-## Configuration Discovery
-
-mdbook-lint automatically searches for configuration files in the following order:
-
-1. Explicit `--config` flag (CLI mode only)
-2. `book.toml` preprocessor configuration
-3. Configuration file discovery (searches up the directory tree):
-
-
-- `.mdbook-lint.toml`
-
-- `mdbook-lint.toml`
-
-- `.mdbook-lint.yaml`
-
-- `.mdbook-lint.yml`
-
-- `.mdbook-lint.json`
-
-The first configuration found is used. Settings from multiple sources are not merged.
-
-## Environment Variables
-
-All preprocessor settings can be overridden using environment variables:
-
-```bash
-# Format: MDBOOK_PREPROCESSOR__MDBOOK_LINT__<SETTING>
-export MDBOOK_PREPROCESSOR__MDBOOK_LINT__FAIL_ON_WARNINGS=true
-export MDBOOK_PREPROCESSOR__MDBOOK_LINT__DISABLED_RULES="MD013,MD033"
-export MDBOOK_PREPROCESSOR__MDBOOK_LINT__OUTPUT=json
-
-mdbook build
-```
-
-## Output Formats
-
-### Concise (Default)
-
-```
-src/chapter1.md:10:1: MD041 First line in file should be a top-level heading
-src/chapter2.md:25:81: MD013 Line length exceeds 80 characters
-```
-
-### Detailed
-
-```
-File: src/chapter1.md
-  Line 10, Column 1: MD041 - First line in file should be a top-level heading
-    The first line of the file should be a top-level (h1) heading.
-    Consider adding '# Title' at the beginning of the file.
-```
-
-### JSON
-
-```json
-{
-  "files": [
-    {
-      "path": "src/chapter1.md",
-      "violations": [
-        {
-          "rule": "MD041",
-          "line": 10,
-          "column": 1,
-          "severity": "warning",
-          "message": "First line in file should be a top-level heading"
-        }
-      ]
-    }
-  ]
-}
-```
-
-## Next Steps
-
-- Review the [Rules Reference](./rules-reference.md) for all available rules
-- Learn about [Creating Custom Rules](./contributing.md#creating-custom-rules)
-- See [Configuration Reference](./configuration-reference.md) for all options
-- Check out [Example Configurations](./example-configuration.md) for real-world setups
+- [Configuration](./configuration.md)
+- [CLI Usage](./cli-usage.md)
+- [CI vs Preprocessor](./ci-vs-preprocessor.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,526 +1,323 @@
 # Troubleshooting Guide
 
-This guide helps you resolve common issues with mdbook-lint.
+This guide covers common installation, configuration, preprocessor, rule, and
+CI problems. Commands and configuration examples match the current
+mdbook-lint CLI.
 
-## Table of Contents
-
-- [Installation Issues](#installation-issues)
-- [Configuration Problems](#configuration-problems)
-- [Preprocessor Issues](#preprocessor-issues)
-- [Performance Problems](#performance-problems)
-- [Rule-Specific Issues](#rule-specific-issues)
-- [CI/CD Problems](#cicd-problems)
-- [Debugging Tips](#debugging-tips)
-
-## Installation Issues
+## Installation
 
 ### Command Not Found
 
-**Problem**: `mdbook-lint: command not found` after installation.
-
-**Solutions**:
-
-1. **Verify Cargo bin directory is in PATH**:
-
-   ```bash
-   echo $PATH | grep -q "$HOME/.cargo/bin" || echo "Not in PATH"
-   export PATH="$HOME/.cargo/bin:$PATH"
-   echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
-   ```
-
-2. **Check installation location**:
-
-   ```bash
-   find ~ -name mdbook-lint -type f 2>/dev/null
-   ```
-
-3. **Reinstall with verbose output**:
-
-   ```bash
-
-   cargo install mdbook-lint --force --verbose
-   ```
-
-### Version Conflicts
-
-**Problem**: Different versions between CLI and preprocessor.
-
-**Solution**:
+Confirm whether the executable is on `PATH`:
 
 ```bash
-# Check versions
+command -v mdbook-lint
 mdbook-lint --version
-cargo install --list | grep mdbook-lint
-
-# Update to latest
-cargo install mdbook-lint --force
 ```
 
-### Build Failures During Installation
+For a Cargo installation, the executable normally lives in
+`~/.cargo/bin`:
 
-**Problem**: Compilation errors when installing from source.
+```bash
+cargo install mdbook-lint --force
+export PATH="$HOME/.cargo/bin:$PATH"
+```
 
-**Solutions**:
+If mdBook runs in CI or a container, install mdbook-lint in that environment as
+well. Installing it on the host does not make it available inside a container.
 
-1. **Update Rust toolchain**:
+### Installation from Source Fails
 
-   ```bash
-   rustup update stable
-   rustup default stable
-   ```
+Update the stable Rust toolchain and retry with locked dependencies:
 
-2. **Clear cargo cache**:
+```bash
+rustup update stable
+cargo install mdbook-lint --locked --force
+```
 
-   ```bash
-   cargo clean
-   rm -rf ~/.cargo/registry/cache
-   ```
+Include the Rust version and the complete Cargo error when reporting a build
+failure:
 
-3. **Install with specific version**:
+```bash
+rustc --version
+cargo --version
+```
 
-   ```bash
+## Configuration
 
-   cargo install mdbook-lint --version 0.11.1
-   ```
+### Configuration Is Not Loading
 
-## Configuration Problems
+Validate the file directly:
 
-### Configuration Not Loading
+```bash
+mdbook-lint check .mdbook-lint.toml
+```
 
-**Problem**: Settings in configuration files are ignored.
+Then run linting with an explicit path and verbose status output:
 
-**Debug Steps**:
+```bash
+mdbook-lint --verbose lint --config .mdbook-lint.toml src/
+```
 
-1. **Check configuration discovery**:
+Without `--config`, mdbook-lint searches the current directory and its parents.
+At each directory it checks these names in order:
 
-   ```bash
+1. `.mdbook-lint.toml`
+2. `mdbook-lint.toml`
+3. `.mdbook-lint.yaml`
+4. `.mdbook-lint.yml`
+5. `.mdbook-lint.json`
 
-## Show which config file is being used
+The verbose command prints the selected configuration path. A similarly named
+file outside the search path is not loaded.
 
-   mdbook-lint lint --debug src/ 2>&1 | grep -i config
+### Rule Configuration Is Ignored
 
-   ```
-
-2. **Validate configuration syntax**:
-   ```bash
-# For TOML
-
-   cat .mdbook-lint.toml | python -m json.tool > /dev/null 2>&1 || echo "Invalid TOML"
-   
-# For JSON
-
-   cat .mdbook-lint.json | jq . > /dev/null || echo "Invalid JSON"
-   
-# For YAML
-
-   cat .mdbook-lint.yaml | python -c "import yaml, sys; yaml.safe_load(sys.stdin)" || echo "Invalid YAML"
-   ```
-
-3. **Test with explicit config**:
-
-   ```bash
-
-   mdbook-lint lint --config ./my-config.toml src/
-   ```
-
-## Rule Configuration Not Working
-
-**Problem**: Rule-specific settings aren't applied.
-
-**Example Working Configurations**:
+Rule-specific configuration uses a top-level table named after the rule:
 
 ```toml
-# .mdbook-lint.toml
-[rules.config]
-# Correct: Use table syntax for rule config
-MD013 = { line_length = 100, tables = false }
-MD024 = { siblings_only = true }
+[MD013]
+line_length = 100
+code_blocks = false
 
-# Wrong: Don't use this format
-# MD013.line_length = 100  # This won't work
+[MD024]
+siblings_only = true
 ```
 
-### Environment Variables Not Working
+Do not nest rule configuration under `[core]`, `[rules.config]`, or
+`[preprocessor.lint.rules]`. Those tables are not part of the configuration
+schema.
 
-**Problem**: Environment variable overrides aren't applied.
-
-**Correct Format**:
+Start from the generated reference when you are unsure which options a rule
+accepts:
 
 ```bash
-# Preprocessor settings
-export MDBOOK_PREPROCESSOR__MDBOOK_LINT__FAIL_ON_WARNINGS=true
-export MDBOOK_PREPROCESSOR__MDBOOK_LINT__DISABLED_RULES='["MD013","MD033"]'
-
-# Note: Use JSON array format for lists
-# Wrong: DISABLED_RULES="MD013,MD033"
-# Right: DISABLED_RULES='["MD013","MD033"]'
+mdbook-lint init --include-all --output reference.toml
+mdbook-lint rules --detailed
 ```
 
-## Preprocessor Issues
+### Configuration in `book.toml` Is Ignored
 
-### Preprocessor Not Running
+The mdBook preprocessor reads only these settings from `[preprocessor.lint]`:
 
-**Problem**: mdbook-lint doesn't execute during `mdbook build`.
+- `fail-on-warnings`
+- `fail-on-errors`
+- `enabled-rules`
+- `disabled-rules`
+- `enabled-categories`
+- `disabled-categories`
 
-**Comprehensive Check**:
+For rule-specific settings and other global options, create a discovered
+`.mdbook-lint.toml` file in the book root or a parent directory.
 
-```bash
-#!/bin/bash
-# Diagnostic script
-
-echo "1. Checking mdbook-lint installation..."
-which mdbook-lint || echo "ERROR: mdbook-lint not found in PATH"
-
-echo "2. Checking book.toml..."
-grep -A5 "preprocessor.lint" book.toml || echo "ERROR: Preprocessor not configured"
-
-echo "3. Testing preprocessor directly..."
-echo '{"root":"","config":{},"renderer":"html","mdbook_version":"0.4.0"}' | mdbook-lint preprocessor
-
-echo "4. Checking mdbook version..."
-mdbook --version
-
-echo "5. Testing build with verbose output..."
-mdbook build -v 2>&1 | grep -i mdbook-lint
-```
-
-### Preprocessor Crashes
-
-**Problem**: Build fails with preprocessor errors.
-
-**Debug Mode**:
-
-```bash
-# Enable debug logging
-export RUST_LOG=mdbook_lint=debug
-export RUST_BACKTRACE=1
-
-# Run build
-mdbook build 2> mdbook-lint-debug.log
-
-# Check error details
-grep ERROR mdbook-lint-debug.log
-```
-
-### Conflicts with Other Preprocessors
-
-**Problem**: mdbook-lint conflicts with other preprocessors.
-
-**Solution - Control execution order**:
+For example:
 
 ```toml
 # book.toml
 [preprocessor.lint]
-before = ["links"]  # Run before links preprocessor
-after = ["index"]   # Run after index preprocessor
-
-[preprocessor.other-processor]
-after = ["mdbook-lint"]  # Ensure mdbook-lint runs first
+fail-on-warnings = true
+disabled-rules = ["MD041"]
 ```
-
-## Performance Problems
-
-### Slow Builds
-
-**Problem**: mdbook build takes too long with linting enabled.
-
-**Optimization Strategies**:
-
-1. **Profile the slowdown**:
-
-   ```bash
-
-   time mdbook build --dest-dir book-without-lint
-   
-## With linting
-
-   time mdbook build --dest-dir book-with-lint
-
-   ```
-
-2. **Disable expensive rules**:
-   ```toml
-   [preprocessor.lint]
-# Line length and link checking are expensive
-
-   disabled-rules = ["MD013", "MD053", "MDBOOK002"]
-   ```
-
-3. **Limit scope**:
-
-   ```toml
-
-   [preprocessor.lint]
-
-## Only lint main content
-
-   include = ["src/chapters/**/*.md"]
-   exclude = ["src/appendix/**", "src/reference/**"]
-
-   ```
-
-4. **Use parallel processing** (if available):
-   ```bash
-   export RAYON_NUM_THREADS=4
-   mdbook build
-   ```
-
-## Memory Issues
-
-**Problem**: Out of memory errors on large books.
-
-**Solutions**:
-
-1. **Process files individually**:
-
-   ```bash
-
-## Instead of linting everything at once
-
-   for file in src/**/*.md; do
-     mdbook-lint lint "$file"
-   done
-
-   ```
-
-2. **Increase memory limits**:
-   ```bash
-# Linux/macOS
-
-   ulimit -v unlimited
-   
-# Or specify a limit
-
-   ulimit -v 4194304  # 4GB
-   ```
-
-## Rule-Specific Issues
-
-### False Positives
-
-**Problem**: Rules flag valid content as violations.
-
-**Solutions**:
-
-1. **Disable rules inline**:
-
-   ```markdown
-   <!-- mdbook-lint-disable MD033 -->
-   <div class="custom-element">
-     This HTML is intentional
-   </div>
-   <!-- mdbook-lint-enable MD033 -->
-   ```
-
-2. **Configure rule parameters**:
-
-   ```toml
-
-   [rules.config]
-
-## Allow specific HTML tags
-
-   MD033 = { allowed_elements = ["div", "span", "details", "summary"] }
-
-   ```
-
-3. **Report false positives**:
-   ```bash
-# Create minimal reproduction
-
-   echo "# Test\n<valid-html></valid-html>" > test.md
-   mdbook-lint lint test.md
-   
-# Report issue with output
-
-   ```
-
-## Rule Conflicts
-
-**Problem**: Different rules want opposite formatting.
-
-**Example Resolution**:
 
 ```toml
-# MD047 wants files to end with newline
-# MD012 limits consecutive blank lines
-# Resolution: Configure both appropriately
-[rules.config]
-MD047 = true  # Require final newline
-MD012 = { maximum = 1 }  # But only one
+# .mdbook-lint.toml
+[MD013]
+line_length = 100
 ```
 
-## CI/CD Problems
+### Environment Variables Have No Effect
 
-### GitHub Actions Failures
+mdbook-lint does not implement environment-variable configuration overrides.
+Names such as `MDBOOK_PREPROCESSOR__...`, `MDBOOK_LINT_CONFIG`, and `RUST_LOG`
+are not read by the application.
 
-**Problem**: CI passes locally but fails in GitHub Actions.
+Use one of the supported mechanisms instead:
 
-**Debug Workflow**:
+- a discovered configuration file;
+- supported `[preprocessor.lint]` keys in `book.toml`;
+- `--config`, `--fail-on-warnings`, `--enable`, or `--disable` with the
+  standalone CLI.
 
-```yaml
-- name: Debug environment
-  run: |
-    echo "PATH: $PATH"
-    which mdbook-lint || echo "mdbook-lint not found"
-    mdbook-lint --version || echo "Version check failed"
-    
-- name: Debug configuration
-  run: |
-    cat book.toml
-    ls -la .mdbook-lint.* 2>/dev/null || echo "No config files"
-    
-- name: Test with explicit verbosity
-  run: |
-    export RUST_LOG=debug
-    mdbook build -v
-```
+## Preprocessor Issues
 
-### Docker Container Issues
+### The Preprocessor Does Not Run
 
-**Problem**: mdbook-lint fails in Docker containers.
-
-**Working Dockerfile**:
-
-```dockerfile
-FROM rust:1.70 AS builder
-
-# Install mdbook and mdbook-lint
-RUN cargo install mdbook mdbook-lint
-
-# Runtime stage
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y \
-    libssl3 \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /usr/local/cargo/bin/mdbook* /usr/local/bin/
-
-WORKDIR /book
-CMD ["mdbook", "build"]
-```
-
-## Debugging Tips
-
-### Enable Verbose Logging
+Check the executables and the mdBook configuration:
 
 ```bash
-# Maximum verbosity
-export RUST_LOG=trace
-export RUST_BACKTRACE=full
-
-# Run with timing information
-time mdbook-lint lint src/ --verbose
-```
-
-### Create Minimal Reproduction
-
-```bash
-#!/bin/bash
-# Create minimal test case
-
-mkdir mdbook-lint-test
-cd mdbook-lint-test
-
-# Create minimal book
-cat > book.toml << EOF
-[book]
-title = "Test"
-authors = ["Test"]
-
-[preprocessor.lint]
-fail-on-warnings = true
-EOF
-
-mkdir src
-echo "# Test\n\nThis is a test." > src/SUMMARY.md
-echo "# Chapter 1" > src/chapter_1.md
-
-# Test
+command -v mdbook
+command -v mdbook-lint
+grep -n "preprocessor.lint" book.toml
 mdbook build -v
 ```
 
-### Check Binary Dependencies
+A minimal `book.toml` entry is:
 
-```bash
-# Linux
-ldd $(which mdbook-lint)
-
-# macOS
-otool -L $(which mdbook-lint)
-
-# Check for missing libraries
-mdbook-lint --version || echo $?
+```toml
+[preprocessor.lint]
 ```
 
-### Trace System Calls
+If command discovery is unusual in your environment, set it explicitly:
+
+```toml
+[preprocessor.lint]
+command = "mdbook-lint"
+```
+
+### The Build Fails Unexpectedly
+
+Warnings fail the build only when `fail-on-warnings = true`. Errors fail by
+default. Run the linter directly to see the same diagnostics without mdBook's
+output around them:
 
 ```bash
-# Linux
-strace -e open,stat mdbook-lint lint src/ 2>&1 | grep -E "\.(toml|yaml|json)"
+mdbook-lint lint src/
+```
 
-# macOS
-dtruss -t open mdbook-lint lint src/ 2>&1 | grep -E "\.(toml|yaml|json)"
+To check whether build policy is the cause, inspect `book.toml` and the
+discovered configuration file for:
+
+```toml
+fail-on-warnings = true
+fail-on-errors = true
+```
+
+Set `RUST_BACKTRACE=1` only when diagnosing a panic. It does not enable normal
+application logging.
+
+### Another Preprocessor Appears to Conflict
+
+mdbook-lint does not modify chapter content, so content-order conflicts are
+unusual. Temporarily remove other preprocessor tables from a copy of
+`book.toml`, rebuild, and add them back one at a time to identify the source.
+
+Do not rely on mdbook-lint-specific `before` or `after` keys; mdbook-lint does
+not read or enforce them.
+
+## Rule Behavior
+
+### A Rule Reports a False Positive
+
+First reproduce the result with only that rule enabled:
+
+```bash
+mdbook-lint lint --enable MD033 path/to/file.md
+```
+
+If the rule has supported options, configure its top-level table:
+
+```toml
+[MD033]
+allowed_elements = ["details", "summary"]
+```
+
+Otherwise disable it globally or for that command:
+
+```toml
+disabled-rules = ["MD033"]
+```
+
+```bash
+mdbook-lint lint --disable MD033 src/
+```
+
+Inline `mdbook-lint-disable` HTML comments are not implemented. If a rule needs
+per-file or inline suppression, open a feature request separately from the
+false-positive report.
+
+When reporting a bug, include the smallest input that reproduces it, the rule
+ID, the exact command, and `mdbook-lint --version`.
+
+### Rules Appear to Conflict
+
+Run each rule independently to identify which diagnostics and fixes overlap:
+
+```bash
+mdbook-lint lint --enable MD018 path/to/file.md
+mdbook-lint lint --enable MD020 path/to/file.md
+```
+
+Preview automatic fixes before applying them:
+
+```bash
+mdbook-lint lint --fix --dry-run path/to/file.md
+```
+
+If two automatic fixes conflict, report both rule IDs and the original input.
+
+## Performance
+
+Compare build time with and without the preprocessor enabled in a temporary
+copy of `book.toml`:
+
+```bash
+time mdbook build
+```
+
+Then narrow the rule set rather than adding unsupported chapter globs:
+
+```toml
+[preprocessor.lint]
+enabled-rules = ["MD001", "MD003", "MD009", "MD040", "MD047"]
+```
+
+Preprocessor mode checks the chapters supplied by mdBook and does not implement
+`include` or `exclude` patterns. If path-level filtering is required, run the
+standalone CLI on explicit paths and use `ignore-paths` in
+`.mdbook-lint.toml`.
+
+## CI
+
+### CI Differs from Local Results
+
+Print tool versions and validate the same configuration used locally:
+
+```bash
+mdbook --version
+mdbook-lint --version
+mdbook-lint check .mdbook-lint.toml
+mdbook-lint lint --config .mdbook-lint.toml --fail-on-warnings src/
+```
+
+Pinning versions in CI avoids changes caused by installing different releases
+on different runs.
+
+For GitHub Actions annotations, use the standalone output format:
+
+```bash
+mdbook-lint lint --output github --fail-on-warnings src/
+```
+
+Preprocessor output does not have a configurable JSON or GitHub format.
+
+## Useful Diagnostics
+
+Use the CLI's supported status and output options:
+
+```bash
+mdbook-lint --verbose lint src/
+mdbook-lint lint --output json src/
+mdbook-lint lint --color never src/
+mdbook build -v
+```
+
+List rules and inspect configuration separately:
+
+```bash
+mdbook-lint rules --detailed
+mdbook-lint check .mdbook-lint.toml
 ```
 
 ## Getting Help
 
-If these solutions don't resolve your issue:
+Search or open an issue at
+<https://github.com/joshrotenberg/mdbook-lint/issues>. Include:
 
-1. **Search existing issues**:
+- `mdbook-lint --version`;
+- `mdbook --version` when preprocessor mode is involved;
+- the relevant configuration with secrets removed;
+- the smallest input that reproduces the problem;
+- the exact command and complete diagnostic output.
 
-   ```bash
-   gh issue list --repo joshrotenberg/mdbook-lint --search "your error"
-   ```
-
-2. **Create detailed bug report**:
-
-   ```bash
-   mdbook-lint --version > bug-report.txt
-   echo "---" >> bug-report.txt
-   mdbook --version >> bug-report.txt
-   echo "---" >> bug-report.txt
-   cat book.toml >> bug-report.txt
-   echo "---" >> bug-report.txt
-   mdbook build -v 2>&1 | tail -50 >> bug-report.txt
-   ```
-
-3. **Join discussions**:
-
-
-- GitHub Issues: <https://github.com/joshrotenberg/mdbook-lint/issues>
-
-- Discussions: <https://github.com/joshrotenberg/mdbook-lint/discussions>
-
-## Common Error Messages
-
-### "Failed to parse configuration"
-
-**Cause**: Syntax error in configuration file.
-
-**Fix**: Validate configuration syntax (see [Configuration Problems](#configuration-problems)).
-
-### "Rule not found: XXXX"
-
-**Cause**: Typo in rule ID or using removed rule.
-
-**Fix**: Check available rules with `mdbook-lint rules`.
-
-### "Preprocessor failed: Input/Output error"
-
-**Cause**: mdbook-lint crashed or timed out.
-
-**Fix**: Check system resources and enable debug logging.
-
-### "No such file or directory"
-
-**Cause**: Incorrect paths in configuration.
-
-**Fix**: Use absolute paths or paths relative to book root:
-
-```toml
-[preprocessor.lint]
-include = ["src/**/*.md"]  # Relative to book root
-exclude = ["/tmp/**"]       # Absolute path
-```
+For configuration syntax, also see [Configuration](./configuration.md). For
+preprocessor setup, see [mdBook Integration](./mdbook-integration.md).

--- a/examples/api-docs.mdbook-lint.toml
+++ b/examples/api-docs.mdbook-lint.toml
@@ -1,0 +1,21 @@
+# Configuration for generated or hand-written API documentation.
+# It permits common generated-document patterns while keeping code examples
+# and terminology consistent.
+
+fail-on-warnings = true
+fail-on-errors = true
+
+disabled-rules = [
+    "MD013", # Signatures and generated links are often long.
+    "MD025", # Generated pages may contain multiple top-level sections.
+    "MD033", # Documentation generators commonly emit inline HTML.
+    "MD041", # API fragments do not always begin with an H1.
+]
+
+[MD024]
+siblings_only = true
+
+[MD044]
+names = ["API", "GitHub", "JSON", "Rust"]
+code_blocks = false
+html_elements = false

--- a/examples/relaxed.mdbook-lint.toml
+++ b/examples/relaxed.mdbook-lint.toml
@@ -1,0 +1,16 @@
+# Relaxed configuration for personal projects and early drafts.
+# Structural errors still fail, while noisy style rules are disabled and
+# warnings remain informational.
+
+fail-on-warnings = false
+fail-on-errors = true
+
+disabled-rules = [
+    "MD013", # Allow long prose while drafting.
+    "MD033", # Allow inline HTML.
+    "MD040", # Allow code fences without language tags.
+    "MD041", # Allow fragments without a leading H1.
+]
+
+[MD024]
+siblings_only = true

--- a/examples/strict.mdbook-lint.toml
+++ b/examples/strict.mdbook-lint.toml
@@ -1,0 +1,32 @@
+# Strict configuration for CI and publication gates.
+# All default rules run, warnings fail the command, and style choices are
+# explicit so contributors get deterministic results.
+
+fail-on-warnings = true
+fail-on-errors = true
+
+[MD003]
+style = "atx"
+
+[MD007]
+indent = 2
+start_indented = false
+
+[MD013]
+line_length = 100
+length_mode = "strict"
+code_blocks = true
+tables = true
+headings = true
+
+[MD024]
+siblings_only = false
+
+[MD029]
+style = "ordered"
+
+[MD046]
+style = "fenced"
+
+[MD048]
+style = "backtick"

--- a/examples/tutorial.mdbook-lint.toml
+++ b/examples/tutorial.mdbook-lint.toml
@@ -1,0 +1,18 @@
+# Configuration for tutorials and step-by-step learning material.
+# Repeated instructional headings and longer explanatory lines are allowed,
+# while list and code-block formatting stays predictable.
+
+fail-on-warnings = true
+fail-on-errors = true
+
+disabled-rules = [
+    "MD013", # Explanatory prose and commands may be long.
+    "MD024", # Repeated headings such as "Try it" are intentional.
+]
+
+[MD007]
+indent = 2
+start_indented = false
+
+[MD029]
+style = "ordered"


### PR DESCRIPTION
## Summary

- replace fictional mdBook integration and troubleshooting guidance with behavior verified against the current parser and CLI
- document the exact `book.toml` surface, configuration precedence, limitations, and supported diagnostics
- add strict, relaxed, API documentation, and tutorial configurations
- validate every example through both `mdbook-lint check` and the real lint engine
- link the examples from the README and configuration guide

## Plan

- [x] rewrite the mdBook integration and troubleshooting pages from current parser and CLI behavior
- [x] add strict, relaxed, API documentation, and tutorial configuration examples
- [x] validate every example automatically and link them from the README/docs
- [x] run the full relevant checks and review the final diff

## Review notes

The example review removed options for rules whose configuration is documented but not actually wired into rule construction. Every rule-specific table retained in the new examples is backed by a live `from_config` path.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features`
- `cargo test --test '*' --all-features`
- `cargo test --doc --all-features`
- focused lint of the rewritten documentation: no findings
- `mdbook build docs`

Fixes #420
Fixes #300