### PR TITLE
chore: release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-08-04
+
+### Bug Fixes
+- *(preprocessor)* Honor global ignore-paths ([#478](https://github.com/joshrotenberg/mdbook-lint/pull/478)) ([80ff400](https://github.com/joshrotenberg/mdbook-lint/commit/80ff40010a00fe18341a34b127525e3523bd37a5))
+- *(rules)* Honor MD052 shortcut_syntax configuration ([#474](https://github.com/joshrotenberg/mdbook-lint/pull/474)) ([9593dea](https://github.com/joshrotenberg/mdbook-lint/commit/9593deac625b693ce157ceac11e7b8c6299e7b25))
+- *(rules)* Ignore dollar signs in inline code and literal table cells for MDBOOK010 ([#477](https://github.com/joshrotenberg/mdbook-lint/pull/477)) ([46e606a](https://github.com/joshrotenberg/mdbook-lint/commit/46e606ad73bc875224ec966ec37325c81faf2b07))
+- *(rules)* Do not infer CONTENT004 document style from an ambiguous heading ([#476](https://github.com/joshrotenberg/mdbook-lint/pull/476)) ([64c78af](https://github.com/joshrotenberg/mdbook-lint/commit/64c78afcc51b1d96c0030f5e707457af47641d78))
+- *(rules)* Scope MDBOOK005 orphan scan to the SUMMARY.md directory ([#475](https://github.com/joshrotenberg/mdbook-lint/pull/475)) ([ab17275](https://github.com/joshrotenberg/mdbook-lint/commit/ab172752eda80dd060d8ba49c60bf0755d3567a6))
+
+
+### Refactoring
+- *(core)* Remove unused mdbook dependency ([#472](https://github.com/joshrotenberg/mdbook-lint/pull/472)) ([74827a7](https://github.com/joshrotenberg/mdbook-lint/commit/74827a7ac725fd8dd1d02af56de3896b4e3cc233))
+
+
+
 ### Changed
 - Remove the unused `mdbook` dependency from `mdbook-lint-core`, reducing the dependency graph for library embedders. ([#457](https://github.com/joshrotenberg/mdbook-lint/issues/457))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -41,8 +41,8 @@ walkdir = "2.3"
 glob = "0.3"
 
 # Internal workspace crates
-mdbook-lint-core = { version = "0.15.1", path = "crates/mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.15.1", path = "crates/mdbook-lint-rulesets" }
+mdbook-lint-core = { version = "0.15.2", path = "crates/mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.15.2", path = "crates/mdbook-lint-rulesets" }
 
 # Dev dependencies
 tempfile = "3.0"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-lint-core`: 0.15.1 -> 0.15.2 (✓ API compatible changes)
* `mdbook-lint-rulesets`: 0.15.1 -> 0.15.2 (✓ API compatible changes)
* `mdbook-lint`: 0.15.1 -> 0.15.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `mdbook-lint`

<blockquote>

## [0.15.2] - 2026-08-04

### Bug Fixes
- *(preprocessor)* Honor global ignore-paths ([#478](https://github.com/joshrotenberg/mdbook-lint/pull/478)) ([80ff400](https://github.com/joshrotenberg/mdbook-lint/commit/80ff40010a00fe18341a34b127525e3523bd37a5))
- *(rules)* Honor MD052 shortcut_syntax configuration ([#474](https://github.com/joshrotenberg/mdbook-lint/pull/474)) ([9593dea](https://github.com/joshrotenberg/mdbook-lint/commit/9593deac625b693ce157ceac11e7b8c6299e7b25))
- *(rules)* Ignore dollar signs in inline code and literal table cells for MDBOOK010 ([#477](https://github.com/joshrotenberg/mdbook-lint/pull/477)) ([46e606a](https://github.com/joshrotenberg/mdbook-lint/commit/46e606ad73bc875224ec966ec37325c81faf2b07))
- *(rules)* Do not infer CONTENT004 document style from an ambiguous heading ([#476](https://github.com/joshrotenberg/mdbook-lint/pull/476)) ([64c78af](https://github.com/joshrotenberg/mdbook-lint/commit/64c78afcc51b1d96c0030f5e707457af47641d78))
- *(rules)* Scope MDBOOK005 orphan scan to the SUMMARY.md directory ([#475](https://github.com/joshrotenberg/mdbook-lint/pull/475)) ([ab17275](https://github.com/joshrotenberg/mdbook-lint/commit/ab172752eda80dd060d8ba49c60bf0755d3567a6))


### Refactoring
- *(core)* Remove unused mdbook dependency ([#472](https://github.com/joshrotenberg/mdbook-lint/pull/472)) ([74827a7](https://github.com/joshrotenberg/mdbook-lint/commit/74827a7ac725fd8dd1d02af56de3896b4e3cc233))



### Changed
- Remove the unused `mdbook` dependency from `mdbook-lint-core`, reducing the dependency graph for library embedders. ([#457](https://github.com/joshrotenberg/mdbook-lint/issues/457))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).