### PR TITLE
feat(cli): implement SARIF v2.1.0 output

### DIFF
--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -5,6 +5,7 @@ mod lsp_server;
 mod output;
 mod preprocessor;
 mod rustdoc;
+mod sarif;
 
 use ignore::filter_ignored_paths;
 
@@ -24,7 +25,7 @@ use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -104,6 +105,9 @@ enum Commands {
         /// Control colored output (auto, always, never)
         #[arg(long, value_enum, default_value = "auto")]
         color: ColorChoice,
+        /// Write the report to a file instead of stdout (used with --output sarif)
+        #[arg(long, value_name = "PATH")]
+        output_file: Option<PathBuf>,
     },
 
     /// Automatically fix issues in markdown files (shorthand for `lint --fix`)
@@ -243,6 +247,8 @@ enum OutputFormat {
     Json,
     /// GitHub Actions format
     Github,
+    /// SARIF v2.1.0 for code scanning tools
+    Sarif,
 }
 
 #[derive(ValueEnum, Clone, PartialEq, Debug)]
@@ -573,6 +579,7 @@ fn main() {
             disable,
             enable,
             color,
+            output_file,
         }) => {
             // Set up color choice before running
             match color {
@@ -596,6 +603,7 @@ fn main() {
                 enable.as_ref(),
                 cli.verbose,
                 cli.quiet,
+                output_file.as_deref(),
             )
         }
         Some(Commands::Fix {
@@ -633,6 +641,7 @@ fn main() {
                 enable.as_ref(),
                 cli.verbose,
                 cli.quiet,
+                None, // fix subcommand has no report file
             )
         }
         Some(Commands::Rules {
@@ -771,6 +780,47 @@ fn create_backup_file(path: &PathBuf) -> Result<()> {
     Ok(())
 }
 
+/// Emit a SARIF report to `output_file`, or to stdout when no path is given.
+///
+/// Writing to a file keeps stdout clean so normal diagnostics and the process
+/// exit status are unaffected, which is what the CI documentation describes.
+fn emit_sarif(
+    violations_by_file: &[(String, Vec<mdbook_lint_core::violation::Violation>)],
+    engine: &mdbook_lint_core::LintEngine,
+    output_file: Option<&Path>,
+) -> Result<()> {
+    let report = sarif::build_report(violations_by_file, engine);
+    let rendered = serde_json::to_string_pretty(&report).map_err(|e| {
+        mdbook_lint::error::MdBookLintError::config_error(format!(
+            "Failed to serialize SARIF report: {e}"
+        ))
+    })?;
+
+    match output_file {
+        Some(path) => {
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    mdbook_lint::error::MdBookLintError::config_error(format!(
+                        "Failed to create directory for {}: {e}",
+                        path.display()
+                    ))
+                })?;
+            }
+            std::fs::write(path, rendered).map_err(|e| {
+                mdbook_lint::error::MdBookLintError::config_error(format!(
+                    "Failed to write SARIF report to {}: {e}",
+                    path.display()
+                ))
+            })?;
+        }
+        None => println!("{rendered}"),
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_cli_mode(
     files: &[String],
@@ -788,6 +838,7 @@ fn run_cli_mode(
     enable: Option<&Vec<String>>,
     verbose: bool,
     quiet: bool,
+    output_file: Option<&Path>,
 ) -> Result<()> {
     // Validate mutually exclusive flags
     if standard_only && mdbook_only {
@@ -1208,6 +1259,9 @@ fn run_cli_mode(
                     );
                 }
             }
+        }
+        OutputFormat::Sarif => {
+            emit_sarif(&violations_by_file, &engine, output_file)?;
         }
     }
 
@@ -1986,6 +2040,10 @@ fn run_rustdoc_mode(
                     );
                 }
             }
+        }
+        OutputFormat::Sarif => {
+            // The rustdoc command has no --output-file flag; redirect stdout instead.
+            emit_sarif(&violations_by_file, &engine, None)?;
         }
     }
 

