### PR TITLE
feat(rules)!: make experimental rules opt-in

### DIFF
--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -19,6 +19,12 @@
 # Paths to ignore when linting
 # ignore-paths = ["target/", "vendor/", "*.backup.md"]
 
+# Experimental rules to run alongside the stable defaults.
+# Experimental rules are off by default because their output may change.
+# Accepts rule IDs, or "*" for all of them. Unlike enabled-rules, this adds
+# to the default set rather than replacing it.
+# experimental-rules = ["MDBOOK010"]
+
 # ============================================================================
 # STANDARD MARKDOWN RULES (MD001-MD059)
 # ============================================================================

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -346,8 +346,28 @@ struct DetailedRuleTableRow {
     category: String,
     #[tabled(rename = "Status")]
     status: String,
+    #[tabled(rename = "Default")]
+    default_on: String,
     #[tabled(rename = "Fix")]
     can_fix: String,
+}
+
+/// Suffix describing a rule's lifecycle for the simple `rules` listing.
+///
+/// Only non-default states are annotated, so a plain entry means "stable and on
+/// by default".
+fn rule_status_suffix(metadata: &mdbook_lint_core::rule::RuleMetadata) -> &'static str {
+    use mdbook_lint_core::rule::RuleStability;
+
+    if metadata.deprecated {
+        return " [deprecated]";
+    }
+    match metadata.stability {
+        RuleStability::Experimental => " [experimental, off by default]",
+        RuleStability::Deprecated => " [deprecated]",
+        RuleStability::Reserved => " [reserved]",
+        RuleStability::Stable => "",
+    }
 }
 
 /// Truncate a string to a maximum length, adding "..." if truncated
@@ -793,16 +813,17 @@ fn run_cli_mode(
     }
 
     if let Some(enabled_rules) = enable {
-        // Clear existing disabled rules and only enable specified rules
+        // --enable is an explicit selection: run exactly these rules.
+        //
+        // This previously inverted the selection, disabling every other rule
+        // and leaving enabled_rules empty. The outcome was the same for stable
+        // rules, but the registry could not tell that a rule had been chosen
+        // deliberately, so `--enable <experimental rule>` selected a rule that
+        // then failed the default-activation check. Recording the selection
+        // directly keeps that information; enabled_rules already means
+        // "only these" in RuleRegistry::should_run_rule.
         config.core.disabled_rules.clear();
-
-        // Get all available rule IDs and disable everything except enabled ones
-        let all_rule_ids = get_all_available_rule_ids();
-        for rule_id in all_rule_ids {
-            if !enabled_rules.contains(&rule_id) {
-                config.core.disabled_rules.push(rule_id);
-            }
-        }
+        config.core.enabled_rules = enabled_rules.clone();
     }
 
     // Create appropriate engine based on flags
@@ -1281,6 +1302,12 @@ fn run_rules_command(
                             description: truncate_string(rule.description(), 50),
                             category: format!("{:?}", metadata.category),
                             status,
+                            default_on: if metadata.runs_by_default() {
+                                "Yes"
+                            } else {
+                                "-"
+                            }
+                            .to_string(),
                             can_fix: if rule.can_fix() { "Yes" } else { "-" }.to_string(),
                         });
                     }
@@ -1310,21 +1337,21 @@ fn run_rules_command(
                             continue;
                         }
 
-                        let status = if metadata.deprecated {
-                            " [deprecated]"
-                        } else {
-                            ""
-                        };
                         println!(
                             "  {:<11} {:<32} {}{}",
                             rule.id(),
                             rule.name(),
                             truncate_string(rule.description(), 50),
-                            status
+                            rule_status_suffix(&metadata)
                         );
                     }
                 }
 
+                println!(
+                    "\nRules marked [experimental] do not run by default. Enable them with\n\
+                     --enable <RULE>, or with experimental-rules = [\"<RULE>\"] (or [\"*\"])\n\
+                     in configuration to add them alongside the stable defaults."
+                );
                 println!("\nUse --detailed for a formatted table with more information.");
             }
         }
@@ -1409,6 +1436,23 @@ fn run_check_command(config_path: &PathBuf) -> Result<()> {
         }
     }
 
