### PR TITLE
fix(rules): correct MD011, MD034, and MD047 autofix corruption

### DIFF
--- a/crates/mdbook-lint-cli/tests/fix_conformance_test.rs
+++ b/crates/mdbook-lint-cli/tests/fix_conformance_test.rs
@@ -1,0 +1,202 @@
+//! Conformance tests for automatic fixes (issue #456).
+//!
+//! Every case here applies fixes through `LintEngine::apply_fixes` and then
+//! re-lints the result. The rule-level tests that existed before asserted the
+//! shape of `Fix` objects without ever applying them, which is how three
+//! corruption bugs shipped:
+//!
+//! - MD011 left a stray `]` because the end position pointed at the bracket
+//!   rather than one past it, and fix ranges are end-exclusive.
+//! - MD034 wrapped Liquid syntax into the URL, and rejected multibyte URLs
+//!   because the span mixed a char index with a byte length.
+//! - MD047 replaced the final newline with itself, reporting a file as fixed
+//!   while leaving it unchanged.
+//!
+//! Applying a fix and re-linting catches all three; inspecting the `Fix` does
+//! not.
+
+use mdbook_lint::Config;
+use mdbook_lint_core::{Document, PluginRegistry};
+use mdbook_lint_rulesets::StandardRuleProvider;
+use std::path::PathBuf;
+
+/// Lint `content` with only `rule_id` enabled.
+fn lint(content: &str, rule_id: &str) -> (Vec<mdbook_lint_core::Violation>, Config) {
+    let mut config = Config::default();
+    config.core.enabled_rules = vec![rule_id.to_string()];
+
+    let mut registry = PluginRegistry::new();
+    registry
+        .register_provider(Box::new(StandardRuleProvider))
+        .unwrap();
+    let engine = registry.create_engine().unwrap();
+
+    let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+    let violations = engine
+        .lint_document_with_config(&document, &config.core)
+        .unwrap();
+    (violations, config)
+}
+
+/// Apply every available fix for `rule_id` once, returning the new content.
+fn fix_once(content: &str, rule_id: &str) -> String {
+    let (violations, _) = lint(content, rule_id);
+    if violations.is_empty() {
+        return content.to_string();
+    }
+
+    let mut registry = PluginRegistry::new();
+    registry
+        .register_provider(Box::new(StandardRuleProvider))
+        .unwrap();
+    let engine = registry.create_engine().unwrap();
+
+    let (fixed, _unfixed) = engine.apply_fixes(content, &violations);
+    fixed
+}
+
+/// Apply fixes, assert the result matches `expected`, and assert the rule is
+/// then silent and a second pass changes nothing.
+fn assert_fixes_to(content: &str, rule_id: &str, expected: &str) {
+    let fixed = fix_once(content, rule_id);
+    assert_eq!(
+        fixed, expected,
+        "{rule_id} produced unexpected output\n  input:    {content:?}\n  expected: {expected:?}\n  actual:   {fixed:?}"
+    );
+
+    let (remaining, _) = lint(&fixed, rule_id);
+    assert!(
+        remaining.is_empty(),
+        "{rule_id} still reports {} violation(s) after fixing: {:?}",
+        remaining.len(),
+        remaining.iter().map(|v| &v.message).collect::<Vec<_>>()
+    );
+
+    let twice = fix_once(&fixed, rule_id);
+    assert_eq!(twice, fixed, "{rule_id} fix is not idempotent");
+}
+
+#[test]
+fn test_md011_fixes_the_complete_reversed_link() {
+    // The stray ']' case from the issue.
+    assert_fixes_to(
+        "(text)[https://example.com]\n",
+        "MD011",
+        "[text](https://example.com)\n",
+    );
+}
+
+#[test]
+fn test_md011_fixes_reversed_link_mid_sentence() {
+    assert_fixes_to(
+        "Before (text)[url] after.\n",
+        "MD011",
+        "Before [text](url) after.\n",
+    );
+}
+
+#[test]
+fn test_md011_handles_multibyte_text_before_the_link() {
+    // Columns are char-based, so preceding multibyte text must not shift the span.
+    assert_fixes_to(
+        "Préface (café)[https://example.com] fin.\n",
+        "MD011",
+        "Préface [café](https://example.com) fin.\n",
+    );
+}
+
+#[test]
+fn test_md034_does_not_consume_liquid_syntax() {
+    assert_fixes_to(
+        "See https://example.com{% if foo %}\n",
+        "MD034",
+        "See <https://example.com>{% if foo %}\n",
+    );
+}
+
+#[test]
+fn test_md034_does_not_consume_handlebars_syntax() {
+    assert_fixes_to(
+        "See https://example.com{{ foo }}\n",
+        "MD034",
+        "See <https://example.com>{{ foo }}\n",
+    );
+}
+
+#[test]
+fn test_md034_fixes_multibyte_urls() {
+    // Previously rejected: the span mixed a char index with a byte length.
+    assert_fixes_to(
+        "Préface https://example.com/café\n",
+        "MD034",
+        "Préface <https://example.com/café>\n",
+    );
+}
+
+#[test]
+fn test_md034_leaves_already_wrapped_urls_alone() {
+    let content = "See <https://example.com> here.\n";
+    let (violations, _) = lint(content, "MD034");
+    assert!(violations.is_empty(), "got: {violations:?}");
+}
+
+#[test]
+fn test_md047_reduces_trailing_newlines_to_one() {
+    for input in [
+        "# Title\n\nBody.\n\n",
+        "# Title\n\nBody.\n\n\n",
+        "# Title\n\nBody.\n\n\n\n\n",
+    ] {
+        assert_fixes_to(input, "MD047", "# Title\n\nBody.\n");
+    }
+}
+
+#[test]
+fn test_md047_adds_a_missing_trailing_newline() {
+    assert_fixes_to("# Title\n\nBody.", "MD047", "# Title\n\nBody.\n");
+}
+
+#[test]
+fn test_md047_leaves_a_correct_ending_alone() {
+    let content = "# Title\n\nBody.\n";
+    let (violations, _) = lint(content, "MD047");
+    assert!(violations.is_empty(), "got: {violations:?}");
+}
+
+#[test]
+fn test_md047_handles_multibyte_final_line() {
+    assert_fixes_to(
+        "# Title\n\nPréface café\n\n",
+        "MD047",
+        "# Title\n\nPréface café\n",
+    );
+}
+
+#[test]
+fn test_fixes_are_idempotent_across_rules() {
+    // Applying each rule's fixes in turn must converge, not oscillate.
+    let content = "(text)[https://example.com/café]\n\n\n";
+
+    let mut current = content.to_string();
+    for rule in ["MD011", "MD034", "MD047"] {
+        current = fix_once(&current, rule);
+    }
+
+    // A second full pass must be a no-op.
+    let mut second = current.clone();
+    for rule in ["MD011", "MD034", "MD047"] {
+        second = fix_once(&second, rule);
+    }
+    assert_eq!(second, current, "combined fixes did not converge");
+
+    assert!(current.ends_with("]\n") || current.ends_with(")\n"));
+    assert!(
+        !current.ends_with("\n\n"),
+        "trailing newlines were not normalized: {current:?}"
+    );
+}
+
+#[test]
+fn test_multiple_violations_on_one_line_all_fixed() {
+    assert_fixes_to("(a)[u1] and (b)[u2]\n", "MD011", "[a](u1) and [b](u2)\n");
+}

