### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-19
+
+### Bug Fixes
+- Define exact autofix coordinates ([#493](https://github.com/joshrotenberg/mdbook-lint/pull/493)) ([4557ed1](https://github.com/joshrotenberg/mdbook-lint/commit/4557ed1afa9b6ccd59d3b6340f9f45e66ec3758f))
+- *(rules)* Correct MD011, MD034, and MD047 autofix corruption ([#486](https://github.com/joshrotenberg/mdbook-lint/pull/486)) ([4a0ddef](https://github.com/joshrotenberg/mdbook-lint/commit/4a0ddefcaff24a5c2c71ac5cd810dac588dd401a))
+- *(lsp)* Load config for all markdown projects, not only mdBook ([#400](https://github.com/joshrotenberg/mdbook-lint/pull/400)) ([98310a8](https://github.com/joshrotenberg/mdbook-lint/commit/98310a8d6f52b68630080c41d2546bd9a2d31df7))
+- Ignore MD018 paragraph continuation lines ([#492](https://github.com/joshrotenberg/mdbook-lint/pull/492)) ([b9b64a6](https://github.com/joshrotenberg/mdbook-lint/commit/b9b64a663af2758a2367e27dfa8d35f55e9a4629))
+- *(rules)* Stop ADR014 reporting ordinary prose as placeholder text ([#487](https://github.com/joshrotenberg/mdbook-lint/pull/487)) ([ab00ad1](https://github.com/joshrotenberg/mdbook-lint/commit/ab00ad1d3d34bce5c6ea8d99b8cd5fe53c9af97b))
+
+
+### Documentation
+- Write the 16 missing rule reference pages ([#488](https://github.com/joshrotenberg/mdbook-lint/pull/488)) ([ba692e6](https://github.com/joshrotenberg/mdbook-lint/commit/ba692e61e153fa0b906c9ee3721add0777899f6f))
+
+
+### Features
+- Add baseline rule preset ([#494](https://github.com/joshrotenberg/mdbook-lint/pull/494)) ([d24a70a](https://github.com/joshrotenberg/mdbook-lint/commit/d24a70a1e405b9876f41392c2d4941ba84f935c0))
+- *(cli)* Implement SARIF v2.1.0 output ([#485](https://github.com/joshrotenberg/mdbook-lint/pull/485)) ([59026a2](https://github.com/joshrotenberg/mdbook-lint/commit/59026a205e708540fd75a8c0c504e865a1d4f4d0))
+- *(rules)* [**breaking**] Make experimental rules opt-in ([#480](https://github.com/joshrotenberg/mdbook-lint/pull/480)) ([538a212](https://github.com/joshrotenberg/mdbook-lint/commit/538a21271ef323f5b044cd90c040fe96d2e9f060))
+
+
+### Refactoring
+- Unify ignore-pattern glob matching into mdbook-lint-core ([#489](https://github.com/joshrotenberg/mdbook-lint/pull/489)) ([d7be6c1](https://github.com/joshrotenberg/mdbook-lint/commit/d7be6c1e86291d3c1bca4654868c1829d9a91a6f))
+
+
+### Testing
+- Add a rule contract test across registry, docs, and example config ([#483](https://github.com/joshrotenberg/mdbook-lint/pull/483)) ([c508260](https://github.com/joshrotenberg/mdbook-lint/commit/c50826030cf1a85f85e67c3ff9e29761fb4d0fce))
+- *(rulesets)* Add edge case tests for MD020, MD028, MD036, MD042 ([#490](https://github.com/joshrotenberg/mdbook-lint/pull/490)) ([eeb49d0](https://github.com/joshrotenberg/mdbook-lint/commit/eeb49d0b736a54543ca3cf01c758159e0bdc6651))
+
+
+
 ### Features
 
 - Add the explicit `baseline` preset for low-noise CI adoption, with CLI, configuration, rules-discovery, and mdBook preprocessor support. ([#466](https://github.com/joshrotenberg/mdbook-lint/issues/466))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-core"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "comrak",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-lint-rulesets"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.2"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -41,8 +41,8 @@ walkdir = "2.3"
 glob = "0.3"
 
 # Internal workspace crates
-mdbook-lint-core = { version = "0.15.2", path = "crates/mdbook-lint-core" }
-mdbook-lint-rulesets = { version = "0.15.2", path = "crates/mdbook-lint-rulesets" }
+mdbook-lint-core = { version = "0.16.0", path = "crates/mdbook-lint-core" }
+mdbook-lint-rulesets = { version = "0.16.0", path = "crates/mdbook-lint-rulesets" }
 
 # Dev dependencies
 tempfile = "3.0"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-lint-core`: 0.15.2 -> 0.16.0 (⚠ API breaking changes)
* `mdbook-lint-rulesets`: 0.15.2 -> 0.16.0 (✓ API compatible changes)
* `mdbook-lint`: 0.15.2 -> 0.16.0 (⚠ API breaking changes)

### ⚠ `mdbook-lint-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.experimental_rules in /tmp/.tmp1KTHio/mdbook-lint/crates/mdbook-lint-core/src/config.rs:71
  field Config.experimental_rules in /tmp/.tmp1KTHio/mdbook-lint/crates/mdbook-lint-core/src/config.rs:71
```

### ⚠ `mdbook-lint` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.preset in /tmp/.tmp1KTHio/mdbook-lint/crates/mdbook-lint-cli/src/config.rs:18
  field Config.preset in /tmp/.tmp1KTHio/mdbook-lint/crates/mdbook-lint-cli/src/config.rs:18
  field Config.preset in /tmp/.tmp1KTHio/mdbook-lint/crates/mdbook-lint-cli/src/config.rs:18

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function mdbook_lint::ignore::path_is_ignored, previously in file /tmp/.tmp6VohEQ/mdbook-lint/src/ignore.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `mdbook-lint`

<blockquote>

## [0.16.0] - 2026-08-19

### Bug Fixes
- Define exact autofix coordinates ([#493](https://github.com/joshrotenberg/mdbook-lint/pull/493)) ([4557ed1](https://github.com/joshrotenberg/mdbook-lint/commit/4557ed1afa9b6ccd59d3b6340f9f45e66ec3758f))
- *(rules)* Correct MD011, MD034, and MD047 autofix corruption ([#486](https://github.com/joshrotenberg/mdbook-lint/pull/486)) ([4a0ddef](https://github.com/joshrotenberg/mdbook-lint/commit/4a0ddefcaff24a5c2c71ac5cd810dac588dd401a))
- *(lsp)* Load config for all markdown projects, not only mdBook ([#400](https://github.com/joshrotenberg/mdbook-lint/pull/400)) ([98310a8](https://github.com/joshrotenberg/mdbook-lint/commit/98310a8d6f52b68630080c41d2546bd9a2d31df7))
- Ignore MD018 paragraph continuation lines ([#492](https://github.com/joshrotenberg/mdbook-lint/pull/492)) ([b9b64a6](https://github.com/joshrotenberg/mdbook-lint/commit/b9b64a663af2758a2367e27dfa8d35f55e9a4629))
- *(rules)* Stop ADR014 reporting ordinary prose as placeholder text ([#487](https://github.com/joshrotenberg/mdbook-lint/pull/487)) ([ab00ad1](https://github.com/joshrotenberg/mdbook-lint/commit/ab00ad1d3d34bce5c6ea8d99b8cd5fe53c9af97b))


### Documentation
- Write the 16 missing rule reference pages ([#488](https://github.com/joshrotenberg/mdbook-lint/pull/488)) ([ba692e6](https://github.com/joshrotenberg/mdbook-lint/commit/ba692e61e153fa0b906c9ee3721add0777899f6f))


### Features
- Add baseline rule preset ([#494](https://github.com/joshrotenberg/mdbook-lint/pull/494)) ([d24a70a](https://github.com/joshrotenberg/mdbook-lint/commit/d24a70a1e405b9876f41392c2d4941ba84f935c0))
- *(cli)* Implement SARIF v2.1.0 output ([#485](https://github.com/joshrotenberg/mdbook-lint/pull/485)) ([59026a2](https://github.com/joshrotenberg/mdbook-lint/commit/59026a205e708540fd75a8c0c504e865a1d4f4d0))
- *(rules)* [**breaking**] Make experimental rules opt-in ([#480](https://github.com/joshrotenberg/mdbook-lint/pull/480)) ([538a212](https://github.com/joshrotenberg/mdbook-lint/commit/538a21271ef323f5b044cd90c040fe96d2e9f060))


### Refactoring
- Unify ignore-pattern glob matching into mdbook-lint-core ([#489](https://github.com/joshrotenberg/mdbook-lint/pull/489)) ([d7be6c1](https://github.com/joshrotenberg/mdbook-lint/commit/d7be6c1e86291d3c1bca4654868c1829d9a91a6f))


### Testing
- Add a rule contract test across registry, docs, and example config ([#483](https://github.com/joshrotenberg/mdbook-lint/pull/483)) ([c508260](https://github.com/joshrotenberg/mdbook-lint/commit/c50826030cf1a85f85e67c3ff9e29761fb4d0fce))
- *(rulesets)* Add edge case tests for MD020, MD028, MD036, MD042 ([#490](https://github.com/joshrotenberg/mdbook-lint/pull/490)) ([eeb49d0](https://github.com/joshrotenberg/mdbook-lint/commit/eeb49d0b736a54543ca3cf01c758159e0bdc6651))



### Features

- Add the explicit `baseline` preset for low-noise CI adoption, with CLI, configuration, rules-discovery, and mdBook preprocessor support. ([#466](https://github.com/joshrotenberg/mdbook-lint/issues/466))

### Changed

- Define `Fix` ranges as exact half-open ranges with 1-based Unicode-scalar
  columns, expose checked `Position`/byte-offset conversions, and make line
  terminator replacement versus boundary insertion explicit. Standard-rule
  fixes now preserve CRLF and do not add a newline at EOF implicitly. ([#456](https://github.com/joshrotenberg/mdbook-lint/issues/456))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).