+    // Validate experimental-rules. "*" selects every experimental rule.
+    for selector in &config.core.experimental_rules {
+        if selector == "*" {
+            continue;
+        }
+        if !available_rules.contains(selector) {
+            errors.push(format!("Unknown rule in experimental-rules: '{selector}'"));
+            if let Some(suggestion) = find_similar_rule(selector, &available_rules) {
+                errors.push(format!("  Did you mean '{suggestion}'?"));
+            }
+        } else if !rule_is_experimental(selector) {
+            warnings.push(format!(
+                "Rule '{selector}' in experimental-rules is not experimental; it already runs by default"
+            ));
+        }
+    }
+
     // Validate enabled-categories
     for category in &config.core.enabled_categories {
         if !valid_categories.contains(category.as_str()) {
@@ -1486,6 +1530,34 @@ fn run_check_command(config_path: &PathBuf) -> Result<()> {
 }
 
 /// Find a similar rule name for typo suggestions
+/// Return true if `rule_id` names a registered experimental rule.
+fn rule_is_experimental(rule_id: &str) -> bool {
+    use mdbook_lint_core::rule::RuleStability;
+
+    let mut registry = PluginRegistry::new();
+    if registry
+        .register_provider(Box::new(StandardRuleProvider))
+        .is_err()
+        || registry
+            .register_provider(Box::new(MdBookRuleProvider))
+            .is_err()
+    {
+        return false;
+    }
+    #[cfg(feature = "content")]
+    let _ = registry.register_provider(Box::new(ContentRuleProvider));
+    #[cfg(feature = "adr")]
+    let _ = registry.register_provider(Box::new(AdrRuleProvider));
+
+    let Ok(engine) = registry.create_engine() else {
+        return false;
+    };
+    engine
+        .registry()
+        .get_rule(rule_id)
+        .is_some_and(|rule| rule.metadata().stability == RuleStability::Experimental)
+}
+
 fn find_similar_rule(input: &str, available: &std::collections::HashSet<String>) -> Option<String> {
     let input_lower = input.to_lowercase();
 

--- a/crates/mdbook-lint-cli/tests/experimental_rules_test.rs
+++ b/crates/mdbook-lint-cli/tests/experimental_rules_test.rs
@@ -1,0 +1,189 @@
+//! Integration tests for experimental rule activation
+//!
+//! Issue #468: experimental rules used to run by default, because the registry's
+//! fallback excluded only deprecated rules. They are now opt-in.
+//!
+//! MDBOOK010 is used as the probe: it is marked experimental and reports an
+//! unclosed inline math block for an odd number of `$` characters.
+
+mod common;
+
+use common::cli_command;
+use predicates::str::contains;
+use std::fs;
+use tempfile::TempDir;
+
+/// Content that trips MDBOOK010 (experimental) and MD001 (stable).
+const CONTENT: &str = "# Level 1\n\n### Skipped level 2\n\nUnclosed math $x = y here.\n";
+
+/// Write `CONTENT` to a temp file and return the directory and file path.
+fn fixture() -> (TempDir, String) {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("doc.md");
+    fs::write(&path, CONTENT).unwrap();
+    let path_str = path.to_string_lossy().to_string();
+    (temp, path_str)
+}
+
+/// Write a config file into `dir` and return its path.
+fn write_config(dir: &TempDir, body: &str) -> String {
+    let path = dir.path().join("config.toml");
+    fs::write(&path, body).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+#[test]
+fn test_experimental_rule_is_off_by_default() {
+    let (_temp, doc) = fixture();
+
+    let assert = cli_command().arg("lint").arg(&doc).assert();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        !output.contains("MDBOOK010"),
+        "experimental rule should not run by default, got:\n{output}"
+    );
+    assert!(
+        output.contains("MD001"),
+        "stable rules should still run, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_enable_flag_activates_experimental_rule() {
+    // --enable is an explicit selection and can name an experimental rule.
+    let (_temp, doc) = fixture();
+
+    cli_command()
+        .arg("lint")
+        .arg("--enable")
+        .arg("MDBOOK010")
+        .arg(&doc)
+        .assert()
+        .stdout(contains("MDBOOK010"));
+}
+
+#[test]
+fn test_enable_flag_still_means_only_these_rules() {
+    // Selecting one rule must not drag in the rest.
+    let (_temp, doc) = fixture();
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--enable")
+        .arg("MD001")
+        .arg(&doc)
+        .assert();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(output.contains("MD001"), "got:\n{output}");
+    assert!(
+        !output.contains("MDBOOK010"),
+        "only the selected rule should run, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_experimental_rules_config_adds_to_defaults() {
+    // Unlike enabled-rules, experimental-rules keeps the stable set active.
+    let (temp, doc) = fixture();
+    let config = write_config(&temp, "experimental-rules = [\"MDBOOK010\"]\n");
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("-c")
+        .arg(&config)
+        .arg(&doc)
+        .assert();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(output.contains("MDBOOK010"), "got:\n{output}");
+    assert!(output.contains("MD001"), "got:\n{output}");
+}
+
+#[test]
+fn test_experimental_rules_wildcard_and_snake_case_alias() {
+    for body in [
+        "experimental-rules = [\"*\"]\n",
+        "experimental_rules = [\"*\"]\n",
+    ] {
+        let (temp, doc) = fixture();
+        let config = write_config(&temp, body);
+
+        cli_command()
+            .arg("lint")
+            .arg("-c")
+            .arg(&config)
+            .arg(&doc)
+            .assert()
+            .stdout(contains("MDBOOK010"));
+    }
+}
+
+#[test]
+fn test_disabled_rules_override_experimental_opt_in() {
+    let (temp, doc) = fixture();
+    let config = write_config(
+        &temp,
+        "experimental-rules = [\"*\"]\ndisabled-rules = [\"MDBOOK010\"]\n",
+    );
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("-c")
+        .arg(&config)
+        .arg(&doc)
+        .assert();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(
+        !output.contains("MDBOOK010"),
+        "disabled-rules must win over the opt-in, got:\n{output}"
+    );
+}
+
+#[test]
+fn test_rules_command_marks_experimental_rules() {
+    cli_command()
+        .arg("rules")
+        .assert()
+        .success()
+        .stdout(contains("MDBOOK010"))
+        .stdout(contains("[experimental, off by default]"))
+        .stdout(contains("experimental-rules"));
+}
+
+#[test]
+fn test_rules_detailed_reports_default_activation() {
+    let assert = cli_command().arg("rules").arg("--detailed").assert();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+    assert!(output.contains("Default"), "expected a Default column");
+    assert!(output.contains("Experimental"), "expected stability values");
+}
+
+#[test]
+fn test_check_reports_unknown_experimental_rule() {
+    let temp = TempDir::new().unwrap();
+    let config = write_config(&temp, "experimental-rules = [\"MDBOOK999\"]\n");
+
+    cli_command()
+        .arg("check")
+        .arg(&config)
+        .assert()
+        .failure()
+        .stderr(contains("Unknown rule in experimental-rules"));
+}
+
+#[test]
+fn test_check_warns_when_rule_is_not_experimental() {
+    let temp = TempDir::new().unwrap();
+    let config = write_config(&temp, "experimental-rules = [\"MD001\"]\n");
+
+    cli_command()
+        .arg("check")
+        .arg(&config)
+        .assert()
+        .success()
+        .stderr(contains("is not experimental"));
+}

--- a/crates/mdbook-lint-core/src/config.rs
+++ b/crates/mdbook-lint-core/src/config.rs
@@ -58,6 +58,18 @@ pub struct Config {
     #[serde(rename = "ignore-paths", alias = "ignore_paths", default)]
     pub ignore_paths: Vec<String>,
 
+    /// Experimental rules to activate alongside the stable defaults.
+    ///
+    /// Experimental rules do not run by default because their diagnostics may
+    /// change. Accepts rule IDs, or `"*"` for every experimental rule.
+    ///
+    /// This exists because `enabled-rules` means "run only these": listing an
+    /// experimental rule there would switch off every stable rule as well.
+    /// `experimental-rules` adds to the defaults rather than replacing them.
+    /// Both `experimental-rules` and `experimental_rules` are accepted.
+    #[serde(rename = "experimental-rules", alias = "experimental_rules", default)]
+    pub experimental_rules: Vec<String>,
+
     /// Rule-specific configuration
     #[serde(flatten)]
     pub rule_configs: HashMap<String, toml::Value>,
@@ -78,6 +90,7 @@ impl Default for Config {
             markdownlint_compatible: false,
             auto_fix: true, // Default to true - fixes are applied when --fix is used
             ignore_paths: Vec::new(),
+            experimental_rules: Vec::new(),
             rule_configs: HashMap::new(),
         }
     }

--- a/crates/mdbook-lint-core/src/registry.rs
+++ b/crates/mdbook-lint-core/src/registry.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Document, config::Config, error::Result, rule::CollectionRule, rule::Rule, violation::Violation,
+    Document, config::Config, error::Result, rule::CollectionRule, rule::Rule, rule::RuleStability,
+    violation::Violation,
 };
 
 /// Registry for managing linting rules
@@ -184,8 +185,18 @@ impl RuleRegistry {
             return false;
         }
 
-        // For rules not explicitly configured, only enable non-deprecated rules by default
-        !metadata.deprecated
+        // An experimental rule that was not explicitly selected runs only when
+        // opted into. This is checked after the filters above so that
+        // disabled-rules and category filtering still win.
+        if metadata.stability == RuleStability::Experimental {
+            return config
+                .experimental_rules
+                .iter()
+                .any(|selector| selector == "*" || selector == rule_id);
+        }
+
+        // Otherwise activation is decided by stability alone.
+        metadata.runs_by_default()
     }
 
     /// Convert RuleCategory to string for configuration matching
@@ -441,6 +452,186 @@ mod tests {
                 crate::violation::Severity::Warning,
             )])
         }
