### PR TITLE
test: add a rule contract test across registry, docs, and example config

### DIFF
--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -352,6 +352,66 @@ struct DetailedRuleTableRow {
     can_fix: String,
 }
 
+/// A rule as presented by the `rules` command.
+///
+/// Document rules and collection rules are stored separately in the registry
+/// but are both part of the public rule inventory, so listing resolves either
+/// kind through this shape. Collection rules analyze several documents at once
+/// and never carry fixes.
+struct ListedRule {
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+    metadata: mdbook_lint_core::rule::RuleMetadata,
+    can_fix: bool,
+}
+
+/// Every rule ID in the public inventory: document rules plus collection rules.
+///
+/// `LintEngine::available_rules` covers document rules only, so any listing
+/// built on it alone omits collection rules such as the cross-document ADR
+/// checks (ADR010 through ADR013).
+fn all_listed_rule_ids(engine: &mdbook_lint_core::LintEngine) -> Vec<String> {
+    let mut ids: Vec<String> = engine
+        .available_rules()
+        .into_iter()
+        .map(String::from)
+        .collect();
+    ids.extend(
+        engine
+            .registry()
+            .collection_rule_ids()
+            .into_iter()
+            .map(String::from),
+    );
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// Resolve a rule ID against both the document and collection registries.
+fn resolve_listed_rule(engine: &mdbook_lint_core::LintEngine, rule_id: &str) -> Option<ListedRule> {
+    if let Some(rule) = engine.registry().get_rule(rule_id) {
+        return Some(ListedRule {
+            id: rule.id(),
+            name: rule.name(),
+            description: rule.description(),
+            metadata: rule.metadata(),
+            can_fix: rule.can_fix(),
+        });
+    }
+    engine
+        .registry()
+        .get_collection_rule(rule_id)
+        .map(|rule| ListedRule {
+            id: rule.id(),
+            name: rule.name(),
+            description: rule.description(),
+            metadata: rule.metadata(),
+            can_fix: false,
+        })
+}
+
 /// Suffix describing a rule's lifecycle for the simple `rules` listing.
 ///
 /// Only non-default states are annotated, so a plain entry means "stable and on
@@ -1221,8 +1281,8 @@ fn run_rules_command(
                 let mut json_rules = Vec::new();
 
                 for rule_id in provider.rule_ids() {
-                    if let Some(rule) = engine.registry().get_rule(rule_id) {
-                        let metadata = rule.metadata();
+                    if let Some(rule) = resolve_listed_rule(&engine, rule_id) {
+                        let metadata = &rule.metadata;
 
                         // Apply category filter
                         if let Some(filter) = category_filter
@@ -1233,16 +1293,16 @@ fn run_rules_command(
                         }
 
                         let json_rule = JsonRule {
-                            id: rule.id().to_string(),
-                            name: rule.name().to_string(),
-                            description: rule.description().to_string(),
+                            id: rule.id.to_string(),
+                            name: rule.name.to_string(),
+                            description: rule.description.to_string(),
                             category: JsonRuleCategory::from(&metadata.category),
                             stability: JsonRuleStability::from(&metadata.stability),
                             deprecated: metadata.deprecated,
                             deprecated_reason: metadata.deprecated_reason.map(String::from),
                             replacement: metadata.replacement.map(String::from),
                             introduced_in: metadata.introduced_in.map(String::from),
-                            can_fix: rule.can_fix(),
+                            can_fix: rule.can_fix,
                         };
 
                         json_rules.push(json_rule);
@@ -1274,9 +1334,9 @@ fn run_rules_command(
             let mut rows: Vec<_> = Vec::new();
             let mut total_rules = 0;
 
-            for rule_id in engine.available_rules() {
-                if let Some(rule) = engine.registry().get_rule(rule_id) {
-                    let metadata = rule.metadata();
+            for rule_id in all_listed_rule_ids(&engine) {
+                if let Some(rule) = resolve_listed_rule(&engine, &rule_id) {
+                    let metadata = &rule.metadata;
 
                     // Apply category filter
                     if let Some(filter) = category_filter
@@ -1297,9 +1357,9 @@ fn run_rules_command(
                         };
 
                         rows.push(DetailedRuleTableRow {
-                            id: rule.id().to_string(),
-                            name: rule.name().to_string(),
-                            description: truncate_string(rule.description(), 50),
+                            id: rule.id.to_string(),
+                            name: rule.name.to_string(),
+                            description: truncate_string(rule.description, 50),
                             category: format!("{:?}", metadata.category),
                             status,
                             default_on: if metadata.runs_by_default() {
@@ -1308,7 +1368,7 @@ fn run_rules_command(
                                 "-"
                             }
                             .to_string(),
-                            can_fix: if rule.can_fix() { "Yes" } else { "-" }.to_string(),
+                            can_fix: if rule.can_fix { "Yes" } else { "-" }.to_string(),
                         });
                     }
                 }
@@ -1325,9 +1385,9 @@ fn run_rules_command(
             } else {
                 // Simple list mode with rule name
                 println!("Available rules:");
-                for rule_id in engine.available_rules() {
-                    if let Some(rule) = engine.registry().get_rule(rule_id) {
-                        let metadata = rule.metadata();
+                for rule_id in all_listed_rule_ids(&engine) {
+                    if let Some(rule) = resolve_listed_rule(&engine, &rule_id) {
+                        let metadata = &rule.metadata;
 
                         // Apply category filter
                         if let Some(filter) = category_filter
@@ -1339,10 +1399,10 @@ fn run_rules_command(
 
                         println!(
                             "  {:<11} {:<32} {}{}",
-                            rule.id(),
-                            rule.name(),
-                            truncate_string(rule.description(), 50),
-                            rule_status_suffix(&metadata)
+                            rule.id,
+                            rule.name,
+                            truncate_string(rule.description, 50),
+                            rule_status_suffix(metadata)
                         );
                     }
                 }

--- a/crates/mdbook-lint-cli/tests/rule_contract_test.rs
+++ b/crates/mdbook-lint-cli/tests/rule_contract_test.rs
@@ -1,0 +1,398 @@
+//! Contract test for the public rule surface (issue #467).
+//!
+//! Rule registration, documentation, and the example configuration are one
+//! coherent surface. Existing tests prove the example config parses; they do
+//! not prove that every documented rule maps to a registered implementation,
+//! or that every registered rule is discoverable.
+//!
+//! This test derives the rule inventory from the providers and checks the other
+//! surfaces against it, so drift fails in CI with the exact IDs named.
+//!
+//! ## Known gaps
+//!
+//! Surfaces that are currently out of sync are listed explicitly below and
+//! asserted by *equality*, not as a floor. Adding a rule without documenting it
+//! fails, and documenting one of the listed rules also fails until the list is
+//! updated. The lists may only shrink.
+
+use mdbook_lint_core::PluginRegistry;
+use mdbook_lint_core::rule::RuleStability;
+use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+/// Registered rules that have no documentation page yet.
+///
+/// Tracked by #482. This list may only shrink.
+const KNOWN_UNDOCUMENTED: &[&str] = &[
+    "CONTENT001",
+    "CONTENT002",
+    "CONTENT003",
+    "CONTENT004",
+    "CONTENT005",
+    "CONTENT006",
+    "CONTENT007",
+    "CONTENT009",
+    "CONTENT010",
+    "CONTENT011",
+    "MD060",
+    "MDBOOK016",
+    "MDBOOK017",
+    "MDBOOK021",
+    "MDBOOK022",
+    "MDBOOK023",
+];
+
+/// Rule IDs referenced by the example config that are not registered.
+///
+/// MD057 is a reserved markdownlint number that was never implemented here, so
+/// `standard/mod.rs` skips registering it. The example config documents the
+/// number for readers coming from markdownlint.
+const KNOWN_UNREGISTERED_IN_EXAMPLE_CONFIG: &[&str] = &["MD057"];
+
+/// Repository root, derived from this crate's manifest directory.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root should resolve")
+}
+
+/// One entry in the rule inventory.
+struct RuleEntry {
+    name: &'static str,
+    description: &'static str,
+    stability: RuleStability,
+    /// Collection rules analyze several documents together.
+    is_collection: bool,
+}
+
+/// Build the rule inventory from every provider, document and collection rules alike.
+fn inventory() -> BTreeMap<String, RuleEntry> {
+    let mut registry = PluginRegistry::new();
+    registry
+        .register_provider(Box::new(StandardRuleProvider))
+        .expect("standard provider registers");
+    registry
+        .register_provider(Box::new(MdBookRuleProvider))
+        .expect("mdbook provider registers");
+    #[cfg(feature = "content")]
+    registry
+        .register_provider(Box::new(mdbook_lint_rulesets::ContentRuleProvider))
+        .expect("content provider registers");
+    #[cfg(feature = "adr")]
+    registry
+        .register_provider(Box::new(mdbook_lint_rulesets::AdrRuleProvider))
+        .expect("adr provider registers");
+
+    let engine = registry.create_engine().expect("engine builds");
+    let mut entries = BTreeMap::new();
+
+    for id in engine.available_rules() {
+        let rule = engine
+            .registry()
+            .get_rule(id)
+            .expect("advertised rule resolves");
+        entries.insert(
+            id.to_string(),
+            RuleEntry {
+                name: rule.name(),
+                description: rule.description(),
+                stability: rule.metadata().stability,
+                is_collection: false,
+            },
+        );
+    }
+
+    for id in engine.registry().collection_rule_ids() {
+        let rule = engine
+            .registry()
+            .get_collection_rule(id)
+            .expect("advertised collection rule resolves");
+        entries.insert(
+            id.to_string(),
+            RuleEntry {
+                name: rule.name(),
+                description: rule.description(),
+                stability: rule.metadata().stability,
+                is_collection: true,
+            },
+        );
+    }
+
+    entries
+}
+
+/// Documentation subdirectory for a rule ID.
+///
+/// Checked before the `MD` prefix, since `MDBOOK` also starts with `MD`.
+fn docs_subdir(rule_id: &str) -> Option<&'static str> {
+    if rule_id.starts_with("MDBOOK") {
+        Some("mdbook")
+    } else if rule_id.starts_with("CONTENT") {
+        Some("content")
+    } else if rule_id.starts_with("ADR") {
+        Some("adr")
+    } else if rule_id.starts_with("MD") {
+        Some("standard")
+    } else {
+        None
+    }
+}
+
+/// Rule IDs that have a documentation page on disk.
+fn documented_rule_ids() -> BTreeSet<String> {
+    let rules_dir = repo_root().join("docs/src/rules");
+    let mut ids = BTreeSet::new();
+
+    for subdir in ["standard", "mdbook", "content", "adr"] {
+        let dir = rules_dir.join(subdir);
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue; // A ruleset with no docs directory yet.
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let upper = stem.to_uppercase();
+            // Category and index pages are not rule pages.
+            if docs_subdir(&upper).is_some()
+                && upper
+                    .trim_start_matches(|c: char| c.is_ascii_alphabetic())
+                    .chars()
+                    .all(|c| c.is_ascii_digit())
+                && upper.chars().any(|c| c.is_ascii_digit())
+            {
+                ids.insert(upper);
+            }
+        }
+    }
+
+    ids
+}
+
+/// Rule IDs mentioned as configurable sections in the example config.
+fn example_config_rule_ids() -> BTreeSet<String> {
+    let path = repo_root().join("crates/mdbook-lint-cli/example-mdbook-lint.toml");
+    let content = std::fs::read_to_string(&path).expect("example config is readable");
+
+    content
+        .lines()
+        .filter_map(|line| {
+            // Entries appear as commented headers: "# MD009 - Trailing spaces"
+            let rest = line.strip_prefix("# ")?;
+            let token = rest.split_whitespace().next()?;
+            if docs_subdir(token).is_some()
+                && token.chars().any(|c| c.is_ascii_digit())
+                && token
+                    .trim_start_matches(|c: char| c.is_ascii_alphabetic())
+                    .chars()
+                    .all(|c| c.is_ascii_digit())
+            {
+                Some(token.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn test_inventory_is_not_empty() {
+    let inventory = inventory();
+    assert!(
+        inventory.len() >= 90,
+        "expected the full rule inventory, got {} rules",
+        inventory.len()
+    );
+}
+
+#[test]
+fn test_every_registered_rule_has_documentation() {
+    let inventory = inventory();
+    let documented = documented_rule_ids();
+
+    let undocumented: BTreeSet<String> = inventory
+        .keys()
+        .filter(|id| !documented.contains(*id))
+        .cloned()
+        .collect();
+
+    let known: BTreeSet<String> = KNOWN_UNDOCUMENTED.iter().map(|s| s.to_string()).collect();
+
+    let newly_undocumented: Vec<&String> = undocumented.difference(&known).collect();
+    assert!(
+        newly_undocumented.is_empty(),
+        "these rules are registered but have no documentation page:\n  {}\n\
+         Add docs/src/rules/<ruleset>/<id>.md for each, or add the ID to \
+         KNOWN_UNDOCUMENTED with a tracking issue.",
+        newly_undocumented
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let now_documented: Vec<&String> = known.difference(&undocumented).collect();
+    assert!(
+        now_documented.is_empty(),
+        "these rules are now documented and must be removed from KNOWN_UNDOCUMENTED:\n  {}",
+        now_documented
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+}
+
+#[test]
+fn test_every_documentation_page_maps_to_a_registered_rule() {
+    let inventory = inventory();
+    let documented = documented_rule_ids();
+
+    let orphans: Vec<&String> = documented
+        .iter()
+        .filter(|id| !inventory.contains_key(*id))
+        .collect();
+
+    assert!(
+        orphans.is_empty(),
+        "these documentation pages describe rules that are not registered:\n  {}\n\
+         Either register the rule or remove the page.",
+        orphans
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+}
+
+#[test]
+fn test_documentation_lives_in_the_ruleset_directory() {
+    let inventory = inventory();
+    let rules_dir = repo_root().join("docs/src/rules");
+
+    for id in inventory.keys() {
+        let subdir = docs_subdir(id).unwrap_or_else(|| panic!("unrecognized rule ID prefix: {id}"));
+        let expected = rules_dir
+            .join(subdir)
+            .join(format!("{}.md", id.to_lowercase()));
+
+        if KNOWN_UNDOCUMENTED.contains(&id.as_str()) {
+            continue;
+        }
+        assert!(
+            expected.exists(),
+            "{id} should be documented at {}",
+            expected.display()
+        );
+    }
+}
+
+#[test]
+fn test_example_config_references_only_registered_rules() {
+    let inventory = inventory();
+    let referenced = example_config_rule_ids();
+
+    assert!(
+        !referenced.is_empty(),
+        "expected the example config to document rule sections"
+    );
+
+    let unregistered: BTreeSet<String> = referenced
+        .iter()
+        .filter(|id| !inventory.contains_key(*id))
+        .cloned()
+        .collect();
+
+    let known: BTreeSet<String> = KNOWN_UNREGISTERED_IN_EXAMPLE_CONFIG
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let unexpected: Vec<&String> = unregistered.difference(&known).collect();
+    assert!(
+        unexpected.is_empty(),
+        "the example config documents rules that are not registered:\n  {}",
+        unexpected
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let now_registered: Vec<&String> = known.difference(&unregistered).collect();
+    assert!(
+        now_registered.is_empty(),
+        "these are now registered and must leave KNOWN_UNREGISTERED_IN_EXAMPLE_CONFIG:\n  {}",
+        now_registered
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+}
+
+#[test]
+fn test_rule_metadata_is_well_formed() {
+    for (id, entry) in inventory() {
+        assert!(!entry.name.is_empty(), "{id} has an empty name");
+        assert!(
+            !entry.description.is_empty(),
+            "{id} has an empty description"
+        );
+        assert!(
+            entry
+                .name
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+            "{id} name '{}' should be lowercase kebab-case",
+            entry.name
+        );
+        assert!(
+            docs_subdir(&id).is_some(),
+            "{id} does not match a known rule ID prefix"
+        );
+    }
+}
+
+#[test]
+fn test_no_registered_rule_is_reserved() {
+    // Reserved numbers are deliberately never registered. If one appears in the
+    // inventory, either the rule was implemented (and its metadata should change)
+    // or a placeholder was registered by mistake.
+    let reserved: Vec<String> = inventory()
+        .iter()
+        .filter(|(_, entry)| entry.stability == RuleStability::Reserved)
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    assert!(
+        reserved.is_empty(),
+        "reserved rules should not be registered: {}",
+        reserved.join(", ")
+    );
+}
+
+#[test]
+fn test_collection_rules_are_part_of_the_inventory() {
+    // Regression guard: collection rules live in a separate registry list, so a
+    // listing built only on document rules silently drops them.
+    let inventory = inventory();
+    let collection: Vec<&String> = inventory
+        .iter()
+        .filter(|(_, e)| e.is_collection)
+        .map(|(id, _)| id)
+        .collect();
+
+    #[cfg(feature = "adr")]
+    assert!(
+        !collection.is_empty(),
+        "expected the cross-document ADR rules in the inventory"
+    );
+    let _ = collection;
+}

--- a/crates/mdbook-lint-core/src/registry.rs
+++ b/crates/mdbook-lint-core/src/registry.rs
@@ -58,6 +58,17 @@ impl RuleRegistry {
         self.rules.iter().find(|r| r.id() == id).map(|r| r.as_ref())
     }
 
+    /// Get a registered collection rule by ID
+    ///
+    /// Collection rules are stored separately from document rules, so a lookup
+    /// that only consults [`RuleRegistry::get_rule`] silently misses them.
+    pub fn get_collection_rule(&self, id: &str) -> Option<&dyn CollectionRule> {
+        self.collection_rules
+            .iter()
+            .find(|r| r.id() == id)
+            .map(|r| r.as_ref())
+    }
+
     /// Get all rule IDs
     ///
     /// Returns a vector of all registered rule IDs in registration order.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -194,6 +194,40 @@ mod tests {
 2. **Register rule**: Add to `StandardRuleProvider::register_rules()`
 3. **Add to rule list**: Include ID in `StandardRuleProvider::rule_ids()`
 
+Cross-document rules implement `CollectionRule` and are registered with
+`register_collection_rule()` instead. They live in a separate registry list, so
+anything that enumerates rules must consult both.
+
+### Public surfaces a rule must update
+
+A rule is not just an implementation. Adding or changing one touches several
+surfaces that are expected to agree, and
+`crates/mdbook-lint-cli/tests/rule_contract_test.rs` fails in CI when they drift.
+
+| Surface | Location | Required |
+|---------|----------|----------|
+| Registration | provider `register_rules` and `rule_ids` | Always |
+| Documentation page | `docs/src/rules/<ruleset>/<id>.md` | Always |
+| Book navigation | `docs/src/SUMMARY.md` | For a new page |
+| Example configuration | `crates/mdbook-lint-cli/example-mdbook-lint.toml` | If the rule takes options |
+| Metadata | `RuleMetadata` category, stability, `introduced_in` | Always |
+
+The contract test names the exact ID and surface when something is missing, so
+read the failure rather than guessing.
+
+Two conventions it enforces:
+
+- **Rule names are lowercase kebab-case** (`heading-increment`), distinct from
+  the uppercase ID (`MD001`).
+- **Reserved numbers are never registered.** A reserved rule is a placeholder
+  for a markdownlint number that was never implemented here; its module exists
+  but the provider skips it.
+
+New rules should be `RuleMetadata::experimental(..)` until their diagnostics
+settle. Experimental rules do not run by default and must be opted into with
+`--enable <RULE>` or `experimental-rules`, which lets them be dogfooded without
+exposing every user to unstable output. Promote to `stable` in a later release.
+
 ### Testing Requirements
 
 **Comprehensive testing is required**:


### PR DESCRIPTION
Closes #467

## Problem

Rule registration, documentation, and the example configuration are one public surface, but nothing checked that they agree. The existing example-config tests prove the file parses; they do not prove that every documented rule maps to a registered implementation, or that every registered rule is discoverable.

## A real bug the test surfaced

ADR010 through ADR013 are **collection rules**, registered with `register_collection_rule` and stored in a list separate from document rules. `RuleRegistry::rule_ids` and the `get_rule` lookup cover only document rules, so the `rules` command silently dropped all four.

They were advertised by the provider, documented, and actually running. They were simply invisible to anyone listing rules:

```console
$ mdbook-lint rules | grep -c '^  [A-Z]'
96          # the project documents 100 rules
$ mdbook-lint rules | grep ADR01[0-3]
            # nothing
```

The lookup returned `None` and the loop skipped them without complaint. Fixed by adding `RuleRegistry::get_collection_rule` and resolving listings through a `ListedRule` view covering both kinds, so the JSON, detailed, and simple output modes all see the full inventory. The count is now 100, and all four ADR rules appear.

This also removed every "orphan documentation page" the test found: those pages were correct all along, and the listing was wrong.

## The test

`crates/mdbook-lint-cli/tests/rule_contract_test.rs` builds the inventory from the providers (document plus collection rules) and asserts:

| Check | Fails when |
|---|---|
| Every registered rule has a doc page | a rule is added without documentation |
| Every doc page maps to a registered rule | a rule is removed or renamed, or a listing drops rules |
| Docs live in the ruleset directory | a page lands in the wrong place |
| Example config references only registered rules | the config documents something that does not exist |
| Metadata is well formed | empty name/description, non-kebab-case name, unknown ID prefix |
| No registered rule is reserved | a placeholder number gets registered by mistake |
| Collection rules are in the inventory | the bug above regresses |

Failures name the exact IDs and say what to do.

## Known gaps, as a ratchet

Sixteen registered rules have no documentation page: the ten CONTENT rules (there is no `docs/src/rules/content/` directory at all), MD060, and MDBOOK016/017/021/022/023. Filed as #482.

They are listed in `KNOWN_UNDOCUMENTED` and asserted **by equality, not as a floor**. Adding an undocumented rule fails, *and* documenting one of the listed rules also fails until the list is updated. The list can only shrink, and the failure tells you to remove the entry. `MD057` is referenced by the example config but deliberately never registered (a reserved markdownlint number), recorded the same way.

I chose this over writing sixteen rule pages in this PR: the pages need real examples and rationale to be worth anything, and that is a docs task rather than a test task. The test delivers its value now by stopping new drift.

## Verification

Confirmed the test catches drift rather than just passing:

| Injected fault | Result |
|---|---|
| Remove MD060 from the known list | `these rules are registered but have no documentation page: MD060` |
| Add `docs/src/rules/standard/md999.md` | `these documentation pages describe rules that are not registered: MD999` |
| Revert the collection-rule listing fix | `ADR010, ADR011, ADR012, ADR013` reported as orphans, plus the inventory guard fails |

The third is the bug this PR fixes, so the test would have caught it.

## Contributor documentation

`docs/src/contributing.md` gains a table of the surfaces a new or changed rule must update, the two conventions the test enforces (kebab-case names, reserved numbers never registered), and a note that new rules should start `experimental` so they can be dogfooded without exposing every user to unstable output.