### PR TITLE
refactor(core): remove unused mdbook dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Remove the unused `mdbook` dependency from `mdbook-lint-core`, reducing the dependency graph for library embedders. ([#457](https://github.com/joshrotenberg/mdbook-lint/issues/457))
+
 ## [0.15.1] - 2026-07-31
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,6 @@ version = "0.15.1"
 dependencies = [
  "anyhow",
  "comrak",
- "mdbook",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/mdbook-lint-core/Cargo.toml
+++ b/crates/mdbook-lint-core/Cargo.toml
@@ -26,9 +26,6 @@ toml = { workspace = true }
 # Markdown parsing
 comrak = { workspace = true }
 
-# mdBook integration
-mdbook = { workspace = true }
-
 # Utilities
 walkdir = { workspace = true }
 


### PR DESCRIPTION
## What changed

- remove the unused unconditional `mdbook` dependency from `mdbook-lint-core`
- update `Cargo.lock` so the core package no longer lists `mdbook`
- document the dependency-graph reduction for library embedders

## Why

`mdbook-lint-core` does not reference the `mdbook` crate directly. Keeping it as an unconditional dependency made generic library consumers pull in mdBook and its transitive dependency graph even when they only use the core engine and standard rules.

The CLI and mdBook-specific ruleset still depend on mdBook normally, so preprocessor and mdBook-rule functionality remain available.

## Impact

A default `mdbook-lint-core` dependency no longer pulls `mdbook`, reducing compile time, dependency surface, binary impact, and license-policy friction for embedders such as Hyalo.

## Validation

- confirmed no direct `mdbook` crate imports or paths in `mdbook-lint-core`
- confirmed `cargo tree -p mdbook-lint-core --edges normal` contains no `mdbook` package
- `cargo check --all-targets --all-features`
- `cargo test --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #457