+    }
+
+    /// Test rule with a configurable stability level.
+    struct StabilityRule {
+        id: &'static str,
+        metadata: RuleMetadata,
+    }
+
+    impl StabilityRule {
+        fn new(id: &'static str, metadata: RuleMetadata) -> Self {
+            Self { id, metadata }
+        }
+    }
+
+    impl Rule for StabilityRule {
+        fn id(&self) -> &'static str {
+            self.id
+        }
+
+        fn name(&self) -> &'static str {
+            "stability-test-rule"
+        }
+
+        fn description(&self) -> &'static str {
+            "A rule used to test stability-based activation"
+        }
+
+        fn metadata(&self) -> RuleMetadata {
+            self.metadata.clone()
+        }
+
+        fn check_with_ast<'a>(
+            &self,
+            _document: &Document,
+            _ast: Option<&'a comrak::nodes::AstNode<'a>>,
+        ) -> Result<Vec<Violation>> {
+            Ok(vec![])
+        }
+    }
+
+    /// Build a registry holding one rule of each stability level.
+    fn stability_registry() -> RuleRegistry {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(StabilityRule::new(
+            "STABLE001",
+            RuleMetadata::stable(RuleCategory::Structure),
+        )));
+        registry.register(Box::new(StabilityRule::new(
+            "EXPER001",
+            RuleMetadata::experimental(RuleCategory::Structure),
+        )));
+        registry.register(Box::new(StabilityRule::new(
+            "EXPER002",
+            RuleMetadata::experimental(RuleCategory::Structure),
+        )));
+        registry.register(Box::new(StabilityRule::new(
+            "DEPREC001",
+            RuleMetadata::deprecated(RuleCategory::Structure, "obsolete", None),
+        )));
+        registry.register(Box::new(StabilityRule::new(
+            "RESERV001",
+            RuleMetadata::reserved("never implemented"),
+        )));
+        registry
+    }
+
+    /// IDs of the rules the registry would run under `config`.
+    fn active_ids(registry: &RuleRegistry, config: &Config) -> Vec<&'static str> {
+        let mut ids: Vec<&'static str> = registry
+            .get_enabled_rules(config)
+            .iter()
+            .map(|r| r.id())
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    #[test]
+    fn test_only_stable_rules_run_by_default() {
+        // Issue #468: experimental rules previously ran by default because the
+        // fallback excluded only deprecated rules.
+        let registry = stability_registry();
+        assert_eq!(active_ids(&registry, &Config::default()), vec!["STABLE001"]);
+    }
+
+    #[test]
+    fn test_explicit_selection_enables_experimental_rule() {
+        let registry = stability_registry();
+        let config = Config {
+            enabled_rules: vec!["EXPER001".to_string()],
+            ..Default::default()
+        };
+        // enabled_rules means "only these", so the stable rule is excluded too.
+        assert_eq!(active_ids(&registry, &config), vec!["EXPER001"]);
+    }
+
+    #[test]
+    fn test_experimental_rules_option_adds_to_defaults() {
+        let registry = stability_registry();
+
+        // A single ID opts in just that rule, alongside the stable defaults.
+        let config = Config {
+            experimental_rules: vec!["EXPER001".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            active_ids(&registry, &config),
+            vec!["EXPER001", "STABLE001"]
+        );
+
+        // "*" opts in every experimental rule.
+        let config = Config {
+            experimental_rules: vec!["*".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            active_ids(&registry, &config),
+            vec!["EXPER001", "EXPER002", "STABLE001"]
+        );
+    }
+
+    #[test]
+    fn test_disabled_rules_beat_experimental_opt_in() {
+        let registry = stability_registry();
+        let config = Config {
+            experimental_rules: vec!["*".to_string()],
+            disabled_rules: vec!["EXPER001".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            active_ids(&registry, &config),
+            vec!["EXPER002", "STABLE001"]
+        );
+    }
+
+    #[test]
+    fn test_disabled_category_beats_experimental_opt_in() {
+        let registry = stability_registry();
+        let config = Config {
+            experimental_rules: vec!["*".to_string()],
+            disabled_categories: vec!["structure".to_string()],
+            ..Default::default()
+        };
+        assert!(active_ids(&registry, &config).is_empty());
+    }
+
+    #[test]
+    fn test_enabled_category_does_not_opt_into_experimental() {
+        // Selecting a category expresses interest in a topic, not in unstable
+        // diagnostics. Stability is orthogonal to category.
+        let registry = stability_registry();
+        let config = Config {
+            enabled_categories: vec!["structure".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(active_ids(&registry, &config), vec!["STABLE001"]);
+    }
+
+    #[test]
+    fn test_deprecated_and_reserved_stay_off_by_default() {
+        let registry = stability_registry();
+        let active = active_ids(&registry, &Config::default());
+        assert!(!active.contains(&"DEPREC001"));
+        assert!(!active.contains(&"RESERV001"));
+
+        // Deprecated rules remain explicitly enableable, as before.
+        let config = Config {
+            enabled_rules: vec!["DEPREC001".to_string()],
+            deprecated_warning: crate::config::DeprecatedWarningLevel::Silent,
+            ..Default::default()
+        };
+        assert_eq!(active_ids(&registry, &config), vec!["DEPREC001"]);
+    }
+
+    #[test]
+    fn test_runs_by_default_matches_stability() {
+        assert!(RuleMetadata::stable(RuleCategory::Structure).runs_by_default());
+        assert!(!RuleMetadata::experimental(RuleCategory::Structure).runs_by_default());
+        assert!(!RuleMetadata::deprecated(RuleCategory::Structure, "x", None).runs_by_default());
+        assert!(!RuleMetadata::reserved("x").runs_by_default());
     }
 
     #[test]

--- a/crates/mdbook-lint-core/src/rule.rs
+++ b/crates/mdbook-lint-core/src/rule.rs
@@ -118,6 +118,26 @@ impl RuleMetadata {
         self.overrides = Some(rule_id);
         self
     }
+
+    /// Whether this rule runs when it has not been explicitly selected.
+    ///
+    /// Only stable rules run by default:
+    ///
+    /// - `Stable` runs.
+    /// - `Experimental` does not. Its diagnostics may change, so it must be
+    ///   opted into by rule ID rather than reaching users who did not ask for
+    ///   it. See the `experimental-rules` configuration option to enable the
+    ///   whole set at once.
+    /// - `Deprecated` does not, matching long-standing behavior.
+    /// - `Reserved` does not. Reserved rules are registered placeholders that
+    ///   never produce violations, so running them is pure overhead.
+    ///
+    /// This is the single definition of default activation. Explicit selection
+    /// (`enabled_rules`) is handled by the registry and takes precedence over
+    /// this method.
+    pub fn runs_by_default(&self) -> bool {
+        !self.deprecated && matches!(self.stability, RuleStability::Stable)
+    }
 }
 
 /// Trait that all linting rules must implement

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -27,8 +27,34 @@ Complete reference for all configuration options in mdbook-lint.
 
 - **Type**: `array<string>`
 - **Default**: `[]`
-- **Description**: List of rule IDs to explicitly enable
+- **Description**: List of rule IDs to explicitly enable. When non-empty this means
+  "run only these rules", so every rule not listed is switched off.
 - **Example**: `["MD001", "MD002"]`
+
+### experimental-rules
+
+- **Type**: `array<string>`
+- **Default**: `[]`
+- **Description**: Experimental rules to run in addition to the stable defaults.
+  Accepts rule IDs, or `"*"` for every experimental rule.
+- **Example**: `["MDBOOK010"]` or `["*"]`
+
+Experimental rules do not run by default because their diagnostics may still
+change. Use this option rather than `enabled-rules` when you want an experimental
+rule *alongside* the normal rule set, since `enabled-rules` would disable
+everything else:
+
+```toml
+# Run all stable rules, plus MDBOOK010.
+experimental-rules = ["MDBOOK010"]
+```
+
+`--enable MDBOOK010` also activates an experimental rule, but follows the
+"only these rules" meaning of an explicit selection.
+
+Run `mdbook-lint rules` to see which rules are experimental, or
+`mdbook-lint rules --detailed` for a table with a `Default` column showing
+whether each rule runs without configuration.
 
 ### enabled-categories
 


### PR DESCRIPTION
Closes #468

## Problem

`RuleStability::Experimental` was informational only. `RuleRegistry::should_run_rule` ended in:

```rust
// For rules not explicitly configured, only enable non-deprecated rules by default
!metadata.deprecated
```

So every non-deprecated rule ran by default, and MDBOOK008 through MDBOOK012 were indistinguishable from stable rules in a normal lint run.

## Change

Default activation is decided by stability, expressed once as `RuleMetadata::runs_by_default()`:

| Stability | Runs by default |
|---|---|
| Stable | yes |
| Experimental | no |
| Deprecated | no (unchanged) |
| Reserved | no (**was yes**) |

Reserved rules (MD008, MD016, MD057) are registered placeholders whose `check_with_ast` returns an empty vector, so running them was pure overhead.

Two opt-in paths, both applied *after* `disabled-rules` and category filtering so those still win:

1. **Explicit selection**, keeping its existing "only these rules" meaning.
2. **`experimental-rules`**, a new config key accepting rule IDs or `"*"`, which adds to the stable defaults rather than replacing them.

## Why the second path is necessary, not convenient

The issue lists `--experimental` as something to "consider". It turns out to be required.

`enabled-rules` means *run only these*. Naming an experimental rule there switches off every stable rule as well, so without a separate surface there is no way to express "the defaults, plus MDBOOK010". That is the common case for anyone dogfooding one experimental rule.

## A second defect found while testing

The registry change alone did not make `--enable MDBOOK010` work. The CLI never populated `enabled_rules`; it inverted the selection instead:

```rust
config.core.disabled_rules.clear();
for rule_id in get_all_available_rule_ids() {
    if !enabled_rules.contains(&rule_id) {
        config.core.disabled_rules.push(rule_id);
    }
}
```

The outcome matched for stable rules, but the registry could not tell that a rule had been chosen deliberately, so `--enable` on an experimental rule selected a rule that then failed the default-activation check. I verified this against `main` to confirm it was a regression I had introduced rather than pre-existing.

`--enable` now records the selection directly in `enabled_rules`, which already carries "only these" semantics. Side effect worth noting: an explicitly enabled *deprecated* rule now emits its deprecation warning, which the old inversion silently skipped.

## Surfaces

- `mdbook-lint rules` marks experimental rules `[experimental, off by default]` and explains how to enable them.
- `mdbook-lint rules --detailed` gains a `Default` column alongside the existing `Status`.
- `mdbook-lint check` errors on unknown `experimental-rules` entries (with a did-you-mean) and warns when a listed rule is not experimental.
- CLI, preprocessor, LSP, and library all lint through `lint_document_with_config` → `should_run_rule`, so the policy is applied once for all of them.

## Breaking change

MDBOOK008, MDBOOK009, MDBOOK010, MDBOOK011, and MDBOOK012 no longer run by default. To restore the previous rule set:

```toml
experimental-rules = ["*"]
```

## Tests

8 registry tests over a fixture registry holding one rule of each stability level, covering default activation, explicit selection, wildcard and per-ID opt-in, and precedence against `disabled-rules`, `disabled-categories`, and `enabled-categories`. Category selection deliberately does *not* opt into experimental rules: a category expresses interest in a topic, not in unstable diagnostics.

12 CLI integration tests covering the same behavior end to end, plus the `rules` and `check` output.

## Note on scope

While tracing the acceptance criterion about CLI/config/library/LSP applying the same policy, I found two further `should_run_rule` implementations that are **dead**: one in `mdbook-lint-core/src/config.rs` with no callers at all, and one in `mdbook-lint-cli/src/config.rs` reachable only from its own tests, which re-derives categories from a hardcoded match against a different `RuleCategory` enum. Neither is on a live path, so the criterion is met by the registry change. I left them alone rather than widening this PR, but they are the same drift hazard as #479 and are worth removing.