--- a/crates/mdbook-lint-cli/src/sarif.rs
+++ b/crates/mdbook-lint-cli/src/sarif.rs
@@ -1,0 +1,467 @@
+//! SARIF v2.1.0 report generation.
+//!
+//! The CI documentation and the companion GitHub Action have advertised SARIF
+//! output for some time (issue #471). This module implements it against the
+//! OASIS SARIF 2.1.0 schema, deriving rule descriptors from `RuleMetadata` so
+//! the report stays consistent with the registry.
+
+use mdbook_lint_core::{LintEngine, Severity, Violation};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Schema URL emitted in the report.
+const SARIF_SCHEMA: &str = "https://json.schemastore.org/sarif-2.1.0.json";
+
+/// SARIF specification version this report conforms to.
+const SARIF_VERSION: &str = "2.1.0";
+
+/// Tool home page, reported as the driver's `informationUri`.
+const INFORMATION_URI: &str = "https://github.com/joshrotenberg/mdbook-lint";
+
+/// Base URL of the published rule reference.
+const DOCS_BASE_URI: &str = "https://joshrotenberg.github.io/mdbook-lint/rules";
+
+/// Map a violation severity onto a SARIF result level.
+///
+/// SARIF defines `none`, `note`, `warning`, and `error`. Info maps to `note`,
+/// which is how code-scanning surfaces advisory results.
+fn sarif_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Info => "note",
+    }
+}
+
+/// Documentation sub-path for a rule ID.
+///
+/// `MDBOOK` is checked before `MD`, since the former also starts with `MD`.
+fn docs_subdir(rule_id: &str) -> Option<&'static str> {
+    if rule_id.starts_with("MDBOOK") {
+        Some("mdbook")
+    } else if rule_id.starts_with("CONTENT") {
+        Some("content")
+    } else if rule_id.starts_with("ADR") {
+        Some("adr")
+    } else if rule_id.starts_with("MD") {
+        Some("standard")
+    } else {
+        None
+    }
+}
+
+/// Published documentation URL for a rule, when its ruleset is recognized.
+fn help_uri(rule_id: &str) -> Option<String> {
+    let subdir = docs_subdir(rule_id)?;
+    Some(format!(
+        "{DOCS_BASE_URI}/{subdir}/{}.html",
+        rule_id.to_lowercase()
+    ))
+}
+
+/// Normalize a file path into a SARIF `artifactLocation` URI.
+///
+/// SARIF consumers, GitHub code scanning in particular, expect paths relative
+/// to the repository root with forward slashes. Absolute paths under the
+/// working directory are made relative; anything else is passed through with
+/// separators normalized.
+fn artifact_uri(path: &str) -> String {
+    let path = Path::new(path);
+
+    let relative = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(&cwd).ok().map(Path::to_path_buf))
+        .unwrap_or_else(|| path.to_path_buf());
+
+    relative
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_string()
+}
+
+/// Build a rule descriptor for the driver's `rules` array.
+///
+/// Metadata comes from the registry where the rule is known. A violation always
+/// carries an ID, name, and message, so a descriptor can still be produced for
+/// a rule the registry cannot resolve.
+fn rule_descriptor(rule_id: &str, rule_name: &str, engine: &LintEngine) -> Value {
+    let mut descriptor = json!({
+        "id": rule_id,
+        "name": rule_name,
+    });
+
+    if let Some(uri) = help_uri(rule_id) {
+        descriptor["helpUri"] = json!(uri);
+    }
+
+    // Document rules and collection rules live in separate registry lists.
+    let registry = engine.registry();
+    let resolved = registry
+        .get_rule(rule_id)
+        .map(|r| (r.description().to_string(), r.metadata()))
+        .or_else(|| {
+            registry
+                .get_collection_rule(rule_id)
+                .map(|r| (r.description().to_string(), r.metadata()))
+        });
+
+    if let Some((description, metadata)) = resolved {
+        descriptor["shortDescription"] = json!({ "text": description });
+
+        let mut properties = json!({
+            "category": format!("{:?}", metadata.category),
+            "stability": format!("{:?}", metadata.stability),
+            "runsByDefault": metadata.runs_by_default(),
+        });
+        if let Some(version) = metadata.introduced_in {
+            properties["introducedIn"] = json!(version);
+        }
+        if metadata.deprecated {
+            properties["deprecated"] = json!(true);
+            if let Some(reason) = metadata.deprecated_reason {
+                properties["deprecatedReason"] = json!(reason);
+            }
+        }
+        descriptor["properties"] = properties;
+    }
+
+    descriptor
+}
+
+/// Build a complete SARIF v2.1.0 report for the given violations.
+///
+/// Rule descriptors are emitted for the rules that actually produced results,
+/// and each result references its descriptor by `ruleIndex`.
+pub fn build_report(violations_by_file: &[(String, Vec<Violation>)], engine: &LintEngine) -> Value {
+    // Stable descriptor ordering, so repeated runs over the same input produce
+    // byte-identical reports.
+    let mut rule_names: BTreeMap<&str, &str> = BTreeMap::new();
+    for (_, violations) in violations_by_file {
+        for violation in violations {
+            rule_names
+                .entry(violation.rule_id.as_str())
+                .or_insert(violation.rule_name.as_str());
+        }
+    }
+
+    let rule_index: BTreeMap<&str, usize> = rule_names
+        .keys()
+        .enumerate()
+        .map(|(index, id)| (*id, index))
+        .collect();
+
+    let rules: Vec<Value> = rule_names
+        .iter()
+        .map(|(id, name)| rule_descriptor(id, name, engine))
+        .collect();
+
+    // Results are sorted by location and then rule ID. The engine does not
+    // guarantee an order for violations reported at the same position, so two
+    // runs over identical input could otherwise emit results in different
+    // orders, producing spurious diffs and defeating caching.
+    let mut ordered: Vec<(String, usize, usize, &str, Value)> = violations_by_file
+        .iter()
+        .flat_map(|(file_path, violations)| {
+            let uri = artifact_uri(file_path);
+            let rule_index = &rule_index;
+            violations.iter().map(move |violation| {
+                let mut region = json!({ "startLine": violation.line.max(1) });
+                if violation.column > 0 {
+                    region["startColumn"] = json!(violation.column);
+                }
+
+                let mut result = json!({
+                    "ruleId": violation.rule_id,
+                    "level": sarif_level(violation.severity),
+                    "message": { "text": violation.message },
+                    "locations": [{
+                        "physicalLocation": {
+                            "artifactLocation": { "uri": uri },
+                            "region": region,
+                        }
+                    }],
+                });
+
+                if let Some(index) = rule_index.get(violation.rule_id.as_str()) {
+                    result["ruleIndex"] = json!(index);
+                }
+
+                (
+                    uri.clone(),
+                    violation.line,
+                    violation.column,
+                    violation.rule_id.as_str(),
+                    result,
+                )
+            })
+        })
+        .collect();
+
+    ordered.sort_by(|a, b| {
+        (&a.0, a.1, a.2, a.3)
+            .cmp(&(&b.0, b.1, b.2, b.3))
+            .then_with(|| a.4.to_string().cmp(&b.4.to_string()))
+    });
+
+    let results: Vec<Value> = ordered
+        .into_iter()
+        .map(|(_, _, _, _, value)| value)
+        .collect();
+
+    json!({
+        "$schema": SARIF_SCHEMA,
+        "version": SARIF_VERSION,
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "mdbook-lint",
+                    "version": env!("CARGO_PKG_VERSION"),
+                    "semanticVersion": env!("CARGO_PKG_VERSION"),
+                    "informationUri": INFORMATION_URI,
+                    "rules": rules,
+                }
+            },
+            "results": results,
+        }]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdbook_lint_core::PluginRegistry;
+    use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
+
+    fn test_engine() -> LintEngine {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(StandardRuleProvider))
+            .unwrap();
+        registry
+            .register_provider(Box::new(MdBookRuleProvider))
+            .unwrap();
+        registry.create_engine().unwrap()
+    }
+
+    fn violation(rule_id: &str, rule_name: &str, line: usize, column: usize) -> Violation {
+        Violation {
+            rule_id: rule_id.to_string(),
+            rule_name: rule_name.to_string(),
+            message: format!("{rule_id} fired"),
+            line,
+            column,
+            severity: Severity::Warning,
+            fix: None,
+        }
+    }
+
+    #[test]
+    fn test_report_has_required_sarif_envelope() {
+        let report = build_report(&[], &test_engine());
+
+        assert_eq!(report["version"], SARIF_VERSION);
+        assert_eq!(report["$schema"], SARIF_SCHEMA);
+
+        let driver = &report["runs"][0]["tool"]["driver"];
+        assert_eq!(driver["name"], "mdbook-lint");
+        assert_eq!(driver["informationUri"], INFORMATION_URI);
+        assert!(!driver["version"].as_str().unwrap().is_empty());
+
+        // An empty run is still a valid report with an empty results array.
+        assert_eq!(report["runs"][0]["results"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_severity_maps_to_sarif_levels() {
+        assert_eq!(sarif_level(Severity::Error), "error");
+        assert_eq!(sarif_level(Severity::Warning), "warning");
+        assert_eq!(sarif_level(Severity::Info), "note");
+    }
+
+    #[test]
+    fn test_results_carry_location_and_rule_index() {
+        let violations = vec![(
+            "docs/guide.md".to_string(),
+            vec![violation("MD001", "heading-increment", 4, 2)],
+        )];
+        let report = build_report(&violations, &test_engine());
+
+        let result = &report["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "MD001");
+        assert_eq!(result["level"], "warning");
+        assert_eq!(result["message"]["text"], "MD001 fired");
+
+        let location = &result["locations"][0]["physicalLocation"];
+        assert_eq!(location["artifactLocation"]["uri"], "docs/guide.md");
+        assert_eq!(location["region"]["startLine"], 4);
+        assert_eq!(location["region"]["startColumn"], 2);
+
+        // ruleIndex must point at the matching descriptor.
+        let index = result["ruleIndex"].as_u64().unwrap() as usize;
+        let rules = report["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rules[index]["id"], "MD001");
+    }
+
+    #[test]
+    fn test_rule_descriptors_are_deduplicated_and_sourced_from_metadata() {
+        let violations = vec![
+            (
+                "a.md".to_string(),
+                vec![
+                    violation("MD001", "heading-increment", 1, 1),
+                    violation("MD001", "heading-increment", 9, 1),
+                ],
+            ),
+            (
+                "b.md".to_string(),
+                vec![violation("MD009", "no-trailing-spaces", 2, 1)],
+            ),
+        ];
+        let report = build_report(&violations, &test_engine());
+
+        let rules = report["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rules.len(), 2, "one descriptor per distinct rule");
+
+        let md001 = rules.iter().find(|r| r["id"] == "MD001").unwrap();
+        assert_eq!(md001["name"], "heading-increment");
+        // Description and properties come from the registry, not the violation.
+        assert!(
+            md001["shortDescription"]["text"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty())
+        );
+        assert_eq!(md001["properties"]["category"], "Structure");
+        assert_eq!(md001["properties"]["stability"], "Stable");
+        assert_eq!(
+            md001["helpUri"],
+            "https://joshrotenberg.github.io/mdbook-lint/rules/standard/md001.html"
+        );
+
+        assert_eq!(report["runs"][0]["results"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_unknown_rule_still_produces_a_descriptor() {
+        // A violation from a rule the registry cannot resolve must not be dropped.
+        let violations = vec![(
+            "a.md".to_string(),
+            vec![violation("ZZZ999", "mystery", 1, 1)],
+        )];
+        let report = build_report(&violations, &test_engine());
+
+        let rules = report["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0]["id"], "ZZZ999");
+        assert!(rules[0]["shortDescription"].is_null());
+        assert!(
+            rules[0]["helpUri"].is_null(),
+            "no docs path for unknown prefix"
+        );
+        assert_eq!(report["runs"][0]["results"][0]["ruleId"], "ZZZ999");
+    }
+
+    #[test]
+    fn test_help_uri_routes_by_ruleset() {
+        assert!(help_uri("MD001").unwrap().contains("/standard/md001.html"));
+        assert!(
+            help_uri("MDBOOK005")
+                .unwrap()
+                .contains("/mdbook/mdbook005.html"),
+            "MDBOOK must not be treated as MD"
+        );
+        assert!(help_uri("CONTENT004").unwrap().contains("/content/"));
+        assert!(help_uri("ADR001").unwrap().contains("/adr/"));
+        assert!(help_uri("ZZZ999").is_none());
+    }
+
+    #[test]
+    fn test_artifact_uri_normalizes_separators() {
+        assert_eq!(artifact_uri("docs/guide.md"), "docs/guide.md");
+        assert_eq!(artifact_uri("./docs/guide.md"), "docs/guide.md");
+        assert_eq!(artifact_uri(r"docs\guide.md"), "docs/guide.md");
+    }
+
+    #[test]
+    fn test_results_are_sorted_by_location_then_rule() {
+        // The engine does not order violations reported at the same position, so
+        // the report imposes its own order. Without this, two runs over identical
+        // input could emit results in different orders.
+        let violations = vec![
+            (
+                "b.md".to_string(),
+                vec![violation("MD009", "no-trailing-spaces", 5, 1)],
+            ),
+            (
+                "a.md".to_string(),
+                vec![
+                    violation("MD060", "z-rule", 3, 1),
+                    violation("MD001", "heading-increment", 3, 1),
+                    violation("MD001", "heading-increment", 1, 1),
+                ],
+            ),
+        ];
+        let report = build_report(&violations, &test_engine());
+        let results = report["runs"][0]["results"].as_array().unwrap();
+
+        let order: Vec<(String, u64, String)> = results
+            .iter()
+            .map(|r| {
+                (
+                    r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                    r["locations"][0]["physicalLocation"]["region"]["startLine"]
+                        .as_u64()
+                        .unwrap(),
+                    r["ruleId"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            order,
+            vec![
+                ("a.md".to_string(), 1, "MD001".to_string()),
+                ("a.md".to_string(), 3, "MD001".to_string()),
+                ("a.md".to_string(), 3, "MD060".to_string()),
+                ("b.md".to_string(), 5, "MD009".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_report_is_deterministic() {
+        let violations = vec![(
+            "a.md".to_string(),
+            vec![
+                violation("MD009", "no-trailing-spaces", 1, 1),
+                violation("MD001", "heading-increment", 2, 1),
+            ],
+        )];
+        let engine = test_engine();
+
+        let first = serde_json::to_string(&build_report(&violations, &engine)).unwrap();
+        let second = serde_json::to_string(&build_report(&violations, &engine)).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_zero_column_is_omitted_rather_than_emitted_as_zero() {
+        // SARIF columns are 1-based; 0 is not a legal startColumn.
+        let violations = vec![("a.md".to_string(), vec![violation("MD001", "x", 3, 0)])];
+        let report = build_report(&violations, &test_engine());
+
+        let region = &report["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"];
+        assert_eq!(region["startLine"], 3);
+        assert!(region["startColumn"].is_null());
+    }
+}

--- a/crates/mdbook-lint-cli/tests/sarif_output_test.rs
+++ b/crates/mdbook-lint-cli/tests/sarif_output_test.rs
@@ -1,0 +1,230 @@
+//! End-to-end tests for `--output sarif` (issue #471).
+//!
+//! The CI guide and the companion GitHub Action advertised SARIF before the CLI
+//! could emit it. These tests exercise the real binary and assert the structure
+//! that code-scanning consumers depend on.
+//!
+//! The emitted report was additionally validated against the OASIS SARIF 2.1.0
+//! JSON schema during development; that check needs network access and a JSON
+//! Schema implementation, so it is not run here.
+
+mod common;
+
+use common::cli_command;
+use serde_json::Value;
+use std::fs;
+use tempfile::TempDir;
+
+/// Trips MD001 (error) and MD009 (warning).
+const CONTENT: &str = "# Level 1\n\n### Skipped level 2\n\nTrailing spaces.   \n";
+
+/// Run the linter over a fixture and return the parsed SARIF report.
+fn sarif_for(content: &str, extra_args: &[&str]) -> Value {
+    let temp = TempDir::new().unwrap();
+    let doc = temp.path().join("doc.md");
+    fs::write(&doc, content).unwrap();
+
+    let mut cmd = cli_command();
+    cmd.arg("lint").arg("--output").arg("sarif");
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+    let assert = cmd.arg(&doc).assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\n{stdout}"))
+}
+
+#[test]
+fn test_sarif_envelope_is_well_formed() {
+    let report = sarif_for(CONTENT, &[]);
+
+    assert_eq!(report["version"], "2.1.0");
+    assert!(
+        report["$schema"].as_str().unwrap().contains("sarif"),
+        "expected a SARIF schema URL"
+    );
+
+    let driver = &report["runs"][0]["tool"]["driver"];
+    assert_eq!(driver["name"], "mdbook-lint");
+    assert!(
+        driver["informationUri"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://")
+    );
+    assert!(!driver["version"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn test_results_reference_rules_and_locations() {
+    let report = sarif_for(CONTENT, &[]);
+
+    let results = report["runs"][0]["results"].as_array().unwrap();
+    assert!(!results.is_empty(), "expected violations to be reported");
+
+    let rules = report["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .unwrap();
+
+    for result in results {
+        // Every result carries a level SARIF recognizes.
+        let level = result["level"].as_str().unwrap();
+        assert!(
+            matches!(level, "error" | "warning" | "note"),
+            "unexpected SARIF level: {level}"
+        );
+
+        assert!(!result["message"]["text"].as_str().unwrap().is_empty());
+
+        let region = &result["locations"][0]["physicalLocation"]["region"];
+        assert!(
+            region["startLine"].as_u64().unwrap() >= 1,
+            "SARIF regions are 1-based"
+        );
+        if let Some(column) = region["startColumn"].as_u64() {
+            assert!(column >= 1, "SARIF columns are 1-based");
+        }
+
+        let uri = result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+            .as_str()
+            .unwrap();
+        assert!(!uri.is_empty());
+        assert!(!uri.contains('\\'), "URIs use forward slashes: {uri}");
+
+        // ruleIndex must resolve to the descriptor for this result's rule.
+        let index = result["ruleIndex"].as_u64().unwrap() as usize;
+        assert_eq!(rules[index]["id"], result["ruleId"]);
+    }
+}
+
+#[test]
+fn test_rule_descriptors_carry_metadata() {
+    let report = sarif_for(CONTENT, &[]);
+    let rules = report["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .unwrap();
+
+    let md001 = rules
+        .iter()
+        .find(|r| r["id"] == "MD001")
+        .expect("MD001 should have a descriptor");
+
+    assert_eq!(md001["name"], "heading-increment");
+    assert!(
+        !md001["shortDescription"]["text"]
+            .as_str()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        md001["helpUri"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://joshrotenberg.github.io/mdbook-lint/rules/"),
+        "descriptors should link to the published rule reference"
+    );
+    assert_eq!(md001["properties"]["stability"], "Stable");
+}
+
+#[test]
+fn test_clean_run_emits_a_valid_empty_report() {
+    // Code scanning still needs a report to upload when nothing was found.
+    let report = sarif_for(
+        "# Title\n\nA clean paragraph of prose.\n",
+        &["--enable", "MD001"],
+    );
+
+    assert_eq!(report["version"], "2.1.0");
+    assert_eq!(report["runs"][0]["results"].as_array().unwrap().len(), 0);
+    assert_eq!(
+        report["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn test_output_file_writes_report_and_keeps_stdout_clean() {
+    let temp = TempDir::new().unwrap();
+    let doc = temp.path().join("doc.md");
+    fs::write(&doc, CONTENT).unwrap();
+    // A nested path exercises parent-directory creation.
+    let report_path = temp.path().join("reports/results.sarif");
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--output")
+        .arg("sarif")
+        .arg("--output-file")
+        .arg(&report_path)
+        .arg(&doc)
+        .assert();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        !stdout.contains("\"$schema\""),
+        "report should go to the file, not stdout"
+    );
+
+    let written = fs::read_to_string(&report_path).expect("report file should exist");
+    let report: Value = serde_json::from_str(&written).expect("report file should be valid JSON");
+    assert_eq!(report["version"], "2.1.0");
+    assert!(!report["runs"][0]["results"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn test_exit_status_still_reflects_findings() {
+    let temp = TempDir::new().unwrap();
+    let doc = temp.path().join("doc.md");
+    fs::write(&doc, CONTENT).unwrap();
+    let report_path = temp.path().join("results.sarif");
+
+    // Errors present: non-zero exit, report still written.
+    cli_command()
+        .arg("lint")
+        .arg("--output")
+        .arg("sarif")
+        .arg("--output-file")
+        .arg(&report_path)
+        .arg(&doc)
+        .assert()
+        .failure();
+    assert!(report_path.exists(), "report is written even when failing");
+
+    // Clean input: success.
+    let clean = temp.path().join("clean.md");
+    fs::write(&clean, "# Title\n\nA clean paragraph of prose.\n").unwrap();
+    cli_command()
+        .arg("lint")
+        .arg("--output")
+        .arg("sarif")
+        .arg("--enable")
+        .arg("MD001")
+        .arg(&clean)
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_report_is_byte_identical_across_runs() {
+    // Deterministic output keeps diffs and caching meaningful.
+    let temp = TempDir::new().unwrap();
+    let doc = temp.path().join("doc.md");
+    fs::write(&doc, CONTENT).unwrap();
+
+    let run = || {
+        let assert = cli_command()
+            .arg("lint")
+            .arg("--output")
+            .arg("sarif")
+            .arg(&doc)
+            .assert();
+        String::from_utf8(assert.get_output().stdout.clone()).unwrap()
+    };
+
+    assert_eq!(run(), run());
+}

--- a/docs/src/ci-vs-preprocessor.md
+++ b/docs/src/ci-vs-preprocessor.md
@@ -132,10 +132,43 @@ jobs:
 # Optional: Upload SARIF results
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
 ```
+
+### SARIF output
+
+The CLI emits SARIF v2.1.0 directly:
+
+```bash
+mdbook-lint lint docs/ --output sarif --output-file results.sarif
+```
+
+`--output-file` writes the report to disk and leaves stdout clean, so normal
+diagnostics and the process exit status are unaffected. The report is written
+even when the run fails, which is what a code-scanning upload step needs:
+
+```yaml
+      - name: Lint Markdown
+        run: mdbook-lint lint docs/ --output sarif --output-file results.sarif
+        continue-on-error: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: results.sarif
+```
+
+A clean run still produces a valid report with an empty `results` array, so the
+upload step does not need to special-case it.
+
+Each result carries the rule ID, a severity mapped to the SARIF levels
+(`error`, `warning`, `note`), and a 1-based line and column. Rule descriptors are
+derived from rule metadata and link to the published rule reference. Results are
+sorted by location, so repeated runs over unchanged input produce identical
+reports.
 
 **Advantages:**
 

--- a/docs/src/cli-usage.md
+++ b/docs/src/cli-usage.md
@@ -109,7 +109,8 @@ mdbook-lint help [COMMAND]
 - `--fix-unsafe`: Apply all fixes, including potentially unsafe ones
 - `--dry-run`: Show what would be fixed without applying changes (requires --fix or --fix-unsafe)
 - `--no-backup`: Skip creating backup files when applying fixes
-- `--output <FORMAT>`: Output format (default, JSON, GitHub)
+- `--output <FORMAT>`: Output format (`default`, `json`, `github`, `sarif`)
+- `--output-file <PATH>`: Write the report to a file instead of stdout, used with `--output sarif`
 - `--color <WHEN>`: Control colored output (auto, always, never)
 
 ### Rules Options


### PR DESCRIPTION
Closes #471

## Problem

The CI guide and the companion GitHub Action advertised SARIF output that the CLI could not produce. `OutputFormat` carried only `Default`, `Json`, and `Github`. The action accepts `format: sarif` and falls back to JSON, after which its SARIF upload contract cannot be satisfied: `upload-sarif` receives a file that is not SARIF.

## Change

`--output sarif` emits a SARIF v2.1.0 report, and `--output-file <PATH>` writes it to disk.

```bash
mdbook-lint lint docs/ --output sarif --output-file results.sarif
```

The report is built in a new `sarif` module:

- Driver `name`, `version`, `semanticVersion`, and `informationUri`.
- One rule descriptor per rule that produced results, with description, category, stability, and introduced-in taken from `RuleMetadata` rather than restated, so descriptors cannot drift from the registry.
- `helpUri` linking each rule to the published reference.
- Severity mapped to `error`, `warning`, `note`.
- 1-based `startLine`, and `startColumn` only when a column is known, since SARIF columns are 1-based and `0` is not legal.
- Artifact URIs relative to the working directory with forward slashes, which is what GitHub code scanning expects.

Descriptors resolve through **both** the document and collection registries, so the cross-document ADR rules are described rather than skipped. That reuses the `get_collection_rule` lookup added in #483.

## A defect the tests caught

Results were non-deterministic. The engine does not order violations reported at the same position, and the round-trip test caught two runs over identical input emitting results in different orders:

```text
run 1: MD001(line 3), CONTENT005(line 3), MD009(line 5)
run 2: CONTENT005(line 3), MD001(line 3), MD009(line 5)
```

Results are now sorted by artifact, line, column, then rule ID, so reports are byte-identical across runs. That matters for diffing reports and for caching. Rule descriptors were already stable via `BTreeMap`; only the results array varied.

## Verification

The emitted report was validated against the **OASIS SARIF 2.1.0 JSON schema** (`sarif-schema-2.1.0.json`, Draft-04) using a real report generated by the binary:

```text
validator: Draft4Validator
VALID against OASIS SARIF 2.1.0 schema
```

That check needs network access and a JSON Schema implementation, so the committed tests assert structure rather than running it in CI. Worth adding as an optional CI step later.

Behavior confirmed end to end:

| Case | Result |
|---|---|
| File under CWD | `"uri": "sarif-doc.md"` (relative, as code scanning wants) |
| `--output-file reports/x.sarif` | parent directory created, stdout stays clean |
| Errors present | report still written, exit code 1 |
| Clean run | valid report with empty `results`, exit code 0 |
| Two identical runs | byte-identical output |

## Docs

`ci-vs-preprocessor.md` gains a SARIF section using the flags that now exist, including a `continue-on-error` + `if: always()` upload pattern so the report uploads even when linting fails. Its `upload-sarif@v2` reference is bumped to `v3`. `cli-usage.md` lists `sarif` and `--output-file`.

## Out of scope

The issue also asks that the companion action stop silently treating JSON as SARIF. That lives in `joshrotenberg/mdbook-lint-action` and needs a change there once a release with this ships. The `rustdoc` subcommand accepts `--output sarif` and writes to stdout; it has no `--output-file` flag, which can be added if wanted.