### PR TITLE
test(rulesets): add edge case tests for MD020, MD028, MD036, MD042

### DIFF
--- a/crates/mdbook-lint-rulesets/src/standard/md020.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md020.rs
@@ -198,4 +198,16 @@ mod tests {
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.end.column, "##Résumé ##".chars().count() + 1);
     }
+
+    #[test]
+    fn empty_document_has_no_violations() {
+        let violations = check("");
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn whitespace_only_document_has_no_violations() {
+        let violations = check("   \n\t\n  ");
+        assert!(violations.is_empty());
+    }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md028.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md028.rs
@@ -324,4 +324,42 @@ The end.
         let rule = MD028;
         assert!(Rule::can_fix(&rule));
     }
+
+    #[test]
+    fn test_md028_empty_document() {
+        let content = "";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD028;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md028_whitespace_only_document() {
+        let content = "   \n\t\n  ";
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD028;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md028_unicode_blockquote() {
+        let content = r#"> 日本語のブロック引用
+> 続きます
+
+> 壊れた後に続く
+> ここまでです
+
+普通のテキストです。
+"#;
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD028;
+        let violations = rule.check(&document).unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 3);
+    }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md036.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md036.rs
@@ -348,4 +348,40 @@ More content.
         assert_eq!(violations.len(), 1); // Only the one without punctuation
         assert_eq!(violations[0].line, 7);
     }
+
+    #[test]
+    fn test_md036_empty_document() {
+        let content = "";
+
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD036::new();
+        let violations = rule.check(&document).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md036_whitespace_only_document() {
+        let content = "   \n\t\n  ";
+
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD036::new();
+        let violations = rule.check(&document).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md036_unicode_emphasis_as_heading() {
+        let content = r#"テキスト
+
+**セクションタイトル**
+
+これは本文です。
+"#;
+
+        let document = Document::new(content.to_string(), PathBuf::from("test.md")).unwrap();
+        let rule = MD036::new();
+        let violations = rule.check(&document).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 3);
+    }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md042.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md042.rs
@@ -307,4 +307,38 @@ Bad [][bad] reference link.
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].line, 3);
     }
+
+    #[test]
+    fn test_md042_empty_document() {
+        let content = "";
+
+        let document = create_test_document(content);
+        let rule = MD042;
+        let violations = rule.check(&document).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md042_whitespace_only_document() {
+        let content = "   \n\t\n  ";
+
+        let document = create_test_document(content);
+        let rule = MD042;
+        let violations = rule.check(&document).unwrap();
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_md042_unicode_link_text() {
+        let content = r#"ここに[リンクテキスト](http://example.com)があります。
+
+これは[](http://example.com)空のリンクです。
+"#;
+
+        let document = create_test_document(content);
+        let rule = MD042;
+        let violations = rule.check(&document).unwrap();
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].line, 3);
+    }
 }


### PR DESCRIPTION
Adds empty-document, whitespace-only-document, and Unicode-content edge case tests to MD020, MD028, MD036, and MD042, the bounded batch requested in the maintainer's triage comment on the original open-ended good-first-issue. No rule logic changed, only new test functions in each file's existing `#[cfg(test)]` module.

Closes #301