--- a/crates/mdbook-lint-rulesets/src/standard/md011.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md011.rs
@@ -83,8 +83,13 @@ impl AstRule for MD011 {
                                 column: start_pos + 1,
                             },
                             end: Position {
+                                // Fix ranges are end-exclusive, so this must be
+                                // one past the closing ']': +1 to make end_pos
+                                // 1-based, +1 more to move past it. Using
+                                // end_pos + 1 pointed at the ']' itself and left
+                                // it stranded after the replacement.
                                 line: line_number + 1,
-                                column: end_pos + 1, // +1 because end_pos is 0-based position of ']'
+                                column: end_pos + 2,
                             },
                         };
 
@@ -171,7 +176,23 @@ mod tests {
     use super::*;
     use mdbook_lint_core::Document;
     use mdbook_lint_core::rule::Rule;
+    use mdbook_lint_core::{PluginRegistry, Violation};
     use std::path::PathBuf;
+
+    /// Apply the first violation's fix through the real engine.
+    ///
+    /// Asserting on `Fix` fields alone is what let the end-exclusive off-by-one
+    /// in issue #456 ship, so tests check the applied result.
+    fn apply_first_fix(content: &str, violations: &[Violation]) -> String {
+        let mut registry = PluginRegistry::new();
+        registry
+            .register_provider(Box::new(crate::StandardRuleProvider))
+            .unwrap();
+        let engine = registry.create_engine().unwrap();
+        engine
+            .apply_fix(content, &violations[0])
+            .expect("fix should apply")
+    }
 
     #[test]
     fn test_md011_no_violations() {
@@ -440,11 +461,20 @@ Some text before (reversed)[url] and text after.
         assert_eq!(fix.start.column, 18); // Position of opening paren
         assert_eq!(fix.end.line, 3);
         // The text is: "Some text before (reversed)[url] and text after."
-        // 0-based: position 17 is '(', position 31 is ']'
-        // 1-based: position 18 is '(', position 32 is ']'
-        // parse_reversed_link returns 31 (0-based position of ']')
-        // Fix adds +1 to convert to 1-based, so end.column = 32
-        assert_eq!(fix.end.column, 32);
+        // 1-based: column 18 is '(', column 32 is ']'.
+        // Fix ranges are end-exclusive, so the end is one past the ']'.
+        // This previously asserted 32, which pinned the off-by-one that left a
+        // stray ']' behind (issue #456).
+        assert_eq!(fix.end.column, 33);
+
+        // Assert on the applied result, not just the range. Checking the Fix
+        // fields alone is what allowed the off-by-one to ship.
+        let fixed = apply_first_fix(content, &violations);
+        assert!(
+            fixed.contains("[reversed](url) and text after."),
+            "fix left the line malformed: {fixed}"
+        );
+        assert!(!fixed.contains(")]"), "stray bracket remained: {fixed}");
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md034.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md034.rs
@@ -131,8 +131,13 @@ impl AstRule for MD034 {
                                 column: start_pos + 1,
                             },
                             end: Position {
+                                // start_pos is a char index, so the span must be
+                                // measured in chars too. url.len() is a byte
+                                // count, which overshot on any multibyte URL and
+                                // made the range invalid, silently dropping the
+                                // fix.
                                 line: line_number + 1,
-                                column: start_pos + url.len() + 1,
+                                column: start_pos + url.chars().count() + 1,
                             },
                         };
 
@@ -217,6 +222,13 @@ impl MD034 {
             let ch = chars[i];
             if ch.is_whitespace() || ch == ')' || ch == ']' || ch == '>' || ch == '"' || ch == '\''
             {
+                break;
+            }
+            // Template syntax that commonly abuts a URL is not part of it.
+            // Liquid and Handlebars/Tera use `{%` and `{{`; wrapping them in
+            // angle brackets corrupts the template. mdBook's own preprocessor
+            // syntax `{{#include}}` has the same shape.
+            if ch == '{' && matches!(chars.get(i + 1), Some('%') | Some('{')) {
                 break;
             }
             url.push(ch);

--- a/crates/mdbook-lint-rulesets/src/standard/md047.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md047.rs
@@ -164,7 +164,12 @@ impl Rule for MD047 {
                 let start_line = line_count - trailing_newlines + 2;
                 Fix {
                     description: "Remove extra trailing newlines".to_string(),
-                    replacement: Some("\n".to_string()),
+                    // The range starts immediately after the newline being kept
+                    // and runs to EOF, so the extras are deleted rather than
+                    // replaced. Substituting "\n" here rewrote the final newline
+                    // as itself, so the file was reported fixed but unchanged and
+                    // re-linted with the same violation.
+                    replacement: Some(String::new()),
                     start: Position {
                         line: start_line,
                         column: 1,
@@ -418,7 +423,10 @@ mod tests {
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Remove extra trailing newlines");
         // The fix replaces the extra newlines with a single newline
-        assert_eq!(fix.replacement, Some("\n".to_string()));
+        // The range starts after the newline being kept and runs to EOF, so
+        // the extras are deleted. This previously asserted "\n", which pinned a
+        // no-op that reported the file fixed while leaving it unchanged (#456).
+        assert_eq!(fix.replacement, Some(String::new()));
         assert_eq!(fix.start.line, 4);
         assert_eq!(fix.start.column, 1);
     }
@@ -436,7 +444,10 @@ mod tests {
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Remove extra trailing newlines");
         // The fix replaces extra newlines with a single newline
-        assert_eq!(fix.replacement, Some("\n".to_string()));
+        // The range starts after the newline being kept and runs to EOF, so
+        // the extras are deleted. This previously asserted "\n", which pinned a
+        // no-op that reported the file fixed while leaving it unchanged (#456).
+        assert_eq!(fix.replacement, Some(String::new()));
         // Should be at the position after the first trailing newline
         assert_eq!(fix.start.line, 2);
         assert_eq!(fix.start.column, 1);
@@ -523,7 +534,10 @@ mod tests {
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Remove extra trailing newlines");
         // The fix replaces extra newlines with a single newline
-        assert_eq!(fix.replacement, Some("\n".to_string()));
+        // The range starts after the newline being kept and runs to EOF, so
+        // the extras are deleted. This previously asserted "\n", which pinned a
+        // no-op that reported the file fixed while leaving it unchanged (#456).
+        assert_eq!(fix.replacement, Some(String::new()));
         assert_eq!(fix.start.line, 2);
         assert_eq!(fix.start.column, 1);
     }


### PR DESCRIPTION
Refs #456

First half of #456: the concrete corruption bugs. The coordinate contract, shared constructors, and CRLF handling remain open there.

## The bugs

All three were reproduced on current `main` before changing anything.

| Input | `--fix` produced | Problem |
|---|---|---|
| `(text)[https://example.com]` | `[text](https://example.com)]` | stray `]` |
| `See https://example.com{% if foo %}` | `See <https://example.com{%> if foo %}` | Liquid tag mangled |
| `Préface https://example.com/café` | unchanged | fix silently dropped |
| file ending `\n\n` | still ends `\n\n` | reported fixed, wasn't |

The first two write invalid markdown over the user's file.

## Causes

**MD011** set the fix end to the column *of* the closing `]`. `LintEngine::apply_fix` replaces `content[start..end]`, so ranges are end-exclusive and the bracket survived. The end must be one past it.

**MD034** had two independent defects:

- `extract_url` broke only on whitespace and a few delimiters, so it ran straight through `{%` and `{{` and pulled template syntax into the link target.
- The fix span computed `start_pos + url.len()`, where `start_pos` is a **char** index into `Vec<char>` and `url.len()` is a **byte** count. They agree for ASCII and diverge for anything else, producing an out-of-range span that `apply_fix` rejected without comment.

**MD047** replaced the extra trailing newlines with `"\n"`. The range already begins after the newline being kept, so the replacement rewrote the final newline as itself. Net effect: reported as fixed, unchanged on disk, re-lints with the same violation.

## Why tests did not catch this

Every existing test asserted the *shape* of the `Fix` object and never applied it. One even documented the off-by-one as intended:

```rust
// parse_reversed_link returns 31 (0-based position of ']')
// Fix adds +1 to convert to 1-based, so end.column = 32
assert_eq!(fix.end.column, 32);
```

That is the bug, written down as an expectation. Column 32 is the `]`; an end-exclusive range must be 33.

`tests/fix_conformance_test.rs` applies fixes through `LintEngine::apply_fixes`, re-lints, and asserts the rule is then silent and a second pass is a no-op. That is the acceptance criterion from the issue about exercising `apply_fix(es)` rather than raw `Fix` objects.

Matrix: multibyte text before a span and inside a URL, Liquid and Handlebars delimiters, already-wrapped URLs, trailing-newline reduction (2, 3, and 5) and insertion, a correct ending left alone, multiple violations on one line, and convergence when several rules fix the same document.

**Verified the tests catch the originals:** reverting all three fixes fails 10 of the 13 cases. The 3 that still pass are the negative cases that should.

## Test changes

Four rule-level tests pinned the old values. They now assert the applied result instead, and MD011 gained a helper that runs the fix through a real engine. The `Some("\n")` assertions on MD047's *add-newline* branch are unchanged; only the three *remove-extra-newlines* cases moved to an empty replacement.

## Not covered here

CRLF, overlapping fixes, and the `Fix`/`Position` documentation are part of the contract work still tracked in #456. This PR does not close that issue.