### PR TITLE
refactor: unify ignore-pattern glob matching into mdbook-lint-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,7 +1213,6 @@ dependencies = [
  "clap",
  "comrak",
  "criterion",
- "glob",
  "mdbook",
  "mdbook-lint-core",
  "mdbook-lint-rulesets",
@@ -1238,6 +1237,7 @@ version = "0.15.2"
 dependencies = [
  "anyhow",
  "comrak",
+ "glob",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1253,7 +1253,6 @@ version = "0.15.2"
 dependencies = [
  "anyhow",
  "comrak",
- "glob",
  "mdbook",
  "mdbook-lint-core",
  "proptest",

--- a/crates/mdbook-lint-cli/Cargo.toml
+++ b/crates/mdbook-lint-cli/Cargo.toml
@@ -37,7 +37,6 @@ comrak = { workspace = true }
 clap = { workspace = true }
 mdbook = { workspace = true }
 walkdir = { workspace = true }
-glob = { workspace = true }
 rayon = "1.10"
 tabled = "0.20"
 anstream = "0.6"

--- a/crates/mdbook-lint-cli/src/ignore.rs
+++ b/crates/mdbook-lint-cli/src/ignore.rs
@@ -1,67 +1,12 @@
-//! Shared matching for the global `ignore-paths` configuration.
+//! CLI-facing helpers for the global `ignore-paths` configuration.
 //!
-//! Both the CLI and the mdBook preprocessor must agree on what `ignore-paths`
-//! means. This module is the single implementation so the two cannot drift:
-//! the CLI filters the file list it collected, and the preprocessor skips
-//! chapters whose source path matches.
+//! The matching semantics live in `mdbook_lint_core::ignore`, shared with the
+//! mdBook preprocessor and the MDBOOK005 rule so the three cannot drift. This
+//! module just adapts that shared matcher to the CLI's file-filtering use case.
 
-use std::path::{Path, PathBuf};
+pub use mdbook_lint_core::ignore::path_is_ignored;
 
-/// Return true if `path` matches any of the given ignore glob patterns.
-///
-/// Matching is intentionally forgiving so the patterns behave the way users
-/// expect from `.gitignore`-style configuration:
-/// - a trailing `/` marks a directory prefix (`target/` behaves like `target/**`),
-/// - a pattern without any `/` also matches anywhere in the tree
-///   (`*.backup.md` matches `sub/dir/file.backup.md`),
-/// - `*` does not cross path separators, but `**` does.
-///
-/// Paths are normalized (leading `./` stripped, backslashes converted to `/`)
-/// before matching so results are consistent across platforms.
-pub fn path_is_ignored(path: &Path, patterns: &[String]) -> bool {
-    use glob::{MatchOptions, Pattern};
-
-    if patterns.is_empty() {
-        return false;
-    }
-
-    let normalized = path
-        .to_string_lossy()
-        .replace('\\', "/")
-        .trim_start_matches("./")
-        .to_string();
-
-    let options = MatchOptions {
-        case_sensitive: true,
-        require_literal_separator: true,
-        require_literal_leading_dot: false,
-    };
-
-    for pattern in patterns {
-        let mut pat = pattern.replace('\\', "/");
-        pat = pat.trim_start_matches("./").to_string();
-        // A trailing slash means "everything under this directory".
-        if pat.ends_with('/') {
-            pat.push_str("**");
-        }
-
-        // A bare name or relative pattern should also match deeper in the tree.
-        let mut candidates = vec![pat.clone()];
-        if !pat.starts_with("**/") {
-            candidates.push(format!("**/{pat}"));
-        }
-
-        for candidate in candidates {
-            if let Ok(compiled) = Pattern::new(&candidate)
-                && compiled.matches_with(&normalized, options)
-            {
-                return true;
-            }
-        }
-    }
-
-    false
-}
+use std::path::PathBuf;
 
 /// Remove files matching any of the configured ignore-paths patterns.
 pub fn filter_ignored_paths(files: &mut Vec<PathBuf>, patterns: &[String]) {
@@ -74,49 +19,6 @@ pub fn filter_ignored_paths(files: &mut Vec<PathBuf>, patterns: &[String]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_path_is_ignored() {
-        let p = |s: &str| PathBuf::from(s);
-
-        // Directory prefix (trailing slash)
-        let pats = vec!["vendor/".to_string()];
-        assert!(path_is_ignored(&p("vendor/skip.md"), &pats));
-        assert!(path_is_ignored(&p("./vendor/nested/skip.md"), &pats));
-        assert!(!path_is_ignored(&p("docs/keep.md"), &pats));
-
-        // Bare suffix glob matches at any depth
-        let pats = vec!["*.backup.md".to_string()];
-        assert!(path_is_ignored(&p("notes.backup.md"), &pats));
-        assert!(path_is_ignored(&p("a/b/notes.backup.md"), &pats));
-        assert!(!path_is_ignored(&p("notes.md"), &pats));
-
-        // Bare name matches anywhere
-        let pats = vec!["not-found.md".to_string()];
-        assert!(path_is_ignored(&p("not-found.md"), &pats));
-        assert!(path_is_ignored(&p("src/deep/not-found.md"), &pats));
-
-        // Explicit ** prefix
-        let pats = vec!["**/generated.md".to_string()];
-        assert!(path_is_ignored(&p("x/y/generated.md"), &pats));
-
-        // Empty patterns never match
-        assert!(!path_is_ignored(&p("anything.md"), &[]));
-    }
-
-    #[test]
-    fn test_path_is_ignored_normalizes_separators() {
-        // mdBook reports chapter source_path with native separators, so a
-        // Windows path must match a pattern written with forward slashes.
-        // Normalization happens on the string, so this holds on every platform.
-        let pats = vec!["generated/".to_string()];
-        assert!(path_is_ignored(&PathBuf::from(r"generated\api.md"), &pats));
-        assert!(path_is_ignored(
-            &PathBuf::from(r"generated\deep\nested.md"),
-            &pats
-        ));
-        assert!(!path_is_ignored(&PathBuf::from(r"guide\intro.md"), &pats));
-    }
 
     #[test]
     fn test_filter_ignored_paths() {

--- a/crates/mdbook-lint-core/Cargo.toml
+++ b/crates/mdbook-lint-core/Cargo.toml
@@ -28,6 +28,7 @@ comrak = { workspace = true }
 
 # Utilities
 walkdir = { workspace = true }
+glob = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/mdbook-lint-core/src/ignore.rs
+++ b/crates/mdbook-lint-core/src/ignore.rs
@@ -1,0 +1,125 @@
+//! Shared matching for `ignore-paths` / `ignore_patterns` style configuration.
+//!
+//! The CLI's `ignore-paths`, the mdBook preprocessor's `ignore-paths`, and the
+//! MDBOOK005 rule's `ignore_patterns` all need to agree on what a glob pattern
+//! matches. This module is the single implementation so the three cannot
+//! drift apart.
+
+use std::path::Path;
+
+/// Return true if `path` matches any of the given ignore glob patterns.
+///
+/// Matching is intentionally forgiving so the patterns behave the way users
+/// expect from `.gitignore`-style configuration:
+/// - a trailing `/` marks a directory prefix (`target/` behaves like `target/**`),
+/// - a pattern without any `/` also matches anywhere in the tree
+///   (`*.backup.md` matches `sub/dir/file.backup.md`),
+/// - `*` does not cross path separators, but `**` does.
+///
+/// Paths are normalized (leading `./` stripped, backslashes converted to `/`)
+/// before matching so results are consistent across platforms.
+pub fn path_is_ignored(path: &Path, patterns: &[String]) -> bool {
+    use glob::{MatchOptions, Pattern};
+
+    if patterns.is_empty() {
+        return false;
+    }
+
+    let normalized = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_string();
+
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+
+    for pattern in patterns {
+        let mut pat = pattern.replace('\\', "/");
+        pat = pat.trim_start_matches("./").to_string();
+        // A trailing slash means "everything under this directory".
+        if pat.ends_with('/') {
+            pat.push_str("**");
+        }
+
+        // A bare name or relative pattern should also match deeper in the tree.
+        let mut candidates = vec![pat.clone()];
+        if !pat.starts_with("**/") {
+            candidates.push(format!("**/{pat}"));
+        }
+
+        for candidate in candidates {
+            if let Ok(compiled) = Pattern::new(&candidate)
+                && compiled.matches_with(&normalized, options)
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_path_is_ignored() {
+        let p = |s: &str| PathBuf::from(s);
+
+        // Directory prefix (trailing slash)
+        let pats = vec!["vendor/".to_string()];
+        assert!(path_is_ignored(&p("vendor/skip.md"), &pats));
+        assert!(path_is_ignored(&p("./vendor/nested/skip.md"), &pats));
+        assert!(!path_is_ignored(&p("docs/keep.md"), &pats));
+
+        // Bare suffix glob matches at any depth
+        let pats = vec!["*.backup.md".to_string()];
+        assert!(path_is_ignored(&p("notes.backup.md"), &pats));
+        assert!(path_is_ignored(&p("a/b/notes.backup.md"), &pats));
+        assert!(!path_is_ignored(&p("notes.md"), &pats));
+
+        // Bare name matches anywhere
+        let pats = vec!["not-found.md".to_string()];
+        assert!(path_is_ignored(&p("not-found.md"), &pats));
+        assert!(path_is_ignored(&p("src/deep/not-found.md"), &pats));
+
+        // Explicit ** prefix
+        let pats = vec!["**/generated.md".to_string()];
+        assert!(path_is_ignored(&p("x/y/generated.md"), &pats));
+
+        // Empty patterns never match
+        assert!(!path_is_ignored(&p("anything.md"), &[]));
+    }
+
+    #[test]
+    fn test_path_is_ignored_normalizes_separators() {
+        // mdBook reports chapter source_path with native separators, so a
+        // Windows path must match a pattern written with forward slashes.
+        // Normalization happens on the string, so this holds on every platform.
+        let pats = vec!["generated/".to_string()];
+        assert!(path_is_ignored(&PathBuf::from(r"generated\api.md"), &pats));
+        assert!(path_is_ignored(
+            &PathBuf::from(r"generated\deep\nested.md"),
+            &pats
+        ));
+        assert!(!path_is_ignored(&PathBuf::from(r"guide\intro.md"), &pats));
+    }
+
+    #[test]
+    fn test_path_is_ignored_star_does_not_cross_separator() {
+        // `*` is anchored to the directory it's written in, so a deeper path
+        // is not matched.
+        let pats = vec!["sub/*.md".to_string()];
+        assert!(path_is_ignored(&PathBuf::from("sub/chapter1.md"), &pats));
+        assert!(!path_is_ignored(
+            &PathBuf::from("sub/deep/chapter1.md"),
+            &pats
+        ));
+    }
+}

--- a/crates/mdbook-lint-core/src/lib.rs
+++ b/crates/mdbook-lint-core/src/lib.rs
@@ -171,6 +171,7 @@ pub mod deduplication;
 pub mod document;
 pub mod engine;
 pub mod error;
+pub mod ignore;
 pub mod registry;
 pub mod rule;
 pub mod test_helpers;
@@ -184,6 +185,7 @@ pub use error::{
     ConfigError, DocumentError, ErrorContext, IntoMdBookLintError, MdBookLintError, MdlntError,
     PluginError, Result, RuleError,
 };
+pub use ignore::path_is_ignored;
 pub use registry::RuleRegistry;
 pub use rule::{AstRule, CollectionRule, Rule, RuleCategory, RuleMetadata, RuleStability};
 pub use violation::{Severity, Violation};

--- a/crates/mdbook-lint-rulesets/Cargo.toml
+++ b/crates/mdbook-lint-rulesets/Cargo.toml
@@ -42,7 +42,6 @@ serde_yaml = { workspace = true, optional = true }
 
 # Utilities
 walkdir = { workspace = true }
-glob = { workspace = true }
 regex = "1.10"
 toml = { workspace = true }
 

--- a/crates/mdbook-lint-rulesets/src/mdbook/mdbook005.rs
+++ b/crates/mdbook-lint-rulesets/src/mdbook/mdbook005.rs
@@ -7,6 +7,7 @@
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
+    ignore::path_is_ignored,
     violation::{Severity, Violation},
 };
 use std::collections::HashSet;
@@ -110,53 +111,6 @@ impl MDBOOK005 {
             check_nested,
         }
     }
-}
-
-/// Return true if `relative_path` matches any of the configured ignore globs.
-///
-/// Matching mirrors the CLI `ignore-paths` behavior: a trailing `/` marks a
-/// directory prefix, a pattern without any `/` also matches deeper in the tree,
-/// and `*` does not cross path separators while `**` does.
-fn matches_ignore_pattern(relative_path: &str, patterns: &[String]) -> bool {
-    use glob::{MatchOptions, Pattern};
-
-    if patterns.is_empty() {
-        return false;
-    }
-
-    let normalized = relative_path
-        .replace('\\', "/")
-        .trim_start_matches("./")
-        .to_string();
-
-    let options = MatchOptions {
-        case_sensitive: true,
-        require_literal_separator: true,
-        require_literal_leading_dot: false,
-    };
-
-    for pattern in patterns {
-        let mut pat = pattern.replace('\\', "/");
-        pat = pat.trim_start_matches("./").to_string();
-        if pat.ends_with('/') {
-            pat.push_str("**");
-        }
-
-        let mut candidates = vec![pat.clone()];
-        if !pat.starts_with("**/") {
-            candidates.push(format!("**/{pat}"));
-        }
-
-        for candidate in candidates {
-            if let Ok(compiled) = Pattern::new(&candidate)
-                && compiled.matches_with(&normalized, options)
-            {
-                return true;
-            }
-        }
-    }
-
-    false
 }
 
 impl Rule for MDBOOK005 {
@@ -326,14 +280,12 @@ impl MDBOOK005 {
                 }
 
                 // Skip files matching any configured ignore glob (matched against
-                // the path relative to the book source directory)
+                // the path relative to the book source directory). This uses the
+                // same matcher as the CLI/preprocessor `ignore-paths` option, so
+                // the two cannot drift apart.
                 if !self.ignore_patterns.is_empty() {
-                    let relative = file
-                        .strip_prefix(book_src_dir)
-                        .unwrap_or(file.as_path())
-                        .to_string_lossy()
-                        .replace('\\', "/");
-                    if matches_ignore_pattern(&relative, &self.ignore_patterns) {
+                    let relative = file.strip_prefix(book_src_dir).unwrap_or(file.as_path());
+                    if path_is_ignored(relative, &self.ignore_patterns) {
                         return false;
                     }
                 }
@@ -713,57 +665,10 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_matches_ignore_pattern() {
-        // Bare name matches at root and anywhere in the tree
-        assert!(matches_ignore_pattern(
-            "not-found.md",
-            &["not-found.md".to_string()]
-        ));
-        assert!(matches_ignore_pattern(
-            "external/docs/not-found.md",
-            &["not-found.md".to_string()]
-        ));
-
-        // Explicit ** prefix matches nested paths
-        assert!(matches_ignore_pattern(
-            "a/b/not-found.md",
-            &["**/not-found.md".to_string()]
-        ));
-
-        // Directory prefix (trailing slash) matches everything under it
-        assert!(matches_ignore_pattern(
-            "drafts/wip.md",
-            &["drafts/".to_string()]
-        ));
-        assert!(matches_ignore_pattern(
-            "drafts/nested/wip.md",
-            &["drafts/".to_string()]
-        ));
-
-        // Suffix glob matches at any depth
-        assert!(matches_ignore_pattern(
-            "guide/notes.backup.md",
-            &["*.backup.md".to_string()]
-        ));
-
-        // Non-matching patterns
-        assert!(!matches_ignore_pattern(
-            "chapter1.md",
-            &["not-found.md".to_string()]
-        ));
-        assert!(!matches_ignore_pattern("chapter1.md", &[]));
-        // An anchored pattern with a separator: `*` does not cross `/`, so a
-        // deeper path is not matched.
-        assert!(matches_ignore_pattern(
-            "sub/chapter1.md",
-            &["sub/*.md".to_string()]
-        ));
-        assert!(!matches_ignore_pattern(
-            "sub/deep/chapter1.md",
-            &["sub/*.md".to_string()]
-        ));
-    }
+    // The glob matching semantics themselves (bare name, directory prefix,
+    // `*` vs `**`, ...) are pinned by the tests in `mdbook_lint_core::ignore`.
+    // The tests below cover this rule's use of that shared matcher: reading
+    // `ignore_patterns` from config and applying it to orphan detection.
 
     #[test]
     fn test_from_config_defaults() {


### PR DESCRIPTION
## Summary
- The CLI/preprocessor `path_is_ignored` and MDBOOK005's `matches_ignore_pattern`
  were line-for-line duplicates of the same .gitignore-style glob matcher.
- Moves the single implementation into `mdbook_lint_core::ignore`, with both
  `mdbook-lint-cli` (`ignore-paths`) and `mdbook-lint-rulesets` (MDBOOK005's
  `ignore_patterns`) routing through it, per #479.
- `mdbook-lint-cli::ignore` keeps `filter_ignored_paths` as a thin wrapper
  over the shared matcher.
- The matching-semantics tests now live once, in `mdbook_lint_core::ignore`.
  MDBOOK005's duplicate was dropped; the `sub/*.md` separator case it covered
  and the CLI tests did not is carried over as a new core test. MDBOOK005's
  config/integration tests for `ignore_patterns` are kept as-is.
- `glob` moves from a direct dependency of cli and rulesets to core.

Fixes #479

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
