### PR TITLE
fix(rules): honor MD052 shortcut_syntax configuration

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -205,7 +205,8 @@
 
 # MD052 - Reference links and images should use a label that is defined
 # [MD052]
-# No configuration options
+# ignored_labels = [" ", "x"]  # Labels never reported as undefined
+# shortcut_syntax = false      # Also validate bare [label] shortcut references
 
 # MD053 - Link and image reference definitions should be needed
 # [MD053]

--- a/crates/mdbook-lint-rulesets/src/standard/md052.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md052.rs
@@ -34,7 +34,11 @@ use std::collections::HashSet;
 /// MD052 - Reference links and images should use a label that is defined
 pub struct MD052 {
     ignored_labels: Vec<String>,
-    #[allow(dead_code)]
+    /// Whether bare `[label]` shortcut references are validated.
+    ///
+    /// Defaults to `false`, matching markdownlint. Bracketed prose such as a
+    /// `- [web] ...` changelog scope is far more common than a genuine shortcut
+    /// reference, so inferring one from `[label]` alone is noisy.
     shortcut_syntax: bool,
 }
 
@@ -157,8 +161,7 @@ impl MD052 {
         rule
     }
 
-    /// Set whether to include shortcut syntax
-    #[allow(dead_code)]
+    /// Set whether bare `[label]` shortcut references are validated
     pub fn shortcut_syntax(mut self, include: bool) -> Self {
         self.shortcut_syntax = include;
         self
@@ -180,7 +183,7 @@ impl MD052 {
     fn check_reference_labels(&self, document: &Document) -> Vec<Violation> {
         let mut violations = Vec::new();
         let defined_labels = self.collect_defined_labels(document);
-        let mut parser = LinkParser::new(document.content.as_bytes());
+        let mut parser = LinkParser::new(document.content.as_bytes(), self.shortcut_syntax);
 
         while let Some(link) = parser.next_link() {
             match link {
@@ -445,10 +448,11 @@ struct LinkParser<'a> {
     in_inline_math: bool,
     in_display_math: bool,
     on_heading_line: bool,
+    shortcut_syntax: bool,
 }
 
 impl<'a> LinkParser<'a> {
-    fn new(input: &'a [u8]) -> Self {
+    fn new(input: &'a [u8], shortcut_syntax: bool) -> Self {
         // Check if first line is a heading
         let first_line_is_heading = {
             let mut pos = 0;
@@ -467,6 +471,7 @@ impl<'a> LinkParser<'a> {
             in_inline_math: false,
             in_display_math: false,
             on_heading_line: first_line_is_heading,
+            shortcut_syntax,
         }
     }
 
@@ -700,11 +705,13 @@ impl<'a> LinkParser<'a> {
                 }
             }
             _ => {
-                // Could be shortcut reference [label] but we need to check
-                // if it's actually at end of word/sentence
-                // Skip shortcut references on heading lines to avoid false positives
-                // like "### Array[i] Notation" where [i] looks like a reference
-                if self.on_heading_line {
+                // Bare [label]. Only a shortcut reference when the caller opted in;
+                // otherwise this is literal bracketed text.
+                if !self.shortcut_syntax {
+                    None
+                } else if self.on_heading_line {
+                    // Skip shortcut references on heading lines to avoid false positives
+                    // like "### Array[i] Notation" where [i] looks like a reference
                     None
                 } else if self.is_likely_reference() {
                     Some(LinkType::Reference {
@@ -760,12 +767,16 @@ impl<'a> LinkParser<'a> {
                 })
             }
             _ => {
-                // Shortcut reference ![label]
-                Some(LinkType::Image {
-                    label: _alt_text,
-                    line: start_line,
-                    column: start_col,
-                })
+                // Bare ![label]. Same opt-in as the link case.
+                if !self.shortcut_syntax {
+                    None
+                } else {
+                    Some(LinkType::Image {
+                        label: _alt_text,
+                        line: start_line,
+                        column: start_col,
+                    })
+                }
             }
         }
     }
@@ -1152,6 +1163,88 @@ mod tests {
     }
 
     #[test]
+    fn test_changelog_scopes_not_flagged_by_default() {
+        // Issue #465: conventional changelog scopes are literal bracketed text,
+        // not shortcut references. This shape produced 2,557 violations on a
+        // real adopter and caused them to disable the rule.
+        let content = r#"# Changelog
+
+- [web] Fix the UI
+- [ci] Pin the toolchain
+- [auth] Rotate the signing key
+"#;
+
+        assert_no_violations(MD052::new(), content);
+    }
+
+    #[test]
+    fn test_shortcut_syntax_enabled_flags_undefined() {
+        let content = r#"This references [missing] which is not defined.
+"#;
+
+        let violation = assert_single_violation(MD052::new().shortcut_syntax(true), content);
+        assert!(violation.message.contains("missing"));
+    }
+
+    #[test]
+    fn test_shortcut_syntax_enabled_allows_defined() {
+        let content = r#"This references [present] which is defined.
+
+[present]: https://example.com
+"#;
+
+        assert_no_violations(MD052::new().shortcut_syntax(true), content);
+    }
+
+    #[test]
+    fn test_full_reference_flagged_under_both_settings() {
+        let content = r#"See [text][missing] for details.
+"#;
+
+        for rule in [MD052::new(), MD052::new().shortcut_syntax(true)] {
+            let violation = assert_single_violation(rule, content);
+            assert!(violation.message.contains("missing"));
+        }
+    }
+
+    #[test]
+    fn test_collapsed_reference_flagged_under_both_settings() {
+        let content = r#"See [missing][] for details.
+"#;
+
+        for rule in [MD052::new(), MD052::new().shortcut_syntax(true)] {
+            let violation = assert_single_violation(rule, content);
+            assert!(violation.message.contains("missing"));
+        }
+    }
+
+    #[test]
+    fn test_shortcut_image_respects_setting() {
+        let content = r#"![missing]
+"#;
+
+        assert_no_violations(MD052::new(), content);
+
+        let violation = assert_single_violation(MD052::new().shortcut_syntax(true), content);
+        assert!(violation.message.contains("missing"));
+    }
+
+    #[test]
+    fn test_shortcut_syntax_from_config() {
+        let config: toml::Value = toml::from_str("shortcut_syntax = true").unwrap();
+        let rule = MD052::from_config(&config);
+
+        let content = r#"This references [missing] which is not defined.
+"#;
+        let violation = assert_single_violation(rule, content);
+        assert!(violation.message.contains("missing"));
+
+        // The default config leaves shortcut checking off.
+        let empty: toml::Value = toml::from_str("").unwrap();
+        assert_no_violations(MD052::from_config(&empty), content);
+    }
+
+    #[test]
     fn test_katex_inline_math_not_flagged() {
         // Issue #321: $A[i][j]$ should not be flagged as reference links
         let content = r#"The matrix element $A[i][j]$ is accessed like this."#;
@@ -1189,8 +1282,9 @@ Matrix: $M[row][col]$
 [defined]: https://example.com
 "#;
 
-        // The \$ is escaped, so [undefined] is not in a math block and should be flagged
-        let violation = assert_single_violation(MD052::new(), content);
+        // The \$ is escaped, so [undefined] is not in a math block and should be flagged.
+        // Uses a shortcut reference as the probe, so shortcut checking must be on.
+        let violation = assert_single_violation(MD052::new().shortcut_syntax(true), content);
         assert!(violation.message.contains("undefined"));
     }
 
@@ -1260,13 +1354,14 @@ Some regular text here.
 
     #[test]
     fn test_shortcut_reference_after_heading() {
-        // Shortcut references in regular text after heading should still be detected
+        // Shortcut references in regular text after a heading are still detected
+        // once shortcut checking is enabled.
         let content = r#"# Heading
 
 This references [undefined] which should be flagged.
 "#;
 
-        let violation = assert_single_violation(MD052::new(), content);
+        let violation = assert_single_violation(MD052::new().shortcut_syntax(true), content);
         assert!(violation.message.contains("undefined"));
     }
 

--- a/docs/src/rules/standard/md052.md
+++ b/docs/src/rules/standard/md052.md
@@ -40,7 +40,30 @@ Visit [our website][site].
 
 ## Configuration
 
-This rule has no configuration options.
+```toml
+[MD052]
+# Labels that are never reported as undefined.
+# Defaults cover task list checkboxes and GitHub-style admonitions.
+ignored_labels = [" ", "x", "!note", "!tip", "!important", "!warning", "!caution"]
+
+# Whether bare [label] shortcut references are validated. Default: false.
+shortcut_syntax = false
+```
+
+### `shortcut_syntax`
+
+With the default `false`, only full `[text][label]` and collapsed `[text][]`
+references are checked. Bare `[label]` text is left alone, so prose such as
+`- [web] Fix the sidebar` is not reported as a broken link.
+
+Set it to `true` to also validate shortcut references:
+
+```toml
+[MD052]
+shortcut_syntax = true
+```
+
+Under `true`, `[missing]` is reported when no `[missing]:` definition exists.
 
 ## When to Disable
 


### PR DESCRIPTION
Closes #465

## Problem

`MD052` accepts a `shortcut_syntax` option (default `false`) through `MD052::new`, the builder, and `from_config`, but the value never reaches the link parser. The field is annotated `#[allow(dead_code)]`.

`LinkParser::try_parse_link` unconditionally applies `is_likely_reference()` to bare `[label]` forms, so any bracketed prose followed by whitespace or punctuation is reported as an undefined reference label.

The practical effect is that conventional changelog scopes are treated as broken links:

```markdown
- [web] Fix the sidebar collapse
- [ci] Pin the toolchain
```

Running `0.15.0` with only MD052 enabled on `moltis-org/moltis` produces 2,557 violations, overwhelmingly of this shape. That project disables the rule outright.

The accumulated `is_likely_reference`, heading-line, array-notation, and IPA heuristics in this file all exist to suppress shortcut false positives. They narrow the blast radius without addressing the cause: shortcut inference is on when the configuration says it is off.

## Plan

1. Thread `shortcut_syntax` from `MD052` into `LinkParser::new` instead of dropping it.
2. With `shortcut_syntax = false`, return `None` for bare `[label]` and `![label]` forms. Full `[text][label]` and collapsed `[text][]` references are still validated.
3. With `shortcut_syntax = true`, preserve today's shortcut behavior, including the existing false-positive heuristics.
4. Update `test_shortcut_reference_after_heading`, which currently asserts the default flags bare `[undefined]`, to opt in explicitly.
5. Add coverage for the acceptance cases in the issue.
6. Correct `docs/src/rules/standard/md052.md`, which stated the rule has no configuration options. It has two: `ignored_labels` and `shortcut_syntax`.
7. Add `shortcut_syntax` to `example-mdbook-lint.toml`.

This aligns the default with markdownlint, whose MD052 also defaults `shortcut_syntax` to false.

## Behavior change

Documents relying on the default to flag undefined shortcut references will see those violations disappear. Setting `shortcut_syntax = true` restores them. This is the documented meaning of the option, so it is a fix rather than a new option, but it does change default output and belongs in the changelog.

## Acceptance tests

- Default MD052 does not flag `- [web] Fix the UI`.
- `shortcut_syntax = true` flags an undefined `[missing]`.
- Both settings continue to flag `[text][missing]`.
- Defined shortcut references still pass when shortcut checking is enabled.