### PR TITLE
fix(preprocessor): honor global ignore-paths

### DIFF
--- a/crates/mdbook-lint-cli/src/config.rs
+++ b/crates/mdbook-lint-cli/src/config.rs
@@ -640,6 +640,9 @@ impl Config {
         if !other.core.disabled_categories.is_empty() {
             self.core.disabled_categories = other.core.disabled_categories;
         }
+        if !other.core.ignore_paths.is_empty() {
+            self.core.ignore_paths = other.core.ignore_paths;
+        }
 
         // Merge rule-specific configs
         self.core.rule_configs.extend(other.core.rule_configs);

--- a/crates/mdbook-lint-cli/src/ignore.rs
+++ b/crates/mdbook-lint-cli/src/ignore.rs
@@ -1,0 +1,123 @@
+//! Shared matching for the global `ignore-paths` configuration.
+//!
+//! Both the CLI and the mdBook preprocessor must agree on what `ignore-paths`
+//! means. This module is the single implementation so the two cannot drift:
+//! the CLI filters the file list it collected, and the preprocessor skips
+//! chapters whose source path matches.
+
+use std::path::{Path, PathBuf};
+
+/// Return true if `path` matches any of the given ignore glob patterns.
+///
+/// Matching is intentionally forgiving so the patterns behave the way users
+/// expect from `.gitignore`-style configuration:
+/// - a trailing `/` marks a directory prefix (`target/` behaves like `target/**`),
+/// - a pattern without any `/` also matches anywhere in the tree
+///   (`*.backup.md` matches `sub/dir/file.backup.md`),
+/// - `*` does not cross path separators, but `**` does.
+///
+/// Paths are normalized (leading `./` stripped, backslashes converted to `/`)
+/// before matching so results are consistent across platforms.
+pub fn path_is_ignored(path: &Path, patterns: &[String]) -> bool {
+    use glob::{MatchOptions, Pattern};
+
+    if patterns.is_empty() {
+        return false;
+    }
+
+    let normalized = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_string();
+
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+
+    for pattern in patterns {
+        let mut pat = pattern.replace('\\', "/");
+        pat = pat.trim_start_matches("./").to_string();
+        // A trailing slash means "everything under this directory".
+        if pat.ends_with('/') {
+            pat.push_str("**");
+        }
+
+        // A bare name or relative pattern should also match deeper in the tree.
+        let mut candidates = vec![pat.clone()];
+        if !pat.starts_with("**/") {
+            candidates.push(format!("**/{pat}"));
+        }
+
+        for candidate in candidates {
+            if let Ok(compiled) = Pattern::new(&candidate)
+                && compiled.matches_with(&normalized, options)
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Remove files matching any of the configured ignore-paths patterns.
+pub fn filter_ignored_paths(files: &mut Vec<PathBuf>, patterns: &[String]) {
+    if patterns.is_empty() {
+        return;
+    }
+    files.retain(|path| !path_is_ignored(path, patterns));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_is_ignored() {
+        let p = |s: &str| PathBuf::from(s);
+
+        // Directory prefix (trailing slash)
+        let pats = vec!["vendor/".to_string()];
+        assert!(path_is_ignored(&p("vendor/skip.md"), &pats));
+        assert!(path_is_ignored(&p("./vendor/nested/skip.md"), &pats));
+        assert!(!path_is_ignored(&p("docs/keep.md"), &pats));
+
+        // Bare suffix glob matches at any depth
+        let pats = vec!["*.backup.md".to_string()];
+        assert!(path_is_ignored(&p("notes.backup.md"), &pats));
+        assert!(path_is_ignored(&p("a/b/notes.backup.md"), &pats));
+        assert!(!path_is_ignored(&p("notes.md"), &pats));
+
+        // Bare name matches anywhere
+        let pats = vec!["not-found.md".to_string()];
+        assert!(path_is_ignored(&p("not-found.md"), &pats));
+        assert!(path_is_ignored(&p("src/deep/not-found.md"), &pats));
+
+        // Explicit ** prefix
+        let pats = vec!["**/generated.md".to_string()];
+        assert!(path_is_ignored(&p("x/y/generated.md"), &pats));
+
+        // Empty patterns never match
+        assert!(!path_is_ignored(&p("anything.md"), &[]));
+    }
+
+    #[test]
+    fn test_filter_ignored_paths() {
+        let mut files = vec![
+            PathBuf::from("docs/keep.md"),
+            PathBuf::from("vendor/skip.md"),
+            PathBuf::from("drafts/wip.md"),
+            PathBuf::from("notes.backup.md"),
+        ];
+        let patterns = vec![
+            "vendor/".to_string(),
+            "drafts/".to_string(),
+            "*.backup.md".to_string(),
+        ];
+        filter_ignored_paths(&mut files, &patterns);
+        assert_eq!(files, vec![PathBuf::from("docs/keep.md")]);
+    }
+}

--- a/crates/mdbook-lint-cli/src/ignore.rs
+++ b/crates/mdbook-lint-cli/src/ignore.rs
@@ -105,6 +105,20 @@ mod tests {
     }
 
     #[test]
+    fn test_path_is_ignored_normalizes_separators() {
+        // mdBook reports chapter source_path with native separators, so a
+        // Windows path must match a pattern written with forward slashes.
+        // Normalization happens on the string, so this holds on every platform.
+        let pats = vec!["generated/".to_string()];
+        assert!(path_is_ignored(&PathBuf::from(r"generated\api.md"), &pats));
+        assert!(path_is_ignored(
+            &PathBuf::from(r"generated\deep\nested.md"),
+            &pats
+        ));
+        assert!(!path_is_ignored(&PathBuf::from(r"guide\intro.md"), &pats));
+    }
+
+    #[test]
     fn test_filter_ignored_paths() {
         let mut files = vec![
             PathBuf::from("docs/keep.md"),

--- a/crates/mdbook-lint-cli/src/lib.rs
+++ b/crates/mdbook-lint-cli/src/lib.rs
@@ -21,6 +21,7 @@
 //! ```
 
 pub mod config;
+pub mod ignore;
 pub mod preprocessor;
 pub mod rustdoc;
 

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -1,9 +1,12 @@
 mod config;
+mod ignore;
 #[cfg(feature = "lsp")]
 mod lsp_server;
 mod output;
 mod preprocessor;
 mod rustdoc;
+
+use ignore::filter_ignored_paths;
 
 use config::Config;
 
@@ -21,7 +24,7 @@ use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -653,70 +656,6 @@ fn collect_markdown_files(dir: &PathBuf, files: &mut Vec<PathBuf>) -> Result<()>
     }
 
     Ok(())
-}
-
-/// Return true if `path` matches any of the given ignore glob patterns.
-///
-/// Matching is intentionally forgiving so the patterns behave the way users
-/// expect from `.gitignore`-style configuration:
-/// - a trailing `/` marks a directory prefix (`target/` behaves like `target/**`),
-/// - a pattern without any `/` also matches anywhere in the tree
-///   (`*.backup.md` matches `sub/dir/file.backup.md`),
-/// - `*` does not cross path separators, but `**` does.
-///
-/// Paths are normalized (leading `./` stripped, backslashes converted to `/`)
-/// before matching so results are consistent across platforms.
-fn path_is_ignored(path: &Path, patterns: &[String]) -> bool {
-    use glob::{MatchOptions, Pattern};
-
-    if patterns.is_empty() {
-        return false;
-    }
-
-    let normalized = path
-        .to_string_lossy()
-        .replace('\\', "/")
-        .trim_start_matches("./")
-        .to_string();
-
-    let options = MatchOptions {
-        case_sensitive: true,
-        require_literal_separator: true,
-        require_literal_leading_dot: false,
-    };
-
-    for pattern in patterns {
-        let mut pat = pattern.replace('\\', "/");
-        pat = pat.trim_start_matches("./").to_string();
-        // A trailing slash means "everything under this directory".
-        if pat.ends_with('/') {
-            pat.push_str("**");
-        }
-
-        // A bare name or relative pattern should also match deeper in the tree.
-        let mut candidates = vec![pat.clone()];
-        if !pat.starts_with("**/") {
-            candidates.push(format!("**/{pat}"));
-        }
-
-        for candidate in candidates {
-            if let Ok(compiled) = Pattern::new(&candidate)
-                && compiled.matches_with(&normalized, options)
-            {
-                return true;
-            }
-        }
-    }
-
-    false
-}
-
-/// Remove files matching any of the configured ignore-paths patterns.
-fn filter_ignored_paths(files: &mut Vec<PathBuf>, patterns: &[String]) {
-    if patterns.is_empty() {
-        return;
-    }
-    files.retain(|path| !path_is_ignored(path, patterns));
 }
 
 /// Check if a file is tracked by git
@@ -1968,6 +1907,7 @@ fn get_all_available_rule_ids() -> Vec<String> {
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::path::Path;
 
     #[test]
     fn test_documented_rule_count_matches_readme() {
@@ -2016,52 +1956,6 @@ mod tests {
 style = \"consistent\"
 ";
         assert_eq!(documented_rule_count(config), 4);
-    }
-
-    #[test]
-    fn test_path_is_ignored() {
-        let p = |s: &str| PathBuf::from(s);
-
-        // Directory prefix (trailing slash)
-        let pats = vec!["vendor/".to_string()];
-        assert!(path_is_ignored(&p("vendor/skip.md"), &pats));
-        assert!(path_is_ignored(&p("./vendor/nested/skip.md"), &pats));
-        assert!(!path_is_ignored(&p("docs/keep.md"), &pats));
-
-        // Bare suffix glob matches at any depth
-        let pats = vec!["*.backup.md".to_string()];
-        assert!(path_is_ignored(&p("notes.backup.md"), &pats));
-        assert!(path_is_ignored(&p("a/b/notes.backup.md"), &pats));
-        assert!(!path_is_ignored(&p("notes.md"), &pats));
-
-        // Bare name matches anywhere
-        let pats = vec!["not-found.md".to_string()];
-        assert!(path_is_ignored(&p("not-found.md"), &pats));
-        assert!(path_is_ignored(&p("src/deep/not-found.md"), &pats));
-
-        // Explicit ** prefix
-        let pats = vec!["**/generated.md".to_string()];
-        assert!(path_is_ignored(&p("x/y/generated.md"), &pats));
-
-        // Empty patterns never match
-        assert!(!path_is_ignored(&p("anything.md"), &[]));
-    }
-
-    #[test]
-    fn test_filter_ignored_paths() {
-        let mut files = vec![
-            PathBuf::from("docs/keep.md"),
-            PathBuf::from("vendor/skip.md"),
-            PathBuf::from("drafts/wip.md"),
-            PathBuf::from("notes.backup.md"),
-        ];
-        let patterns = vec![
-            "vendor/".to_string(),
-            "drafts/".to_string(),
-            "*.backup.md".to_string(),
-        ];
-        filter_ignored_paths(&mut files, &patterns);
-        assert_eq!(files, vec![PathBuf::from("docs/keep.md")]);
     }
 
     #[test]

--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -2,6 +2,7 @@ use mdbook::book::{Book, BookItem, Chapter};
 use mdbook::preprocess::{Preprocessor, PreprocessorContext};
 
 use crate::Config;
+use crate::ignore::path_is_ignored;
 #[cfg(test)]
 use mdbook_lint_core::RuleCategory;
 use mdbook_lint_core::{
@@ -129,6 +130,27 @@ impl MdBookLint {
         Ok(())
     }
 
+    /// Return true if a chapter is excluded by the global `ignore-paths` config.
+    ///
+    /// Patterns are matched against the chapter's `source_path`, which mdBook
+    /// reports relative to the book source directory. Matching the relative path
+    /// keeps a pattern such as `generated/` meaningful regardless of where the
+    /// book lives on disk, and matches how the CLI applies the same patterns.
+    ///
+    /// A chapter with no `source_path` (a generated or synthetic chapter) has
+    /// nothing to match against and is never ignored.
+    pub fn chapter_is_ignored(&self, chapter: &Chapter) -> bool {
+        let patterns = &self.config.core.ignore_paths;
+        if patterns.is_empty() {
+            return false;
+        }
+
+        chapter
+            .source_path
+            .as_ref()
+            .is_some_and(|path| path_is_ignored(path, patterns))
+    }
+
     /// Process a chapter and return any violations found
     fn process_chapter(&self, chapter: &Chapter) -> mdbook_lint_core::Result<Vec<Violation>> {
         // Create document from chapter content
@@ -208,6 +230,12 @@ impl Preprocessor for MdBookLint {
         // Process each chapter
         for item in book.iter() {
             if let BookItem::Chapter(chapter) = item {
+                // Honor the same global ignore-paths the CLI applies. Ignored
+                // chapters are left untouched in the returned book.
+                if self.chapter_is_ignored(chapter) {
+                    continue;
+                }
+
                 let violations = self.process_chapter(chapter).map_err(|e| {
                     mdbook::errors::Error::msg(format!("Failed to process chapter: {e}"))
                 })?;
@@ -336,6 +364,22 @@ fn parse_mdbook_config(config: &toml::value::Table) -> mdbook_lint_core::Result<
                     .core
                     .disabled_rules
                     .push(rule_str.to_string());
+            }
+        }
+    }
+
+    // Both spellings are accepted, matching the standalone config file.
+    if let Some(ignore_paths) = config
+        .get("ignore-paths")
+        .or_else(|| config.get("ignore_paths"))
+        && let Some(paths_array) = ignore_paths.as_array()
+    {
+        for path in paths_array {
+            if let Some(path_str) = path.as_str() {
+                preprocessor_config
+                    .core
+                    .ignore_paths
+                    .push(path_str.to_string());
             }
         }
     }
@@ -910,6 +954,103 @@ count threshold that is required by the linter for content validation.
         assert!(!config.fail_on_errors);
         assert_eq!(config.core.enabled_rules, vec!["MD001", "MD013"]);
         assert_eq!(config.core.disabled_rules, vec!["MD002"]);
+    }
+
+    /// Build a chapter with the given source path.
+    fn chapter_at(source_path: &str) -> Chapter {
+        Chapter::new(
+            "Test Chapter",
+            "# Heading\n".to_string(),
+            PathBuf::from(source_path),
+            Vec::new(),
+        )
+    }
+
+    /// Build a preprocessor whose config sets `ignore-paths` to `patterns`.
+    fn preprocessor_ignoring(patterns: &[&str]) -> MdBookLint {
+        let toml = format!(
+            "ignore-paths = [{}]",
+            patterns
+                .iter()
+                .map(|p| format!("\"{p}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        MdBookLint::with_config(Config::from_toml_str(&toml).unwrap())
+    }
+
+    #[test]
+    fn test_chapter_is_ignored_matches_relative_source_path() {
+        // Issue #463: the preprocessor must honor the same ignore-paths the CLI
+        // applies, matched against the chapter source_path.
+        let pp = preprocessor_ignoring(&["generated/"]);
+
+        assert!(pp.chapter_is_ignored(&chapter_at("generated/api.md")));
+        assert!(pp.chapter_is_ignored(&chapter_at("generated/deep/nested.md")));
+        assert!(!pp.chapter_is_ignored(&chapter_at("guide/intro.md")));
+        assert!(!pp.chapter_is_ignored(&chapter_at("generated.md")));
+    }
+
+    #[test]
+    fn test_chapter_is_ignored_supports_glob_patterns() {
+        let pp = preprocessor_ignoring(&["*.backup.md", "vendor/"]);
+
+        assert!(pp.chapter_is_ignored(&chapter_at("notes.backup.md")));
+        assert!(pp.chapter_is_ignored(&chapter_at("a/b/notes.backup.md")));
+        assert!(pp.chapter_is_ignored(&chapter_at("vendor/thing.md")));
+        assert!(!pp.chapter_is_ignored(&chapter_at("notes.md")));
+    }
+
+    #[test]
+    fn test_chapter_is_ignored_accepts_both_config_spellings() {
+        for toml in [
+            "ignore-paths = [\"generated/\"]",
+            "ignore_paths = [\"generated/\"]",
+        ] {
+            let pp = MdBookLint::with_config(Config::from_toml_str(toml).unwrap());
+            assert!(
+                pp.chapter_is_ignored(&chapter_at("generated/api.md")),
+                "spelling not honored: {toml}"
+            );
+            assert!(!pp.chapter_is_ignored(&chapter_at("guide/intro.md")));
+        }
+    }
+
+    #[test]
+    fn test_chapter_is_ignored_defaults_to_linting_everything() {
+        // No ignore-paths configured: nothing is skipped.
+        let pp = MdBookLint::new();
+        assert!(!pp.chapter_is_ignored(&chapter_at("generated/api.md")));
+    }
+
+    #[test]
+    fn test_chapter_without_source_path_is_never_ignored() {
+        // A synthetic chapter has nothing to match against.
+        let pp = preprocessor_ignoring(&["generated/"]);
+        let mut chapter = chapter_at("generated/api.md");
+        chapter.source_path = None;
+        assert!(!pp.chapter_is_ignored(&chapter));
+    }
+
+    #[test]
+    fn test_ignored_chapter_is_not_linted() {
+        // A chapter that would otherwise produce violations produces none once
+        // its path is ignored.
+        let content = "# Level 1\n### Level 3 - skipped level 2\n";
+        let chapter = Chapter::new(
+            "Test Chapter",
+            content.to_string(),
+            PathBuf::from("generated/api.md"),
+            Vec::new(),
+        );
+
+        // Without ignore-paths the chapter is linted and reports violations.
+        let plain = MdBookLint::new();
+        assert!(!plain.chapter_is_ignored(&chapter));
+        assert!(!plain.process_chapter(&chapter).unwrap().is_empty());
+
+        // With ignore-paths the run loop skips it entirely.
+        assert!(preprocessor_ignoring(&["generated/"]).chapter_is_ignored(&chapter));
     }
 
     #[test]

--- a/crates/mdbook-lint-cli/tests/mdbook_integration_tests.rs
+++ b/crates/mdbook-lint-cli/tests/mdbook_integration_tests.rs
@@ -1190,7 +1190,7 @@ Code block without a language tag triggers MDBOOK001
     // The ignored chapter is still present, unchanged, in the returned book.
     let stdout_output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     assert!(
-        stdout_output.contains("generated/api.md"),
+        to_slashes(&stdout_output).contains("generated/api.md"),
         "ignored chapter must remain in the returned book"
     );
 }
@@ -1226,10 +1226,19 @@ fn test_preprocessor_ignore_paths_accepts_snake_case_alias() {
 /// Violation lines are `<path>:<line>:<col>: ...`, so anchoring on the leading
 /// path avoids counting a violation on another file that merely mentions this
 /// one (SUMMARY.md's MDBOOK023 names every chapter it links to).
+///
+/// Separators are normalized because `source_path` renders natively, so the
+/// same chapter appears as `generated/api.md` on Unix and `generated\api.md`
+/// on Windows.
 fn reports_for(stderr: &str, chapter_path: &str) -> usize {
-    let prefix = format!("{chapter_path}:");
+    let prefix = format!("{}:", to_slashes(chapter_path));
     stderr
         .lines()
-        .filter(|line| line.starts_with(&prefix))
+        .filter(|line| to_slashes(line).starts_with(&prefix))
         .count()
+}
+
+/// Normalize path separators so assertions are platform independent.
+fn to_slashes(s: &str) -> String {
+    s.replace('\\', "/")
 }

--- a/crates/mdbook-lint-cli/tests/mdbook_integration_tests.rs
+++ b/crates/mdbook-lint-cli/tests/mdbook_integration_tests.rs
@@ -1126,3 +1126,110 @@ fn test_preprocessor_deeply_nested_v04_v05_equivalent() {
         "Deeply nested chapter parent_names should be identical"
     );
 }
+
+#[test]
+fn test_preprocessor_honors_ignore_paths() {
+    // Issue #463: the CLI applied global ignore-paths but the preprocessor
+    // linted every chapter regardless, so books with generated or
+    // differently-formatted subtrees could not use [preprocessor.lint].
+    let temp_book = TempMdBook::new();
+
+    let violating_content = r#"
+# Level 1
+
+### Skipped level 2 triggers MD001
+
+```
+Code block without a language tag triggers MDBOOK001
+```
+"#;
+
+    temp_book
+        .with_summary(
+            r#"
+# Summary
+
+- [Guide](./guide.md)
+- [Generated](./generated/api.md)
+"#,
+        )
+        .with_chapter("guide.md", violating_content)
+        .with_chapter("generated/api.md", violating_content);
+
+    // Without ignore-paths both chapters are linted.
+    let baseline = cli_command()
+        .write_stdin(temp_book.create_preprocessor_input())
+        .assert();
+    let baseline_err = String::from_utf8(baseline.get_output().stderr.clone()).unwrap();
+    assert!(
+        reports_for(&baseline_err, "generated/api.md") > 0,
+        "baseline should lint the generated chapter, got:\n{baseline_err}"
+    );
+
+    // With ignore-paths the generated subtree is skipped, and the rest is not.
+    // fail-on-* are disabled so the run succeeds and emits the book on stdout,
+    // letting the same run assert that ignored chapters survive untouched.
+    let input = temp_book.create_preprocessor_input_with_config(json!({
+        "ignore-paths": ["generated/"],
+        "fail-on-errors": false,
+        "fail-on-warnings": false
+    }));
+    let assert = cli_command().write_stdin(input).assert();
+    let stderr_output = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+
+    assert_eq!(
+        reports_for(&stderr_output, "generated/api.md"),
+        0,
+        "ignored chapter should not be linted, got:\n{stderr_output}"
+    );
+    assert!(
+        reports_for(&stderr_output, "guide.md") > 0,
+        "non-ignored chapter should still be linted, got:\n{stderr_output}"
+    );
+
+    // The ignored chapter is still present, unchanged, in the returned book.
+    let stdout_output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout_output.contains("generated/api.md"),
+        "ignored chapter must remain in the returned book"
+    );
+}
+
+#[test]
+fn test_preprocessor_ignore_paths_accepts_snake_case_alias() {
+    // Both spellings are accepted through [preprocessor.lint].
+    for key in ["ignore-paths", "ignore_paths"] {
+        let temp_book = TempMdBook::new();
+        temp_book
+            .with_summary("# Summary\n\n- [Generated](./generated/api.md)\n")
+            .with_chapter(
+                "generated/api.md",
+                "# Level 1\n\n### Skipped level 2 triggers MD001\n",
+            );
+
+        let input = temp_book.create_preprocessor_input_with_config(json!({
+            key: ["generated/"]
+        }));
+        let assert = cli_command().write_stdin(input).assert();
+        let stderr_output = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+
+        assert_eq!(
+            reports_for(&stderr_output, "generated/api.md"),
+            0,
+            "{key} was not honored, got:\n{stderr_output}"
+        );
+    }
+}
+
+/// Count violations reported *against* `chapter_path`.
+///
+/// Violation lines are `<path>:<line>:<col>: ...`, so anchoring on the leading
+/// path avoids counting a violation on another file that merely mentions this
+/// one (SUMMARY.md's MDBOOK023 names every chapter it links to).
+fn reports_for(stderr: &str, chapter_path: &str) -> usize {
+    let prefix = format!("{chapter_path}:");
+    stderr
+        .lines()
+        .filter(|line| line.starts_with(&prefix))
+        .count()
+}


### PR DESCRIPTION
Closes #463

## Problem

The CLI filters its collected file list through `ignore-paths`, but the preprocessor's `run` loop sent every `BookItem::Chapter` to `process_chapter` without consulting the configuration. Books with generated or intentionally differently-formatted subtrees could not use `[preprocessor.lint]` and had to run a separately scoped CLI command instead.

## Three defects, not one

The issue describes the `run` loop. While testing the fix I found two more, each of which would have left the option a silent no-op on its own:

| # | Defect | Effect |
|---|---|---|
| 1 | `run` never consulted `config.core.ignore_paths` | described in the issue |
| 2 | `parse_mdbook_config` never read the key | a value in `[preprocessor.lint]` was dropped before reaching the loop |
| 3 | `Config::merge` did not carry `ignore_paths` | a value from a discovered `.mdbook-lint.toml` was lost as soon as any `book.toml` preprocessor config merged over it |

Fixing only the `run` loop passes a unit test but still does nothing end to end, which is how #2 and #3 surfaced: the integration test kept linting the ignored chapter after the loop was correct.

## Change

- Skip ignored chapters in `run`, before linting. They remain unchanged in the returned `Book`.
- Parse `ignore-paths` in `parse_mdbook_config`, accepting the `ignore_paths` spelling too, matching the standalone config file.
- Carry `ignore_paths` through `Config::merge`.
- Move `path_is_ignored` and `filter_ignored_paths` out of `main.rs` into a shared `ignore` module used by both the CLI and the preprocessor, as the issue's implementation note suggests, so the two cannot drift.

Patterns match chapter `source_path`, which mdBook reports relative to the book source directory, so `generated/` means the same thing regardless of where the book lives on disk. A chapter with no `source_path` has nothing to match against and is never ignored.

## Acceptance tests

- A preprocessor fixture with `ignore-paths = ["generated/"]` emits no violations from `generated/*.md`.
- Non-ignored chapters are still linted.
- Both `ignore-paths` and `ignore_paths` work through `[preprocessor.lint]`.
- The ignored chapter remains present in the book JSON written to stdout.

The integration test anchors on the violation line's leading path rather than a substring match, because SUMMARY.md's MDBOOK023 violation names every chapter it links to. A plain `contains` check would have reported a false failure against a correct fix.

## Note on a remaining duplicate

`matches_ignore_pattern` in `mdbook005.rs` is a third near-identical copy of this glob matcher. It lives in the rulesets crate rather than the CLI crate, so unifying it means moving the matcher into core, which is beyond the scope of this issue. Left as is and worth a follow-up.