### PR TITLE
fix: define exact autofix coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Define `Fix` ranges as exact half-open ranges with 1-based Unicode-scalar
+  columns, expose checked `Position`/byte-offset conversions, and make line
+  terminator replacement versus boundary insertion explicit. Standard-rule
+  fixes now preserve CRLF and do not add a newline at EOF implicitly. ([#456](https://github.com/joshrotenberg/mdbook-lint/issues/456))
+
 ## [0.15.2] - 2026-08-04
 
 ### Bug Fixes
@@ -600,5 +607,4 @@ All notable changes to this project will be documented in this file.
 
 ### Miscellaneous
 - *(main)* Release 0.1.0 ([#3](https://github.com/joshrotenberg/mdbook-lint/pull/3)) ([a78f99a](https://github.com/joshrotenberg/mdbook-lint/commit/a78f99ad93f1e27ef47856b7d02ee7903b579283))
-
 

--- a/crates/mdbook-lint-cli/tests/fix_conformance_test.rs
+++ b/crates/mdbook-lint-cli/tests/fix_conformance_test.rs
@@ -2,15 +2,14 @@
 //!
 //! Every case here applies fixes through `LintEngine::apply_fixes` and then
 //! re-lints the result. The rule-level tests that existed before asserted the
-//! shape of `Fix` objects without ever applying them, which is how three
-//! corruption bugs shipped:
+//! shape of `Fix` objects without ever applying them, which is how coordinate
+//! and newline bugs shipped. The contract exercised here is:
 //!
-//! - MD011 left a stray `]` because the end position pointed at the bracket
-//!   rather than one past it, and fix ranges are end-exclusive.
-//! - MD034 wrapped Liquid syntax into the URL, and rejected multibyte URLs
-//!   because the span mixed a char index with a byte length.
-//! - MD047 replaced the final newline with itself, reporting a file as fixed
-//!   while leaving it unchanged.
+//! - positions use 1-based Unicode-scalar columns;
+//! - fix ranges are exact and end-exclusive;
+//! - CRLF is preserved as one atomic line terminator;
+//! - replacing a complete line and inserting at a line boundary are distinct;
+//! - EOF fixes do not acquire an implicit newline.
 //!
 //! Applying a fix and re-linting catches all three; inspecting the `Fix` does
 //! not.
@@ -199,4 +198,61 @@ fn test_fixes_are_idempotent_across_rules() {
 #[test]
 fn test_multiple_violations_on_one_line_all_fixed() {
     assert_fixes_to("(a)[u1] and (b)[u2]\n", "MD011", "[a](u1) and [b](u2)\n");
+}
+
+#[test]
+fn test_unicode_scalar_columns_resolve_to_byte_ranges() {
+    let content = "é🙂   \n";
+    let (violations, _) = lint(content, "MD009");
+    assert_eq!(violations.len(), 1);
+
+    let violation = &violations[0];
+    assert_eq!(violation.column, 3);
+    let fix = violation.fix.as_ref().unwrap();
+    assert_eq!(fix.byte_range(content), Some(0..content.len()));
+    assert_eq!(fix.replacement.as_deref(), Some("é🙂\n"));
+
+    assert_fixes_to(content, "MD009", "é🙂\n");
+}
+
+#[test]
+fn test_complete_line_replacement_preserves_crlf() {
+    let content = "  # Résumé\r\nBody\r\n";
+    let (violations, _) = lint(content, "MD023");
+    assert_eq!(violations.len(), 1);
+
+    let fix = violations[0].fix.as_ref().unwrap();
+    assert_ne!(fix.start, fix.end);
+    assert_eq!(&content[fix.byte_range(content).unwrap()], "  # Résumé\r\n");
+    assert_eq!(fix.replacement.as_deref(), Some("# Résumé\r\n"));
+
+    assert_fixes_to(content, "MD023", "# Résumé\r\nBody\r\n");
+}
+
+#[test]
+fn test_complete_line_replacement_at_eof_does_not_add_newline() {
+    let content = "  # Résumé";
+    let (violations, _) = lint(content, "MD023");
+    let fix = violations[0].fix.as_ref().unwrap();
+
+    assert_eq!(fix.byte_range(content), Some(0..content.len()));
+    assert_eq!(fix.replacement.as_deref(), Some("# Résumé"));
+    assert_fixes_to(content, "MD023", "# Résumé");
+}
+
+#[test]
+fn test_blank_line_fixes_are_boundary_insertions_with_crlf() {
+    let content = "Préface\r\n# Title\r\nBody\r\n";
+    let (violations, _) = lint(content, "MD022");
+    assert_eq!(violations.len(), 2);
+
+    for violation in &violations {
+        let fix = violation.fix.as_ref().unwrap();
+        assert_eq!(fix.start, fix.end);
+        assert_eq!(fix.replacement.as_deref(), Some("\r\n"));
+        let range = fix.byte_range(content).unwrap();
+        assert!(range.is_empty());
+    }
+
+    assert_fixes_to(content, "MD022", "Préface\r\n\r\n# Title\r\n\r\nBody\r\n");
 }

--- a/crates/mdbook-lint-core/src/document.rs
+++ b/crates/mdbook-lint-core/src/document.rs
@@ -111,6 +111,26 @@ impl Document {
         1 // Default to column 1
     }
 
+    /// Return the source terminator for a 1-based logical line.
+    ///
+    /// The returned value is `"\n"`, `"\r\n"`, or `None` when the line has no
+    /// terminator or does not exist. Rules that insert source lines should use
+    /// this instead of assuming LF.
+    pub fn line_ending(&self, line: usize) -> Option<&str> {
+        if line == 0 {
+            return None;
+        }
+
+        let source_line = self.content.split_inclusive('\n').nth(line - 1)?;
+        if source_line.ends_with("\r\n") {
+            Some("\r\n")
+        } else if source_line.ends_with('\n') {
+            Some("\n")
+        } else {
+            None
+        }
+    }
+
     /// Get all heading nodes from the AST
     pub fn headings<'a>(&self, ast: &'a AstNode<'a>) -> Vec<&'a AstNode<'a>> {
         let mut headings = Vec::new();
@@ -361,6 +381,11 @@ mod tests {
         assert_eq!(doc.lines[1], "Line 2");
         assert_eq!(doc.lines[2], "Line 3");
         assert_eq!(doc.lines[3], "Line 4");
+        assert_eq!(doc.line_ending(1), Some("\r\n"));
+        assert_eq!(doc.line_ending(2), Some("\n"));
+        assert_eq!(doc.line_ending(3), Some("\r\n"));
+        assert_eq!(doc.line_ending(4), None);
+        assert_eq!(doc.line_ending(0), None);
     }
 
     #[test]

--- a/crates/mdbook-lint-core/src/engine.rs
+++ b/crates/mdbook-lint-core/src/engine.rs
@@ -232,25 +232,11 @@ impl LintEngine {
     pub fn apply_fix(&self, content: &str, violation: &crate::Violation) -> Option<String> {
         let fix = violation.fix.as_ref()?;
 
-        let start_offset = position_to_offset(content, &fix.start)?;
-        let mut end_offset = position_to_offset(content, &fix.end)?;
-
-        // Handle newline duplication: if the replacement ends with a newline and
-        // the original content has a newline at the end position, skip it to avoid
-        // double newlines. This is a common pattern when rules create fixes that
-        // replace entire lines including their trailing newline.
+        let range = fix.byte_range(content)?;
         let replacement = fix.replacement.as_deref().unwrap_or("");
-        if replacement.ends_with('\n') && content.as_bytes().get(end_offset) == Some(&b'\n') {
-            end_offset += 1;
-        }
-
-        if start_offset <= end_offset && end_offset <= content.len() {
-            let mut result = content.to_string();
-            result.replace_range(start_offset..end_offset, replacement);
-            Some(result)
-        } else {
-            None
-        }
+        let mut result = content.to_string();
+        result.replace_range(range, replacement);
+        Some(result)
     }
 
     /// Apply all available fixes to content
@@ -291,26 +277,17 @@ impl LintEngine {
             let Some(fix) = violation.fix.as_ref() else {
                 continue;
             };
-            let (Some(start), Some(mut end)) = (
-                position_to_offset(content, &fix.start),
-                position_to_offset(content, &fix.end),
-            ) else {
+            let Some(range) = fix.byte_range(content) else {
                 continue;
             };
 
             let replacement = fix.replacement.as_deref().unwrap_or("");
-            if replacement.ends_with('\n') && content.as_bytes().get(end) == Some(&b'\n') {
-                end += 1;
-            }
-
-            if start <= end && end <= content.len() {
-                planned.push(PlannedFix {
-                    violation_index,
-                    start,
-                    end,
-                    replacement,
-                });
-            }
+            planned.push(PlannedFix {
+                violation_index,
+                start: range.start,
+                end: range.end,
+                replacement,
+            });
         }
 
         // Conflicting edits are unsafe to compose. Exact duplicates are safe and
@@ -403,32 +380,6 @@ impl LintEngine {
     /// Check if there are any collection rules registered
     pub fn has_collection_rules(&self) -> bool {
         self.registry.has_collection_rules()
-    }
-}
-
-/// Convert a line/column position to a byte offset in text
-fn position_to_offset(text: &str, pos: &crate::violation::Position) -> Option<usize> {
-    let mut current_line = 1;
-    let mut current_col = 1;
-
-    for (offset, ch) in text.char_indices() {
-        if current_line == pos.line && current_col == pos.column {
-            return Some(offset);
-        }
-
-        if ch == '\n' {
-            current_line += 1;
-            current_col = 1;
-        } else {
-            current_col += 1;
-        }
-    }
-
-    // Handle position at end of content
-    if current_line == pos.line && current_col == pos.column {
-        Some(text.len())
-    } else {
-        None
     }
 }
 
@@ -666,37 +617,35 @@ mod tests {
 
         // Line 1, column 1 = offset 0
         assert_eq!(
-            super::position_to_offset(text, &crate::violation::Position { line: 1, column: 1 }),
+            crate::violation::Position { line: 1, column: 1 }.to_byte_offset(text),
             Some(0)
         );
 
         // Line 1, column 3 = offset 2 ('n' in 'line1')
         assert_eq!(
-            super::position_to_offset(text, &crate::violation::Position { line: 1, column: 3 }),
+            crate::violation::Position { line: 1, column: 3 }.to_byte_offset(text),
             Some(2)
         );
 
         // Line 2, column 1 = offset 6 (after 'line1\n')
         assert_eq!(
-            super::position_to_offset(text, &crate::violation::Position { line: 2, column: 1 }),
+            crate::violation::Position { line: 2, column: 1 }.to_byte_offset(text),
             Some(6)
         );
 
         // Line 3, column 1 = offset 12
         assert_eq!(
-            super::position_to_offset(text, &crate::violation::Position { line: 3, column: 1 }),
+            crate::violation::Position { line: 3, column: 1 }.to_byte_offset(text),
             Some(12)
         );
 
         // Invalid position
         assert_eq!(
-            super::position_to_offset(
-                text,
-                &crate::violation::Position {
-                    line: 10,
-                    column: 1
-                }
-            ),
+            crate::violation::Position {
+                line: 10,
+                column: 1,
+            }
+            .to_byte_offset(text),
             None
         );
     }
@@ -851,10 +800,9 @@ mod tests {
             fix: Some(crate::violation::Fix {
                 description: "Replace heading".to_string(),
                 start: crate::violation::Position { line: 1, column: 1 },
-                end: crate::violation::Position {
-                    line: 1,
-                    column: 14,
-                }, // Points to the newline position
+                // Ending at the following line explicitly consumes the original
+                // line terminator.
+                end: crate::violation::Position { line: 2, column: 1 },
                 replacement: Some("# New Heading\n".to_string()),
             }),
         };
@@ -866,6 +814,33 @@ mod tests {
         // Should have exactly one newline between the heading and next line, not two
         assert_eq!(fixed, "# New Heading\nNext line\n");
         assert!(!fixed.contains("\n\n"), "Should not have double newlines");
+    }
+
+    #[test]
+    fn test_apply_fix_does_not_infer_newline_consumption() {
+        let engine = LintEngine::new();
+        let content = "old\nnext\n";
+        let violation = crate::Violation {
+            rule_id: "TEST".to_string(),
+            rule_name: "test".to_string(),
+            message: "Replace line content only".to_string(),
+            line: 1,
+            column: 1,
+            severity: crate::Severity::Warning,
+            fix: Some(crate::violation::Fix {
+                description: "Replace line content only".to_string(),
+                start: crate::violation::Position::line_start(1),
+                end: crate::violation::Position::line_end(1, "old"),
+                replacement: Some("new\n".to_string()),
+            }),
+        };
+
+        // The replacement contains a newline, but the exact source range does
+        // not consume one. The engine must not reinterpret that intent.
+        assert_eq!(
+            engine.apply_fix(content, &violation),
+            Some("new\n\nnext\n".to_string())
+        );
     }
 
     #[test]
@@ -952,7 +927,7 @@ mod tests {
                 description: "Normalize heading".to_string(),
                 replacement: Some("# Bad #\n".to_string()),
                 start: crate::violation::Position { line: 1, column: 1 },
-                end: crate::violation::Position { line: 1, column: 6 },
+                end: crate::violation::Position { line: 2, column: 1 },
             }),
         };
         let violations = vec![make_violation("TEST1"), make_violation("TEST2")];

--- a/crates/mdbook-lint-core/src/lib.rs
+++ b/crates/mdbook-lint-core/src/lib.rs
@@ -134,6 +134,13 @@
 //! };
 //! ```
 //!
+//! `Fix::start..Fix::end` is an exact, half-open range. Lines and columns are
+//! 1-based, and columns count Unicode scalar values rather than UTF-8 bytes.
+//! Line terminators are not implied: an endpoint at the content end of a line
+//! is before its terminator, while column 1 of the next line is after the full
+//! LF or CRLF terminator. Use [`Fix::byte_range`](crate::violation::Fix::byte_range)
+//! for the canonical checked conversion to UTF-8 byte offsets.
+//!
 //! ## Rule Traits
 //!
 //! Rules can be implemented using different traits based on their needs:
@@ -188,7 +195,7 @@ pub use error::{
 pub use ignore::path_is_ignored;
 pub use registry::RuleRegistry;
 pub use rule::{AstRule, CollectionRule, Rule, RuleCategory, RuleMetadata, RuleStability};
-pub use violation::{Severity, Violation};
+pub use violation::{Fix, Position, Severity, Violation};
 
 /// Current version of mdbook-lint-core
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/mdbook-lint-core/src/violation.rs
+++ b/crates/mdbook-lint-core/src/violation.rs
@@ -2,26 +2,264 @@
 //!
 //! This module contains the core types for representing linting violations.
 
-/// A suggested fix for a violation
+use std::ops::Range;
+
+/// A suggested fix for a violation.
+///
+/// `start` and `end` form an exact, half-open range: the character at `start`
+/// is replaced and the character at `end` is not. Equal positions represent
+/// an insertion. Line terminators are never included implicitly; a range that
+/// consumes a line terminator ends at column 1 of the following line.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct Fix {
     /// Description of what the fix does
     pub description: String,
     /// The replacement text (None means delete)
     pub replacement: Option<String>,
-    /// Start position of the text to replace
+    /// Inclusive start position of the text to replace
     pub start: Position,
-    /// End position of the text to replace  
+    /// Exclusive end position of the text to replace
     pub end: Position,
 }
 
-/// Position in a document
+/// A position in a document.
+///
+/// Lines and columns are 1-based. Columns count Unicode scalar values in the
+/// line's content; they are not UTF-8 byte offsets, grapheme clusters, or
+/// display cells. A line containing `"café"` therefore ends at column 5.
+///
+/// The end-of-line column is immediately before the complete line terminator.
+/// Column 1 of the following line is immediately after it. Consequently CRLF
+/// is atomic: no valid `Position` can point between `\r` and `\n`.
+///
+/// EOF is represented by the final line's end column when the document has no
+/// trailing terminator, or by column 1 of the next line when it does.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub struct Position {
     /// Line number (1-based)
     pub line: usize,
     /// Column number (1-based)
     pub column: usize,
+}
+
+impl Position {
+    /// Return column 1 of `line`.
+    pub const fn line_start(line: usize) -> Self {
+        Self { line, column: 1 }
+    }
+
+    /// Return the position immediately after `line_content` and before its
+    /// terminator, if any.
+    pub fn line_end(line: usize, line_content: &str) -> Self {
+        Self {
+            line,
+            column: line_content.chars().count() + 1,
+        }
+    }
+
+    /// Convert a zero-based UTF-8 byte offset within one line to a scalar-based
+    /// document position.
+    ///
+    /// Returns `None` if `byte_offset` is outside `line_content` or is not a
+    /// UTF-8 character boundary.
+    pub fn from_byte_offset_in_line(
+        line: usize,
+        line_content: &str,
+        byte_offset: usize,
+    ) -> Option<Self> {
+        if line == 0
+            || byte_offset > line_content.len()
+            || !line_content.is_char_boundary(byte_offset)
+        {
+            return None;
+        }
+
+        Some(Self {
+            line,
+            column: line_content[..byte_offset].chars().count() + 1,
+        })
+    }
+
+    /// Resolve this position to a zero-based UTF-8 byte offset in `content`.
+    ///
+    /// Invalid line or column numbers, including positions inside CRLF, return
+    /// `None`.
+    pub fn to_byte_offset(self, content: &str) -> Option<usize> {
+        if self.line == 0 || self.column == 0 {
+            return None;
+        }
+
+        let (line_start, line_end) = logical_line_bounds(content, self.line)?;
+        let target = self.column - 1;
+        let line_content = &content[line_start..line_end];
+
+        for (scalar_index, (byte_offset, _)) in line_content.char_indices().enumerate() {
+            if scalar_index == target {
+                return Some(line_start + byte_offset);
+            }
+        }
+
+        (line_content.chars().count() == target).then_some(line_end)
+    }
+
+    /// Convert a zero-based UTF-8 byte offset in `content` to a document
+    /// position.
+    ///
+    /// Offsets outside the document, in the middle of a UTF-8 scalar, or
+    /// between the two bytes of a CRLF terminator return `None`.
+    pub fn from_byte_offset(content: &str, byte_offset: usize) -> Option<Self> {
+        if byte_offset > content.len() || !content.is_char_boundary(byte_offset) {
+            return None;
+        }
+
+        let mut line = 1;
+        let mut line_start = 0;
+        loop {
+            let newline = content[line_start..]
+                .find('\n')
+                .map(|relative| line_start + relative);
+            let line_end = match newline {
+                Some(newline_offset)
+                    if content.as_bytes().get(newline_offset.wrapping_sub(1)) == Some(&b'\r') =>
+                {
+                    newline_offset - 1
+                }
+                Some(newline_offset) => newline_offset,
+                None => content.len(),
+            };
+
+            if byte_offset >= line_start && byte_offset <= line_end {
+                return Some(Self {
+                    line,
+                    column: content[line_start..byte_offset].chars().count() + 1,
+                });
+            }
+
+            let next_line_start = newline? + 1;
+            if byte_offset < next_line_start {
+                // The only representable gap is between '\r' and '\n'.
+                return None;
+            }
+            line += 1;
+            line_start = next_line_start;
+        }
+    }
+}
+
+impl Fix {
+    /// Construct an exact insertion at `position`.
+    pub fn insertion(
+        description: impl Into<String>,
+        replacement: impl Into<String>,
+        position: Position,
+    ) -> Self {
+        Self {
+            description: description.into(),
+            replacement: Some(replacement.into()),
+            start: position,
+            end: position,
+        }
+    }
+
+    /// Construct a replacement for one complete source line.
+    ///
+    /// `replacement` contains line content only. When `line_ending` is present,
+    /// the helper appends that exact terminator and makes the range end at
+    /// column 1 of the following line. With `None`, the range ends before EOF
+    /// and no terminator is added.
+    pub fn line_replacement(
+        description: impl Into<String>,
+        replacement: impl Into<String>,
+        line: usize,
+        original_line: &str,
+        line_ending: Option<&str>,
+    ) -> Self {
+        let mut replacement = replacement.into();
+        let end = if let Some(line_ending) = line_ending {
+            replacement.push_str(line_ending);
+            Position::line_start(line + 1)
+        } else {
+            Position::line_end(line, original_line)
+        };
+
+        Self {
+            description: description.into(),
+            replacement: Some(replacement),
+            start: Position::line_start(line),
+            end,
+        }
+    }
+
+    /// Construct a replacement spanning complete source lines.
+    ///
+    /// This is the multi-line counterpart to [`Self::line_replacement`]. The
+    /// replacement contains its internal line terminators but not the terminator
+    /// of `end_line`; that final terminator is supplied separately so its
+    /// inclusion is explicit and CRLF can be preserved.
+    pub fn line_range_replacement(
+        description: impl Into<String>,
+        replacement: impl Into<String>,
+        start_line: usize,
+        end_line: usize,
+        original_end_line: &str,
+        end_line_ending: Option<&str>,
+    ) -> Self {
+        let mut replacement = replacement.into();
+        let end = if let Some(line_ending) = end_line_ending {
+            replacement.push_str(line_ending);
+            Position::line_start(end_line + 1)
+        } else {
+            Position::line_end(end_line, original_end_line)
+        };
+
+        Self {
+            description: description.into(),
+            replacement: Some(replacement),
+            start: Position::line_start(start_line),
+            end,
+        }
+    }
+
+    /// Resolve the exact half-open fix range to UTF-8 byte offsets.
+    ///
+    /// This is the canonical conversion for library embedders. The returned
+    /// range is validated for ordering, document bounds, UTF-8 boundaries, and
+    /// CRLF atomicity.
+    pub fn byte_range(&self, content: &str) -> Option<Range<usize>> {
+        let start = self.start.to_byte_offset(content)?;
+        let end = self.end.to_byte_offset(content)?;
+        (start <= end).then_some(start..end)
+    }
+}
+
+fn logical_line_bounds(content: &str, target_line: usize) -> Option<(usize, usize)> {
+    if target_line == 0 {
+        return None;
+    }
+
+    let mut line = 1;
+    let mut line_start = 0;
+    loop {
+        let newline = content[line_start..]
+            .find('\n')
+            .map(|relative| line_start + relative);
+        let line_end = match newline {
+            Some(newline_offset)
+                if content.as_bytes().get(newline_offset.wrapping_sub(1)) == Some(&b'\r') =>
+            {
+                newline_offset - 1
+            }
+            Some(newline_offset) => newline_offset,
+            None => content.len(),
+        };
+
+        if line == target_line {
+            return Some((line_start, line_end));
+        }
+
+        line_start = newline? + 1;
+        line += 1;
+    }
 }
 
 /// A violation found during linting
@@ -278,5 +516,112 @@ mod tests {
 
         assert_eq!(fix.replacement, None);
         assert_eq!(fix.description, "Remove extra newlines");
+    }
+
+    #[test]
+    fn position_columns_count_unicode_scalars() {
+        let content = "é🙂x\nβ";
+
+        assert_eq!(
+            Position { line: 1, column: 1 }.to_byte_offset(content),
+            Some(0)
+        );
+        assert_eq!(
+            Position { line: 1, column: 2 }.to_byte_offset(content),
+            Some(2)
+        );
+        assert_eq!(
+            Position { line: 1, column: 3 }.to_byte_offset(content),
+            Some(6)
+        );
+        assert_eq!(
+            Position { line: 1, column: 4 }.to_byte_offset(content),
+            Some(7)
+        );
+        assert_eq!(
+            Position { line: 2, column: 1 }.to_byte_offset(content),
+            Some(8)
+        );
+        assert_eq!(
+            Position { line: 2, column: 2 }.to_byte_offset(content),
+            Some(10)
+        );
+
+        assert_eq!(
+            Position::from_byte_offset(content, 6),
+            Some(Position { line: 1, column: 3 })
+        );
+        assert_eq!(
+            Position::from_byte_offset(content, 8),
+            Some(Position { line: 2, column: 1 })
+        );
+        assert_eq!(Position::from_byte_offset(content, 1), None);
+    }
+
+    #[test]
+    fn positions_keep_crlf_atomic() {
+        let content = "a\r\né";
+
+        assert_eq!(Position::line_end(1, "a").to_byte_offset(content), Some(1));
+        assert_eq!(Position::line_start(2).to_byte_offset(content), Some(3));
+        assert_eq!(
+            Position::from_byte_offset(content, 1),
+            Some(Position { line: 1, column: 2 })
+        );
+        assert_eq!(Position::from_byte_offset(content, 2), None);
+        assert_eq!(
+            Position::from_byte_offset(content, 3),
+            Some(Position { line: 2, column: 1 })
+        );
+    }
+
+    #[test]
+    fn fix_byte_ranges_are_exact_and_half_open() {
+        let content = "é🙂x\n";
+        let fix = Fix {
+            description: "replace emoji".to_string(),
+            replacement: Some("!".to_string()),
+            start: Position { line: 1, column: 2 },
+            end: Position { line: 1, column: 3 },
+        };
+
+        assert_eq!(fix.byte_range(content), Some(2..6));
+
+        let insertion = Fix::insertion("insert", "!", Position { line: 1, column: 2 });
+        assert_eq!(insertion.byte_range(content), Some(2..2));
+    }
+
+    #[test]
+    fn line_replacement_has_explicit_terminator_intent() {
+        let lf = Fix::line_replacement("replace", "new", 1, "old", Some("\n"));
+        assert_eq!(lf.replacement.as_deref(), Some("new\n"));
+        assert_eq!(lf.start, Position::line_start(1));
+        assert_eq!(lf.end, Position::line_start(2));
+        assert_eq!(lf.byte_range("old\nnext"), Some(0..4));
+
+        let crlf = Fix::line_replacement("replace", "new", 1, "old", Some("\r\n"));
+        assert_eq!(crlf.replacement.as_deref(), Some("new\r\n"));
+        assert_eq!(crlf.end, Position::line_start(2));
+        assert_eq!(crlf.byte_range("old\r\nnext"), Some(0..5));
+
+        let eof = Fix::line_replacement("replace", "new", 1, "old", None);
+        assert_eq!(eof.replacement.as_deref(), Some("new"));
+        assert_eq!(eof.end, Position::line_end(1, "old"));
+        assert_eq!(eof.byte_range("old"), Some(0..3));
+    }
+
+    #[test]
+    fn eof_positions_cover_empty_and_terminated_documents() {
+        assert_eq!(Position::line_start(1).to_byte_offset(""), Some(0));
+        assert_eq!(
+            Position::from_byte_offset("", 0),
+            Some(Position::line_start(1))
+        );
+        assert_eq!(Position::line_start(2).to_byte_offset("x\n"), Some(2));
+        assert_eq!(
+            Position::from_byte_offset("x\n", 2),
+            Some(Position::line_start(2))
+        );
+        assert_eq!(Position::line_start(2).to_byte_offset("x"), None);
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md001.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md001.rs
@@ -3,7 +3,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::{
     Document,
     rule::{AstRule, RuleCategory, RuleMetadata},
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// MD001: Heading levels should only increment by one level at a time
@@ -128,30 +128,21 @@ impl AstRule for MD001 {
                         } else {
                             ""
                         };
-                        format!(
-                            "{}{}\n",
-                            "#".repeat(expected_level as usize),
-                            heading_content
-                        )
+                        format!("{}{}", "#".repeat(expected_level as usize), heading_content)
                     } else {
                         // For simplicity, convert Setext to ATX with correct level
                         let heading_text = document.node_text(heading);
                         let heading_text = heading_text.trim();
-                        format!("{} {}\n", "#".repeat(expected_level as usize), heading_text)
+                        format!("{} {}", "#".repeat(expected_level as usize), heading_text)
                     };
 
-                    let fix = Fix {
-                        description: format!(
-                            "Change heading level from {} to {}",
-                            level, expected_level
-                        ),
-                        replacement: Some(fixed_line),
-                        start: Position { line, column: 1 },
-                        end: Position {
-                            line,
-                            column: line_content.len() + 1,
-                        },
-                    };
+                    let fix = Fix::line_replacement(
+                        format!("Change heading level from {} to {}", level, expected_level),
+                        fixed_line,
+                        line,
+                        line_content,
+                        document.line_ending(line),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         message,
@@ -301,7 +292,7 @@ mod tests {
         assert_eq!(fix.description, "Change heading level from 5 to 2");
         assert_eq!(
             fix.replacement,
-            Some("## Level 5 - skipped levels\n".to_string())
+            Some("## Level 5 - skipped levels".to_string())
         );
     }
 

--- a/crates/mdbook-lint-rulesets/src/standard/md002.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md002.rs
@@ -8,7 +8,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check that the first heading is a top-level heading
@@ -107,28 +107,26 @@ impl AstRule for MD002 {
                 } else {
                     ""
                 };
-                format!("{}{}\n", "#".repeat(self.level as usize), heading_content)
+                format!("{}{}", "#".repeat(self.level as usize), heading_content)
             } else {
                 // For Setext headings, convert to ATX with correct level
                 format!(
-                    "{} {}\n",
+                    "{} {}",
                     "#".repeat(self.level as usize),
                     heading_text.trim()
                 )
             };
 
-            let fix = Fix {
-                description: format!(
+            let fix = Fix::line_replacement(
+                format!(
                     "Change first heading level from {} to {}",
                     heading_level, self.level
                 ),
-                replacement: Some(fixed_line),
-                start: Position { line, column: 1 },
-                end: Position {
-                    line,
-                    column: line_content.len() + 1,
-                },
-            };
+                fixed_line,
+                line,
+                line_content,
+                document.line_ending(line),
+            );
 
             violations.push(self.create_violation_with_fix(
                 message,

--- a/crates/mdbook-lint-rulesets/src/standard/md003.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md003.rs
@@ -7,7 +7,7 @@ use comrak::nodes::{AstNode, NodeValue};
 use mdbook_lint_core::Document;
 use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{RuleCategory, RuleMetadata};
-use mdbook_lint_core::violation::{Fix, Position, Severity, Violation};
+use mdbook_lint_core::violation::{Fix, Severity, Violation};
 use serde::{Deserialize, Serialize};
 
 use super::atx::before_closing_hash_sequence;
@@ -251,15 +251,16 @@ impl MD003 {
 
         // Get the heading text content
         let heading_text = self.extract_heading_text(document, heading);
+        let line_ending = document.line_ending(heading.line).unwrap_or("\n");
 
         // Generate the replacement based on expected style
         let replacement = match expected_style {
             HeadingStyle::Atx => {
-                format!("{} {}\n", "#".repeat(heading.level as usize), heading_text)
+                format!("{} {}", "#".repeat(heading.level as usize), heading_text)
             }
             HeadingStyle::AtxClosed => {
                 format!(
-                    "{} {} {}\n",
+                    "{} {} {}",
                     "#".repeat(heading.level as usize),
                     heading_text,
                     "#".repeat(heading.level as usize)
@@ -269,25 +270,27 @@ impl MD003 {
                 if heading.level <= 2 {
                     let underline = if heading.level == 1 { "=" } else { "-" };
                     format!(
-                        "{}\n{}\n",
+                        "{}{}{}",
                         heading_text,
-                        underline.repeat(heading_text.len())
+                        line_ending,
+                        underline.repeat(heading_text.chars().count())
                     )
                 } else {
                     // Setext only supports levels 1 and 2, use ATX for higher levels
-                    format!("{} {}\n", "#".repeat(heading.level as usize), heading_text)
+                    format!("{} {}", "#".repeat(heading.level as usize), heading_text)
                 }
             }
             HeadingStyle::SetextWithAtx => {
                 if heading.level <= 2 {
                     let underline = if heading.level == 1 { "=" } else { "-" };
                     format!(
-                        "{}\n{}\n",
+                        "{}{}{}",
                         heading_text,
-                        underline.repeat(heading_text.len())
+                        line_ending,
+                        underline.repeat(heading_text.chars().count())
                     )
                 } else {
-                    format!("{} {}\n", "#".repeat(heading.level as usize), heading_text)
+                    format!("{} {}", "#".repeat(heading.level as usize), heading_text)
                 }
             }
         };
@@ -301,22 +304,19 @@ impl MD003 {
                 (heading.line, heading.line)
             };
 
-        Fix {
-            description: format!("Convert to {} style", expected_style),
-            replacement: Some(replacement),
-            start: Position {
-                line: start_line,
-                column: 1,
-            },
-            end: Position {
-                line: end_line,
-                column: if end_line > start_line && end_line <= document.lines.len() {
-                    document.lines[end_line - 1].len() + 1
-                } else {
-                    document.lines[line_idx].len() + 1
-                },
-            },
-        }
+        let original_end_line = if end_line > start_line && end_line <= document.lines.len() {
+            &document.lines[end_line - 1]
+        } else {
+            &document.lines[line_idx]
+        };
+        Fix::line_range_replacement(
+            format!("Convert to {} style", expected_style),
+            replacement,
+            start_line,
+            end_line,
+            original_end_line,
+            document.line_ending(end_line),
+        )
     }
 
     /// Extract the text content of a heading
@@ -726,14 +726,14 @@ Section A
         assert_eq!(fix1.description, "Convert to atx style");
         assert_eq!(fix1.replacement, Some("# Main Title\n".to_string()));
         assert_eq!(fix1.start.line, 1);
-        assert_eq!(fix1.end.line, 2); // Setext spans two lines
+        assert_eq!(fix1.end.line, 3); // Consumes the underline terminator
 
         // Check second heading fix
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
         assert_eq!(fix2.replacement, Some("## Section A\n".to_string()));
         assert_eq!(fix2.start.line, 4);
-        assert_eq!(fix2.end.line, 5);
+        assert_eq!(fix2.end.line, 6);
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md004.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md004.rs
@@ -263,10 +263,7 @@ impl MD004 {
                     line: line_number,
                     column: 1,
                 },
-                end: Position {
-                    line: line_number,
-                    column: line.len() + 1,
-                },
+                end: Position::line_end(line_number, line),
             }
         } else {
             Fix {

--- a/crates/mdbook-lint-rulesets/src/standard/md005.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md005.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check for consistent list item indentation
@@ -80,27 +80,22 @@ impl MD005 {
 
                     let fixed_line = if actual_indent > expected {
                         // Remove extra spaces
-                        format!("{}\n", &line[spaces_to_adjust..])
+                        line[spaces_to_adjust..].to_string()
                     } else {
                         // Add missing spaces
-                        format!("{}{}\n", " ".repeat(spaces_to_adjust), line)
+                        format!("{}{}", " ".repeat(spaces_to_adjust), line)
                     };
 
-                    let fix = Fix {
-                        description: format!(
+                    let fix = Fix::line_replacement(
+                        format!(
                             "Adjust indentation from {} to {} spaces",
                             actual_indent, expected
                         ),
-                        replacement: Some(fixed_line),
-                        start: Position {
-                            line: line_num,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: line_num,
-                            column: line.len() + 1,
-                        },
-                    };
+                        fixed_line,
+                        line_num,
+                        line,
+                        document.line_ending(line_num),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         format!(
@@ -336,7 +331,7 @@ Some text here.
         assert_eq!(fix.description, "Adjust indentation from 0 to 2 spaces");
         assert_eq!(
             fix.replacement,
-            Some("  - Item 3 (wrong indentation)\n".to_string())
+            Some("  - Item 3 (wrong indentation)".to_string())
         );
     }
 
@@ -361,7 +356,7 @@ Some text here.
         assert_eq!(fix.description, "Adjust indentation from 1 to 0 spaces");
         assert_eq!(
             fix.replacement,
-            Some("- Item 3 (inconsistent at same level)\n".to_string())
+            Some("- Item 3 (inconsistent at same level)".to_string())
         );
     }
 
@@ -408,7 +403,7 @@ Some text here.
         assert_eq!(fix.description, "Adjust indentation from 3 to 2 spaces");
         assert_eq!(
             fix.replacement,
-            Some("  - Nested item B (inconsistent)\n".to_string())
+            Some("  - Nested item B (inconsistent)".to_string())
         );
     }
 
@@ -457,7 +452,7 @@ Some text here.
         );
         assert_eq!(
             violations[2].fix.as_ref().unwrap().replacement,
-            Some("- Item 4 (3 spaces)\n".to_string())
+            Some("- Item 4 (3 spaces)".to_string())
         );
     }
 
@@ -503,7 +498,7 @@ Some text here.
         assert_eq!(fix.description, "Adjust indentation from 1 to 0 spaces");
         assert_eq!(
             fix.replacement,
-            Some("- Item 2 (1 space - inconsistent)\n".to_string())
+            Some("- Item 2 (1 space - inconsistent)".to_string())
         );
     }
 

--- a/crates/mdbook-lint-rulesets/src/standard/md006.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md006.rs
@@ -1,7 +1,7 @@
 use mdbook_lint_core::Document;
 use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
-use mdbook_lint_core::violation::{Fix, Position, Severity, Violation};
+use mdbook_lint_core::violation::{Fix, Severity, Violation};
 
 /// MD006 - Consider starting bulleted lists at the beginning of the line
 pub struct MD006;
@@ -68,19 +68,14 @@ impl Rule for MD006 {
                     if second_char.is_whitespace() {
                         // This is an indented unordered list item
                         // Create fix by removing the indentation
-                        let fixed_line = format!("{}\n", &line[first_char_pos..]);
-                        let fix = Fix {
-                            description: format!("Remove {} spaces of indentation", first_char_pos),
-                            replacement: Some(fixed_line),
-                            start: Position {
-                                line: line_number,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: line_number,
-                                column: line.len() + 1,
-                            },
-                        };
+                        let fixed_line = line[first_char_pos..].to_string();
+                        let fix = Fix::line_replacement(
+                            format!("Remove {} spaces of indentation", first_char_pos),
+                            fixed_line,
+                            line_number,
+                            line,
+                            document.line_ending(line_number),
+                        );
 
                         violations.push(
                             self.create_violation_with_fix(

--- a/crates/mdbook-lint-rulesets/src/standard/md007.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md007.rs
@@ -277,10 +277,7 @@ impl AstRule for MD007 {
                                 line: line_number,
                                 column: 1,
                             },
-                            end: Position {
-                                line: line_number,
-                                column: line.len() + 1,
-                            },
+                            end: Position::line_end(line_number, line),
                         };
 
                         violations.push(self.create_violation_with_fix(

--- a/crates/mdbook-lint-rulesets/src/standard/md009.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md009.rs
@@ -60,7 +60,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check for trailing spaces at the end of lines
@@ -195,27 +195,22 @@ impl AstRule for MD009 {
             }
 
             // Create violation with fix
-            let column = line.len() - trailing_spaces + 1;
+            let column = line.chars().count() - trailing_spaces + 1;
 
             // Create the fixed line by removing trailing whitespace
-            let fixed_line = line.trim_end().to_string() + "\n";
+            let fixed_line = line.trim_end().to_string();
 
-            let fix = Fix {
-                description: format!(
+            let fix = Fix::line_replacement(
+                format!(
                     "Remove {} trailing space{}",
                     trailing_spaces,
                     if trailing_spaces == 1 { "" } else { "s" }
                 ),
-                replacement: Some(fixed_line),
-                start: Position {
-                    line: line_num,
-                    column: 1,
-                },
-                end: Position {
-                    line: line_num,
-                    column: line.len() + 1,
-                },
-            };
+                fixed_line,
+                line_num,
+                line,
+                document.line_ending(line_num),
+            );
 
             violations.push(self.create_violation_with_fix(
                 format!(
@@ -411,7 +406,7 @@ mod tests {
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(
             fix.replacement.as_ref().unwrap(),
-            "Line with trailing space\n"
+            "Line with trailing space"
         );
         assert_eq!(fix.description, "Remove 1 trailing space");
     }
@@ -426,7 +421,7 @@ mod tests {
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with spaces\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with spaces");
         assert_eq!(fix.description, "Remove 4 trailing spaces");
     }
 
@@ -440,7 +435,7 @@ mod tests {
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with tab\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with tab");
         assert_eq!(fix.description, "Remove 1 trailing space");
     }
 
@@ -454,7 +449,7 @@ mod tests {
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with mixed\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "Line with mixed");
         assert_eq!(fix.description, "Remove 5 trailing spaces");
     }
 
@@ -488,7 +483,7 @@ mod tests {
         assert_eq!(fix.start.line, 1);
         assert_eq!(fix.start.column, 1);
         assert_eq!(fix.end.line, 1);
-        assert_eq!(fix.end.column, content.len() + 1);
+        assert_eq!(fix.end.column, content.chars().count() + 1);
     }
 
     #[test]
@@ -547,7 +542,7 @@ mod tests {
                 .replacement
                 .as_ref()
                 .unwrap(),
-            "Third line with many\n"
+            "Third line with many"
         );
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md010.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md010.rs
@@ -186,10 +186,7 @@ impl Rule for MD010 {
                         line: line_num,
                         column: 1,
                     },
-                    end: Position {
-                        line: line_num,
-                        column: line.len() + 1,
-                    },
+                    end: Position::line_end(line_num, line),
                 };
 
                 violations.push(self.create_violation_with_fix(

--- a/crates/mdbook-lint-rulesets/src/standard/md014.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md014.rs
@@ -8,7 +8,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check that shell commands don't include dollar signs
@@ -89,6 +89,8 @@ impl AstRule for MD014 {
                                 };
 
                                 // Create a fixed version of the entire code block
+                                let line_ending =
+                                    document.line_ending(base_line + 1).unwrap_or("\n");
                                 let fixed_content = lines
                                     .iter()
                                     .enumerate()
@@ -100,22 +102,18 @@ impl AstRule for MD014 {
                                         }
                                     })
                                     .collect::<Vec<_>>()
-                                    .join("\n");
+                                    .join(line_ending);
 
                                 // The fix needs to replace the entire code block content
-                                let fix = Fix {
-                                    description: "Remove dollar sign prompt from command"
-                                        .to_string(),
-                                    replacement: Some(format!("{}\n", fixed_content)),
-                                    start: Position {
-                                        line: base_line + 1,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: base_line + lines.len(),
-                                        column: lines.last().map(|l| l.len() + 1).unwrap_or(1),
-                                    },
-                                };
+                                let end_line = base_line + lines.len();
+                                let fix = Fix::line_range_replacement(
+                                    "Remove dollar sign prompt from command",
+                                    fixed_content,
+                                    base_line + 1,
+                                    end_line,
+                                    lines.last().copied().unwrap_or(""),
+                                    document.line_ending(end_line),
+                                );
 
                                 violations.push(self.create_violation_with_fix(
                                     format!("Shell command should not include dollar sign prompt: '{trimmed}'"),

--- a/crates/mdbook-lint-rulesets/src/standard/md018.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md018.rs
@@ -6,7 +6,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 use super::atx::trailing_hash_sequence;
@@ -81,23 +81,18 @@ impl Rule for MD018 {
                             let content =
                                 trimmed[hash_count..closing_start].trim_matches([' ', '\t']);
                             let closing_hashes = &trimmed[closing_start..closing_end];
-                            format!("{indent}{hashes} {content} {closing_hashes}\n")
+                            format!("{indent}{hashes} {content} {closing_hashes}")
                         } else {
-                            format!("{indent}{hashes} {}\n", after_hashes.trim())
+                            format!("{indent}{hashes} {}", after_hashes.trim())
                         };
 
-                        let fix = Fix {
-                            description: "Add space after hash on atx style heading".to_string(),
-                            replacement: Some(fixed_line),
-                            start: Position {
-                                line: line_num,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: line_num,
-                                column: line.chars().count() + 1,
-                            },
-                        };
+                        let fix = Fix::line_replacement(
+                            "Add space after hash on atx style heading",
+                            fixed_line,
+                            line_num,
+                            line,
+                            document.line_ending(line_num),
+                        );
 
                         violations.push(self.create_violation_with_fix(
                             "No space after hash on atx style heading".to_string(),
@@ -277,7 +272,7 @@ def foo():
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "# Heading\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "# Heading");
         assert_eq!(fix.description, "Add space after hash on atx style heading");
     }
 
@@ -296,7 +291,7 @@ def foo():
 
         // Second heading
         let fix2 = violations[1].fix.as_ref().unwrap();
-        assert_eq!(fix2.replacement.as_ref().unwrap(), "### Heading Three\n");
+        assert_eq!(fix2.replacement.as_ref().unwrap(), "### Heading Three");
     }
 
     #[test]
@@ -308,7 +303,7 @@ def foo():
 
         assert_eq!(violations.len(), 1);
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "  ## Indented Heading\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "  ## Indented Heading");
     }
 
     #[test]
@@ -320,7 +315,7 @@ def foo():
 
         assert_eq!(violations.len(), 1);
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "## Closed Heading ##\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "## Closed Heading ##");
     }
 
     #[test]
@@ -335,7 +330,7 @@ def foo():
         assert_eq!(fix.start.line, 1);
         assert_eq!(fix.start.column, 1);
         assert_eq!(fix.end.line, 1);
-        assert_eq!(fix.end.column, content.len() + 1);
+        assert_eq!(fix.end.column, content.chars().count() + 1);
     }
 
     #[test]
@@ -347,7 +342,7 @@ def foo():
 
         assert_eq!(violations.len(), 1);
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "# Heading with spaces\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "# Heading with spaces");
     }
 
     #[test]
@@ -416,7 +411,7 @@ def foo():
                 .replacement
                 .as_ref()
                 .unwrap(),
-            "###### H6\n"
+            "###### H6"
         );
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md019.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md019.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check for multiple spaces after hash on ATX style headings
@@ -70,23 +70,18 @@ impl Rule for MD019 {
                         let indent = &line[..line.len() - trimmed.len()];
                         let hashes = &trimmed[..hash_count];
                         let content = after_hashes.trim_start();
-                        let fixed_line = format!("{}{} {}\n", indent, hashes, content);
+                        let fixed_line = format!("{}{} {}", indent, hashes, content);
 
-                        let fix = Fix {
-                            description: format!(
+                        let fix = Fix::line_replacement(
+                            format!(
                                 "Replace {} spaces with 1 space after hash",
                                 whitespace_count
                             ),
-                            replacement: Some(fixed_line),
-                            start: Position {
-                                line: line_num,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: line_num,
-                                column: line.len() + 1,
-                            },
-                        };
+                            fixed_line,
+                            line_num,
+                            line,
+                            document.line_ending(line_num),
+                        );
 
                         violations.push(self.create_violation_with_fix(
                             format!("Multiple spaces after hash on ATX heading: found {whitespace_count} whitespace characters, expected 1"),
@@ -451,7 +446,7 @@ Regular text.
         );
         assert_eq!(
             violations[5].fix.as_ref().unwrap().replacement,
-            Some("###### Level 6\n".to_string())
+            Some("###### Level 6".to_string())
         );
     }
 }

--- a/crates/mdbook-lint-rulesets/src/standard/md020.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md020.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 use super::atx::trailing_hash_sequence;
@@ -86,20 +86,15 @@ impl Rule for MD020 {
             let indent = &line[..line.len() - trimmed.len()];
             let opening_hashes = &trimmed[..opening_hash_count];
             let closing_hashes = &trimmed[closing_start..closing_end];
-            let fixed_line = format!("{indent}{opening_hashes} {content} {closing_hashes}\n");
+            let fixed_line = format!("{indent}{opening_hashes} {content} {closing_hashes}");
 
-            let fix = Fix {
-                description: "Add missing spaces inside closed ATX heading".to_string(),
-                replacement: Some(fixed_line),
-                start: Position {
-                    line: line_num,
-                    column: 1,
-                },
-                end: Position {
-                    line: line_num,
-                    column: line.chars().count() + 1,
-                },
-            };
+            let fix = Fix::line_replacement(
+                "Add missing spaces inside closed ATX heading",
+                fixed_line,
+                line_num,
+                line,
+                document.line_ending(line_num),
+            );
 
             violations.push(self.create_violation_with_fix(
                 "Missing space inside hashes on closed ATX heading".to_string(),
@@ -196,7 +191,8 @@ mod tests {
     fn fix_range_uses_character_columns() {
         let violations = check("##Résumé ##\n");
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.end.column, "##Résumé ##".chars().count() + 1);
+        assert_eq!(fix.end.line, 2);
+        assert_eq!(fix.end.column, 1);
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md021.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md021.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check for multiple spaces inside hashes on closed ATX style headings
@@ -79,24 +79,17 @@ impl Rule for MD021 {
                             let closing_hashes = &trimmed[trimmed.len() - closing_hash_count..];
                             let content = content_with_spaces.trim();
                             let fixed_line = format!(
-                                "{}{} {} {}\n",
+                                "{}{} {} {}",
                                 indent, opening_hashes, content, closing_hashes
                             );
 
-                            let fix = Fix {
-                                description:
-                                    "Replace multiple spaces with single spaces inside hashes"
-                                        .to_string(),
-                                replacement: Some(fixed_line),
-                                start: Position {
-                                    line: line_num,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: line_num,
-                                    column: line.len() + 1,
-                                },
-                            };
+                            let fix = Fix::line_replacement(
+                                "Replace multiple spaces with single spaces inside hashes",
+                                fixed_line,
+                                line_num,
+                                line,
+                                document.line_ending(line_num),
+                            );
 
                             if leading_whitespace_count > 1 {
                                 violations.push(self.create_violation_with_fix(

--- a/crates/mdbook-lint-rulesets/src/standard/md022.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md022.rs
@@ -56,22 +56,11 @@ impl AstRule for MD022 {
                 if !self.has_blank_line_before(document, line) {
                     // Create fix to add blank line before heading
                     let fix = if line > 1 {
-                        // Get the previous line to determine where to insert the blank line
-                        let prev_line_idx = line - 2; // Convert to 0-based index
-                        let prev_line = &document.lines[prev_line_idx];
-
-                        Fix {
-                            description: "Add blank line before heading".to_string(),
-                            replacement: Some(format!("{}\n", prev_line)),
-                            start: Position {
-                                line: line - 1,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: line - 1,
-                                column: prev_line.len() + 1,
-                            },
-                        }
+                        Fix::insertion(
+                            "Add blank line before heading",
+                            document.line_ending(line - 1).unwrap_or("\n"),
+                            Position::line_start(line),
+                        )
                     } else {
                         // Can't add blank line before first line
                         Fix {
@@ -93,18 +82,11 @@ impl AstRule for MD022 {
 
                 // Check for blank line after the heading
                 if !self.has_blank_line_after(document, line) {
-                    // Create fix to add blank line after heading
-                    let current_line = &document.lines[line - 1]; // Convert to 0-based
-
-                    let fix = Fix {
-                        description: "Add blank line after heading".to_string(),
-                        replacement: Some(format!("{}\n", current_line)),
-                        start: Position { line, column: 1 },
-                        end: Position {
-                            line,
-                            column: current_line.len() + 1,
-                        },
-                    };
+                    let fix = Fix::insertion(
+                        "Add blank line after heading",
+                        document.line_ending(line).unwrap_or("\n"),
+                        Position::line_start(line + 1),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         "Heading should be followed by a blank line".to_string(),
@@ -475,9 +457,10 @@ Content after."#;
 
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Add blank line before heading");
-        assert_eq!(fix.replacement, Some("Some text before.\n".to_string()));
-        assert_eq!(fix.start.line, 1);
+        assert_eq!(fix.replacement, Some("\n".to_string()));
+        assert_eq!(fix.start.line, 2);
         assert_eq!(fix.start.column, 1);
+        assert_eq!(fix.end, fix.start);
     }
 
     #[test]
@@ -493,9 +476,10 @@ Content immediately after."#;
 
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.description, "Add blank line after heading");
-        assert_eq!(fix.replacement, Some("# Title\n".to_string()));
-        assert_eq!(fix.start.line, 1);
+        assert_eq!(fix.replacement, Some("\n".to_string()));
+        assert_eq!(fix.start.line, 2);
         assert_eq!(fix.start.column, 1);
+        assert_eq!(fix.end, fix.start);
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md023.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md023.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check that headings start at the beginning of the line
@@ -58,24 +58,19 @@ impl AstRule for MD023 {
                 let leading_whitespace = line.len() - trimmed.len();
 
                 // Create fixed line by removing the indentation
-                let fixed_line = format!("{}\n", trimmed);
+                let fixed_line = trimmed.to_string();
 
-                let fix = Fix {
-                    description: format!(
+                let fix = Fix::line_replacement(
+                    format!(
                         "Remove {} character{} of indentation",
                         leading_whitespace,
                         if leading_whitespace == 1 { "" } else { "s" }
                     ),
-                    replacement: Some(fixed_line),
-                    start: Position {
-                        line: line_num,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: line_num,
-                        column: line.len() + 1,
-                    },
-                };
+                    fixed_line,
+                    line_num,
+                    line,
+                    document.line_ending(line_num),
+                );
 
                 violations.push(self.create_violation_with_fix(
                     format!(
@@ -289,7 +284,7 @@ mod tests {
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "# Heading\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "# Heading");
         assert_eq!(fix.description, "Remove 1 character of indentation");
     }
 
@@ -304,7 +299,7 @@ mod tests {
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(
             fix.replacement.as_ref().unwrap(),
-            "## Heading with 3 spaces\n"
+            "## Heading with 3 spaces"
         );
         assert_eq!(fix.description, "Remove 3 characters of indentation");
     }
@@ -319,7 +314,7 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "# Two space indented\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "# Two space indented");
         assert_eq!(fix.description, "Remove 2 characters of indentation");
     }
 
@@ -333,7 +328,7 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "### Two space indent\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "### Two space indent");
         assert_eq!(fix.description, "Remove 2 characters of indentation");
     }
 
@@ -346,7 +341,7 @@ mod tests {
 
         assert_eq!(violations.len(), 1);
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "## Closed heading ##\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "## Closed heading ##");
     }
 
     #[test]
@@ -385,7 +380,7 @@ mod tests {
                 .replacement
                 .as_ref()
                 .unwrap(),
-            "### Third\n"
+            "### Third"
         );
     }
 
@@ -401,7 +396,7 @@ mod tests {
         assert_eq!(fix.start.line, 1);
         assert_eq!(fix.start.column, 1);
         assert_eq!(fix.end.line, 1);
-        assert_eq!(fix.end.column, content.len() + 1);
+        assert_eq!(fix.end.column, content.chars().count() + 1);
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md024.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md024.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 use std::collections::HashMap;
 
@@ -132,21 +132,19 @@ impl MD024 {
                         let trimmed = line_content.trim_start();
                         let hashes_end = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
                         let hashes = &trimmed[..hashes_end];
-                        format!("{} {}\n", hashes, unique_text)
+                        format!("{} {}", hashes, unique_text)
                     } else {
                         // Setext heading - keep original format but change text
-                        format!("{}\n", unique_text)
+                        unique_text.clone()
                     };
 
-                    let fix = Fix {
-                        description: format!("Make heading unique by appending ' {}'", counter),
-                        replacement: Some(fixed_line),
-                        start: Position { line, column: 1 },
-                        end: Position {
-                            line,
-                            column: line_content.len() + 1,
-                        },
-                    };
+                    let fix = Fix::line_replacement(
+                        format!("Make heading unique by appending ' {}'", counter),
+                        fixed_line,
+                        line,
+                        line_content,
+                        document.line_ending(line),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         format!(
@@ -216,21 +214,19 @@ impl MD024 {
                         let trimmed = line_content.trim_start();
                         let hashes_end = trimmed.find(|c: char| c != '#').unwrap_or(trimmed.len());
                         let hashes = &trimmed[..hashes_end];
-                        format!("{} {}\n", hashes, unique_text)
+                        format!("{} {}", hashes, unique_text)
                     } else {
                         // Setext heading - keep original format but change text
-                        format!("{}\n", unique_text)
+                        unique_text.clone()
                     };
 
-                    let fix = Fix {
-                        description: format!("Make heading unique by appending ' {}'", counter),
-                        replacement: Some(fixed_line),
-                        start: Position { line, column: 1 },
-                        end: Position {
-                            line,
-                            column: line_content.len() + 1,
-                        },
-                    };
+                    let fix = Fix::line_replacement(
+                        format!("Make heading unique by appending ' {}'", counter),
+                        fixed_line,
+                        line,
+                        line_content,
+                        document.line_ending(line),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         format!(
@@ -553,7 +549,7 @@ ATX Heading
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
         assert_eq!(fix2.description, "Make heading unique by appending ' 3'");
-        assert_eq!(fix2.replacement, Some("## Config 3\n".to_string()));
+        assert_eq!(fix2.replacement, Some("## Config 3".to_string()));
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md025.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md025.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check that documents have only one H1 heading
@@ -99,24 +99,19 @@ impl AstRule for MD025 {
                     } else {
                         ""
                     };
-                    format!("{}{}\n", "#".repeat(new_level as usize), heading_content)
+                    format!("{}{}", "#".repeat(new_level as usize), heading_content)
                 } else {
                     // Setext heading - convert to ATX at level 2
-                    format!("{} {}\n", "#".repeat(new_level as usize), heading_text)
+                    format!("{} {}", "#".repeat(new_level as usize), heading_text)
                 };
 
-                let fix = Fix {
-                    description: format!("Demote heading to level {}", new_level),
-                    replacement: Some(fixed_line),
-                    start: Position {
-                        line: *line,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: *line,
-                        column: line_content.len() + 1,
-                    },
-                };
+                let fix = Fix::line_replacement(
+                    format!("Demote heading to level {}", new_level),
+                    fixed_line,
+                    *line,
+                    line_content,
+                    document.line_ending(*line),
+                );
 
                 violations.push(self.create_violation_with_fix(
                     format!(
@@ -362,7 +357,7 @@ More content.
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
         assert_eq!(fix2.description, "Demote heading to level 2");
-        assert_eq!(fix2.replacement, Some("## Third Title\n".to_string()));
+        assert_eq!(fix2.replacement, Some("## Third Title".to_string()));
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md026.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md026.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check that headings do not end with punctuation
@@ -186,28 +186,26 @@ impl AstRule for MD026 {
                                 .map(|i| i + 1)
                                 .unwrap_or(0);
                             format!(
-                                "{} {} {}\n",
+                                "{} {} {}",
                                 hashes,
                                 heading_without_punct,
                                 content_after_hashes[closing_hashes_start..].trim()
                             )
                         } else {
-                            format!("{} {}\n", hashes, heading_without_punct)
+                            format!("{} {}", hashes, heading_without_punct)
                         }
                     } else {
                         // Setext heading - just replace the text
-                        format!("{}\n", heading_without_punct)
+                        heading_without_punct.to_string()
                     };
 
-                    let fix = Fix {
-                        description: format!("Remove trailing punctuation '{}'", last_char),
-                        replacement: Some(fixed_line),
-                        start: Position { line, column: 1 },
-                        end: Position {
-                            line,
-                            column: line_content.len() + 1,
-                        },
-                    };
+                    let fix = Fix::line_replacement(
+                        format!("Remove trailing punctuation '{}'", last_char),
+                        fixed_line,
+                        line,
+                        line_content,
+                        document.line_ending(line),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         format!(
@@ -485,10 +483,7 @@ Another setext with exclamation!
         assert!(violations[1].fix.is_some());
         let fix2 = violations[1].fix.as_ref().unwrap();
         assert_eq!(fix2.description, "Remove trailing punctuation '.'");
-        assert_eq!(
-            fix2.replacement,
-            Some("## Another with period\n".to_string())
-        );
+        assert_eq!(fix2.replacement, Some("## Another with period".to_string()));
     }
 
     #[test]
@@ -504,10 +499,7 @@ Another setext with exclamation!
 
         let fix = violations[0].fix.as_ref().unwrap();
         // Should remove all trailing punctuation
-        assert_eq!(
-            fix.replacement,
-            Some("# Heading with multiple\n".to_string())
-        );
+        assert_eq!(fix.replacement, Some("# Heading with multiple".to_string()));
     }
 
     #[test]

--- a/crates/mdbook-lint-rulesets/src/standard/md027.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md027.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check for multiple spaces after blockquote symbol
@@ -115,25 +115,16 @@ impl Rule for MD027 {
                         fixed_line.push(' ');
                     }
                     fixed_line.push_str(&after);
-                    if !fixed_line.ends_with('\n') {
-                        fixed_line.push('\n');
-                    }
-
-                    let fix = Fix {
-                        description: format!(
+                    let fix = Fix::line_replacement(
+                        format!(
                             "Replace {} spaces with 1 space after blockquote symbol",
                             whitespace_count
                         ),
-                        replacement: Some(fixed_line),
-                        start: Position {
-                            line: line_num,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: line_num,
-                            column: line.len() + 1,
-                        },
-                    };
+                        fixed_line,
+                        line_num,
+                        line,
+                        document.line_ending(line_num),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         format!("Multiple spaces after blockquote symbol: found {whitespace_count} whitespace characters, expected 1"),

--- a/crates/mdbook-lint-rulesets/src/standard/md028.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md028.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check for blank lines inside blockquotes
@@ -72,18 +72,13 @@ impl Rule for MD028 {
                 // then this blank line breaks the blockquote
                 if prev_is_blockquote && next_is_blockquote {
                     // Create fix by adding > to the blank line
-                    let fix = Fix {
-                        description: "Add blockquote marker to blank line".to_string(),
-                        replacement: Some(">\n".to_string()),
-                        start: Position {
-                            line: line_num,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: line_num,
-                            column: line.len() + 1,
-                        },
-                    };
+                    let fix = Fix::line_replacement(
+                        "Add blockquote marker to blank line",
+                        ">",
+                        line_num,
+                        line,
+                        document.line_ending(line_num),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         "Blank line inside blockquote".to_string(),

--- a/crates/mdbook-lint-rulesets/src/standard/md029.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md029.rs
@@ -8,7 +8,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Configuration for ordered list prefix style
@@ -165,23 +165,18 @@ impl MD029 {
                 // Find where the number ends (at the dot)
                 if let Some(dot_pos) = trimmed.find('.') {
                     let after_dot = &trimmed[dot_pos..];
-                    let fixed_line = format!("{}{}{}\n", indent, expected_prefix, after_dot);
+                    let fixed_line = format!("{}{}{}", indent, expected_prefix, after_dot);
 
-                    let fix = Fix {
-                        description: format!(
+                    let fix = Fix::line_replacement(
+                        format!(
                             "Change list item prefix from '{}' to '{}'",
                             actual_prefix, expected_prefix
                         ),
-                        replacement: Some(fixed_line),
-                        start: Position {
-                            line: *line_num,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: *line_num,
-                            column: line_content.len() + 1,
-                        },
-                    };
+                        fixed_line,
+                        *line_num,
+                        line_content,
+                        document.line_ending(*line_num),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         format!(

--- a/crates/mdbook-lint-rulesets/src/standard/md030.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md030.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Configuration for spaces after list markers
@@ -159,7 +159,7 @@ impl Rule for MD030 {
                 continue;
             }
 
-            if let Some(violation) = self.check_list_marker_spacing(line, line_num) {
+            if let Some(violation) = self.check_list_marker_spacing(document, line, line_num) {
                 violations.push(violation);
             }
         }
@@ -170,7 +170,12 @@ impl Rule for MD030 {
 
 impl MD030 {
     /// Check spacing after list markers on a single line
-    fn check_list_marker_spacing(&self, line: &str, line_num: usize) -> Option<Violation> {
+    fn check_list_marker_spacing(
+        &self,
+        document: &Document,
+        line: &str,
+        line_num: usize,
+    ) -> Option<Violation> {
         let trimmed = line.trim_start();
         let indent_count = line.len() - trimmed.len();
 
@@ -202,22 +207,17 @@ impl MD030 {
                 let content_after_spaces = after_marker.trim_start();
                 let spaces = " ".repeat(expected_spaces);
                 let fixed_line = format!(
-                    "{}{}{}{}\n",
+                    "{}{}{}{}",
                     indent, marker_char, spaces, content_after_spaces
                 );
 
-                let fix = Fix {
-                    description: format!("Use {} space(s) after list marker", expected_spaces),
-                    replacement: Some(fixed_line),
-                    start: Position {
-                        line: line_num,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: line_num,
-                        column: line.len() + 1,
-                    },
-                };
+                let fix = Fix::line_replacement(
+                    format!("Use {} space(s) after list marker", expected_spaces),
+                    fixed_line,
+                    line_num,
+                    line,
+                    document.line_ending(line_num),
+                );
 
                 return Some(self.create_violation_with_fix(
                     format!(
@@ -249,21 +249,15 @@ impl MD030 {
                 let indent = &line[..indent_count];
                 let content_after_spaces = after_dot.trim_start();
                 let spaces = " ".repeat(expected_spaces);
-                let fixed_line =
-                    format!("{}{}.{}{}\n", indent, number, spaces, content_after_spaces);
+                let fixed_line = format!("{}{}.{}{}", indent, number, spaces, content_after_spaces);
 
-                let fix = Fix {
-                    description: format!("Use {} space(s) after list marker", expected_spaces),
-                    replacement: Some(fixed_line),
-                    start: Position {
-                        line: line_num,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: line_num,
-                        column: line.len() + 1,
-                    },
-                };
+                let fix = Fix::line_replacement(
+                    format!("Use {} space(s) after list marker", expected_spaces),
+                    fixed_line,
+                    line_num,
+                    line,
+                    document.line_ending(line_num),
+                );
 
                 return Some(self.create_violation_with_fix(
                     format!(
@@ -886,10 +880,7 @@ Another list:
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(
-            fix.replacement.as_ref().unwrap(),
-            "* No space after marker\n"
-        );
+        assert_eq!(fix.replacement.as_ref().unwrap(), "* No space after marker");
         assert_eq!(fix.description, "Use 1 space(s) after list marker");
     }
 
@@ -903,7 +894,7 @@ Another list:
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(fix.replacement.as_ref().unwrap(), "- Too many spaces\n");
+        assert_eq!(fix.replacement.as_ref().unwrap(), "- Too many spaces");
     }
 
     #[test]
@@ -918,7 +909,7 @@ Another list:
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(
             fix.replacement.as_ref().unwrap(),
-            "1. No space after period\n"
+            "1. No space after period"
         );
     }
 
@@ -932,10 +923,7 @@ Another list:
         assert_eq!(violations.len(), 1);
         assert!(violations[0].fix.is_some());
         let fix = violations[0].fix.as_ref().unwrap();
-        assert_eq!(
-            fix.replacement.as_ref().unwrap(),
-            "42. Way too many spaces\n"
-        );
+        assert_eq!(fix.replacement.as_ref().unwrap(), "42. Way too many spaces");
     }
 
     #[test]
@@ -950,7 +938,7 @@ Another list:
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(
             fix.replacement.as_ref().unwrap(),
-            "    * No space after marker\n"
+            "    * No space after marker"
         );
     }
 
@@ -996,7 +984,7 @@ Another list:
                 .replacement
                 .as_ref()
                 .unwrap(),
-            "+ Way too many\n"
+            "+ Way too many"
         );
     }
 
@@ -1034,7 +1022,7 @@ Another list:
                 .replacement
                 .as_ref()
                 .unwrap(),
-            "1.  One space\n"
+            "1.  One space"
         );
     }
 
@@ -1049,7 +1037,7 @@ Another list:
         let fix = violations[0].fix.as_ref().unwrap();
         assert_eq!(fix.start.line, 2);
         assert_eq!(fix.start.column, 1);
-        assert_eq!(fix.end.line, 2);
+        assert_eq!(fix.end.line, 3);
         assert_eq!(violations[0].line, 2);
     }
 

--- a/crates/mdbook-lint-rulesets/src/standard/md031.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md031.rs
@@ -50,26 +50,11 @@ impl AstRule for MD031 {
                 // Check for blank line before the code block
                 if !self.has_blank_line_before(document, line) {
                     // Create fix by inserting a blank line before the code block
-                    let fix = Fix {
-                        description: "Add blank line before fenced code block".to_string(),
-                        replacement: Some("\n".to_string()),
-                        start: Position {
-                            line: line - 1,
-                            column: if line > 1 {
-                                document.lines.get(line - 2).map_or(1, |l| l.len() + 1)
-                            } else {
-                                1
-                            },
-                        },
-                        end: Position {
-                            line: line - 1,
-                            column: if line > 1 {
-                                document.lines.get(line - 2).map_or(1, |l| l.len() + 1)
-                            } else {
-                                1
-                            },
-                        },
-                    };
+                    let fix = Fix::insertion(
+                        "Add blank line before fenced code block",
+                        document.line_ending(line - 1).unwrap_or("\n"),
+                        Position::line_start(line),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         "Fenced code block should be preceded by a blank line".to_string(),
@@ -84,18 +69,11 @@ impl AstRule for MD031 {
                 let end_line = self.find_code_block_end_line(document, line);
                 if !self.has_blank_line_after(document, end_line) {
                     // Create fix by inserting a blank line after the code block
-                    let fix = Fix {
-                        description: "Add blank line after fenced code block".to_string(),
-                        replacement: Some("\n".to_string()),
-                        start: Position {
-                            line: end_line,
-                            column: document.lines.get(end_line - 1).map_or(1, |l| l.len() + 1),
-                        },
-                        end: Position {
-                            line: end_line,
-                            column: document.lines.get(end_line - 1).map_or(1, |l| l.len() + 1),
-                        },
-                    };
+                    let fix = Fix::insertion(
+                        "Add blank line after fenced code block",
+                        document.line_ending(end_line).unwrap_or("\n"),
+                        Position::line_start(end_line + 1),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         "Fenced code block should be followed by a blank line".to_string(),

--- a/crates/mdbook-lint-rulesets/src/standard/md032.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md032.rs
@@ -50,32 +50,11 @@ impl AstRule for MD032 {
                     // Check for blank line before the list
                     if !self.has_blank_line_before(document, start_line) {
                         // Create fix by inserting a blank line before the list
-                        let fix = Fix {
-                            description: "Add blank line before list".to_string(),
-                            replacement: Some("\n".to_string()),
-                            start: Position {
-                                line: start_line - 1,
-                                column: if start_line > 1 {
-                                    document
-                                        .lines
-                                        .get(start_line - 2)
-                                        .map_or(1, |l| l.len() + 1)
-                                } else {
-                                    1
-                                },
-                            },
-                            end: Position {
-                                line: start_line - 1,
-                                column: if start_line > 1 {
-                                    document
-                                        .lines
-                                        .get(start_line - 2)
-                                        .map_or(1, |l| l.len() + 1)
-                                } else {
-                                    1
-                                },
-                            },
-                        };
+                        let fix = Fix::insertion(
+                            "Add blank line before list",
+                            document.line_ending(start_line - 1).unwrap_or("\n"),
+                            Position::line_start(start_line),
+                        );
 
                         violations.push(self.create_violation_with_fix(
                             "List should be preceded by a blank line".to_string(),
@@ -90,18 +69,11 @@ impl AstRule for MD032 {
                     let end_line = self.find_list_end_line(document, node);
                     if !self.has_blank_line_after(document, end_line) {
                         // Create fix by inserting a blank line after the list
-                        let fix = Fix {
-                            description: "Add blank line after list".to_string(),
-                            replacement: Some("\n".to_string()),
-                            start: Position {
-                                line: end_line,
-                                column: document.lines.get(end_line - 1).map_or(1, |l| l.len() + 1),
-                            },
-                            end: Position {
-                                line: end_line,
-                                column: document.lines.get(end_line - 1).map_or(1, |l| l.len() + 1),
-                            },
-                        };
+                        let fix = Fix::insertion(
+                            "Add blank line after list",
+                            document.line_ending(end_line).unwrap_or("\n"),
+                            Position::line_start(end_line + 1),
+                        );
 
                         violations.push(self.create_violation_with_fix(
                             "List should be followed by a blank line".to_string(),

--- a/crates/mdbook-lint-rulesets/src/standard/md035.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md035.rs
@@ -1,7 +1,7 @@
 use mdbook_lint_core::Document;
 use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
-use mdbook_lint_core::violation::{Fix, Position, Severity, Violation};
+use mdbook_lint_core::violation::{Fix, Severity, Violation};
 
 /// MD035 - Horizontal rule style
 pub struct MD035 {
@@ -180,18 +180,13 @@ impl Rule for MD035 {
                 let leading_whitespace = line_content.len() - line_content.trim_start().len();
                 let indent = &line_content[..leading_whitespace];
 
-                let fix = Fix {
-                    description: format!("Change horizontal rule style to '{}'", expected),
-                    replacement: Some(format!("{}{}\n", indent, expected)),
-                    start: Position {
-                        line: line_number,
-                        column: 1,
-                    },
-                    end: Position {
-                        line: line_number,
-                        column: line_content.len() + 1,
-                    },
-                };
+                let fix = Fix::line_replacement(
+                    format!("Change horizontal rule style to '{}'", expected),
+                    format!("{}{}", indent, expected),
+                    line_number,
+                    line_content,
+                    document.line_ending(line_number),
+                );
 
                 violations.push(self.create_violation_with_fix(
                     format!(

--- a/crates/mdbook-lint-rulesets/src/standard/md037.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md037.rs
@@ -1,7 +1,7 @@
 use mdbook_lint_core::Document;
 use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
-use mdbook_lint_core::violation::{Fix, Position, Severity, Violation};
+use mdbook_lint_core::violation::{Fix, Severity, Violation};
 
 /// MD037 - Spaces inside emphasis markers
 pub struct MD037;
@@ -111,7 +111,7 @@ impl MD037 {
     #[allow(clippy::too_many_arguments)]
     fn check_pattern(
         &self,
-        _document: &Document,
+        document: &Document,
         line: &str,
         chars: &[char],
         marker: &str,
@@ -162,21 +162,13 @@ impl MD037 {
                                 replacement.push_str(fixed_content);
                                 replacement.push_str(marker);
                                 replacement.push_str(&line[byte_end..]);
-                                replacement.push('\n');
-
-                                let fix = Fix {
-                                    description: "Remove spaces inside emphasis markers"
-                                        .to_string(),
-                                    replacement: Some(replacement),
-                                    start: Position {
-                                        line: line_number,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: line_number,
-                                        column: line.len() + 1,
-                                    },
-                                };
+                                let fix = Fix::line_replacement(
+                                    "Remove spaces inside emphasis markers",
+                                    replacement,
+                                    line_number,
+                                    line,
+                                    document.line_ending(line_number),
+                                );
 
                                 violations.push(self.create_violation_with_fix(
                                     "Spaces inside emphasis markers".to_string(),
@@ -206,7 +198,7 @@ impl MD037 {
     #[allow(clippy::too_many_arguments)]
     fn check_single_pattern(
         &self,
-        _document: &Document,
+        document: &Document,
         line: &str,
         chars: &[char],
         marker: char,
@@ -286,21 +278,13 @@ impl MD037 {
                                 replacement.push_str(fixed_content);
                                 replacement.push(marker);
                                 replacement.push_str(&line[byte_end..]);
-                                replacement.push('\n');
-
-                                let fix = Fix {
-                                    description: "Remove spaces inside emphasis markers"
-                                        .to_string(),
-                                    replacement: Some(replacement),
-                                    start: Position {
-                                        line: line_number,
-                                        column: 1,
-                                    },
-                                    end: Position {
-                                        line: line_number,
-                                        column: line.len() + 1,
-                                    },
-                                };
+                                let fix = Fix::line_replacement(
+                                    "Remove spaces inside emphasis markers",
+                                    replacement,
+                                    line_number,
+                                    line,
+                                    document.line_ending(line_number),
+                                );
 
                                 violations.push(self.create_violation_with_fix(
                                     "Spaces inside emphasis markers".to_string(),

--- a/crates/mdbook-lint-rulesets/src/standard/md038.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md038.rs
@@ -1,13 +1,18 @@
 use mdbook_lint_core::Document;
 use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
-use mdbook_lint_core::violation::{Fix, Position, Severity, Violation};
+use mdbook_lint_core::violation::{Fix, Severity, Violation};
 
 /// MD038 - Spaces inside code span elements
 pub struct MD038;
 
 impl MD038 {
-    fn find_code_span_violations(&self, line: &str, line_number: usize) -> Vec<Violation> {
+    fn find_code_span_violations(
+        &self,
+        document: &Document,
+        line: &str,
+        line_number: usize,
+    ) -> Vec<Violation> {
         let mut violations = Vec::new();
         let chars: Vec<char> = line.chars().collect();
         let len = chars.len();
@@ -63,20 +68,13 @@ impl MD038 {
                             replacement.push_str(&fixed_content);
                             replacement.push_str(&backticks);
                             replacement.push_str(&line[byte_end..]);
-                            replacement.push('\n');
-
-                            let fix = Fix {
-                                description: "Remove spaces inside code span".to_string(),
-                                replacement: Some(replacement),
-                                start: Position {
-                                    line: line_number,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: line_number,
-                                    column: line.len() + 1,
-                                },
-                            };
+                            let fix = Fix::line_replacement(
+                                "Remove spaces inside code span",
+                                replacement,
+                                line_number,
+                                line,
+                                document.line_ending(line_number),
+                            );
 
                             violations.push(self.create_violation_with_fix(
                                 "Spaces inside code span elements".to_string(),
@@ -263,7 +261,7 @@ impl Rule for MD038 {
                 continue;
             }
 
-            violations.extend(self.find_code_span_violations(line, line_number));
+            violations.extend(self.find_code_span_violations(document, line, line_number));
         }
 
         Ok(violations)

--- a/crates/mdbook-lint-rulesets/src/standard/md039.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md039.rs
@@ -6,7 +6,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check for spaces inside link text
@@ -14,7 +14,12 @@ pub struct MD039;
 
 impl MD039 {
     /// Find link violations in a line
-    fn check_line_links(&self, line: &str, line_number: usize) -> Vec<Violation> {
+    fn check_line_links(
+        &self,
+        document: &Document,
+        line: &str,
+        line_number: usize,
+    ) -> Vec<Violation> {
         let mut violations = Vec::new();
         let chars: Vec<char> = line.chars().collect();
         let mut i = 0;
@@ -53,20 +58,13 @@ impl MD039 {
                         replacement.push_str(&fixed_text);
                         replacement.push(']');
                         replacement.push_str(&line[byte_end..]);
-                        replacement.push('\n');
-
-                        let fix = Fix {
-                            description: "Remove spaces inside link text".to_string(),
-                            replacement: Some(replacement),
-                            start: Position {
-                                line: line_number,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: line_number,
-                                column: line.len() + 1,
-                            },
-                        };
+                        let fix = Fix::line_replacement(
+                            "Remove spaces inside link text",
+                            replacement,
+                            line_number,
+                            line,
+                            document.line_ending(line_number),
+                        );
 
                         violations.push(self.create_violation_with_fix(
                             "Spaces inside link text".to_string(),
@@ -199,7 +197,7 @@ impl Rule for MD039 {
                 continue;
             }
 
-            violations.extend(self.check_line_links(line, line_number));
+            violations.extend(self.check_line_links(document, line, line_number));
         }
 
         Ok(violations)

--- a/crates/mdbook-lint-rulesets/src/standard/md045.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md045.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check that images have alternate text
@@ -80,25 +80,23 @@ impl MD045 {
                 if let Some(end) = line_content[start..].find("]") {
                     let before = &line_content[..start + 2];
                     let after = &line_content[start + end..];
-                    format!("{}{}{}\n", before, placeholder, after)
+                    format!("{}{}{}", before, placeholder, after)
                 } else {
                     // Can't fix if syntax is malformed
-                    line_content.to_string() + "\n"
+                    line_content.to_string()
                 }
             } else {
                 // Can't find image syntax
-                line_content.to_string() + "\n"
+                line_content.to_string()
             };
 
-            let fix = Fix {
-                description: format!("Add placeholder alt text: '{}'", placeholder),
-                replacement: Some(fixed_line),
-                start: Position { line, column: 1 },
-                end: Position {
-                    line,
-                    column: line_content.len() + 1,
-                },
-            };
+            let fix = Fix::line_replacement(
+                format!("Add placeholder alt text: '{}'", placeholder),
+                fixed_line,
+                line,
+                line_content,
+                document.line_ending(line),
+            );
 
             violations.push(self.create_violation_with_fix(
                 "Images should have alternate text".to_string(),

--- a/crates/mdbook-lint-rulesets/src/standard/md046.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md046.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check code block style consistency
@@ -128,33 +128,37 @@ impl MD046 {
                 _ => None,
             };
 
-            replacement.map(|replacement_text| Fix {
-                description: format!(
-                    "Convert {} code block to {}",
-                    match from_style {
-                        CodeBlockStyle::Fenced => "fenced",
-                        CodeBlockStyle::Indented => "indented",
-                        _ => "unknown",
-                    },
-                    match to_style {
-                        CodeBlockStyle::Fenced => "fenced",
-                        CodeBlockStyle::Indented => "indented",
-                        _ => "unknown",
-                    }
-                ),
-                replacement: Some(replacement_text),
-                start: Position {
-                    line: start_line,
-                    column: 1,
-                },
-                end: Position {
-                    line: end_line,
-                    column: document
-                        .lines
-                        .get(end_line - 1)
-                        .map(|l| l.len() + 1)
-                        .unwrap_or(1),
-                },
+            replacement.map(|replacement_text| {
+                let replacement_text = replacement_text
+                    .strip_suffix('\n')
+                    .unwrap_or(&replacement_text);
+                let line_ending = document.line_ending(start_line).unwrap_or("\n");
+                let replacement_text = if line_ending == "\r\n" {
+                    replacement_text.replace('\n', "\r\n")
+                } else {
+                    replacement_text.to_string()
+                };
+
+                Fix::line_range_replacement(
+                    format!(
+                        "Convert {} code block to {}",
+                        match from_style {
+                            CodeBlockStyle::Fenced => "fenced",
+                            CodeBlockStyle::Indented => "indented",
+                            _ => "unknown",
+                        },
+                        match to_style {
+                            CodeBlockStyle::Fenced => "fenced",
+                            CodeBlockStyle::Indented => "indented",
+                            _ => "unknown",
+                        }
+                    ),
+                    replacement_text,
+                    start_line,
+                    end_line,
+                    document.lines.get(end_line - 1).map_or("", String::as_str),
+                    document.line_ending(end_line),
+                )
             })
         } else {
             None

--- a/crates/mdbook-lint-rulesets/src/standard/md047.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md047.rs
@@ -132,27 +132,14 @@ impl Rule for MD047 {
             // Create fix based on the specific issue
             let fix = if document.content.is_empty() {
                 // Empty file: add a single newline
-                Fix {
-                    description: "Add newline at end of file".to_string(),
-                    replacement: Some("\n".to_string()),
-                    start: Position { line: 1, column: 1 },
-                    end: Position { line: 1, column: 1 },
-                }
+                Fix::insertion("Add newline at end of file", "\n", Position::line_start(1))
             } else if !document.content.ends_with('\n') {
                 // No trailing newline: add one
-                let last_line_len = document.lines.last().map(|l| l.len()).unwrap_or(0) + 1;
-                Fix {
-                    description: "Add newline at end of file".to_string(),
-                    replacement: Some("\n".to_string()),
-                    start: Position {
-                        line: line_number,
-                        column: last_line_len,
-                    },
-                    end: Position {
-                        line: line_number,
-                        column: last_line_len,
-                    },
-                }
+                let position = Position::line_end(
+                    line_number,
+                    document.lines.last().map_or("", String::as_str),
+                );
+                Fix::insertion("Add newline at end of file", "\n", position)
             } else {
                 // Multiple trailing newlines: remove extras
                 let trailing_newlines = document

--- a/crates/mdbook-lint-rulesets/src/standard/md048.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md048.rs
@@ -7,7 +7,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{AstRule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check code fence style consistency
@@ -140,25 +140,19 @@ impl MD048 {
                         // Closing fence
                         fixed_lines.push(expected_fence.clone());
 
-                        let fix = Fix {
-                            description: format!(
+                        let line_ending = document.line_ending(start_line).unwrap_or("\n");
+                        let replacement = fixed_lines.join(line_ending);
+                        let fix = Fix::line_range_replacement(
+                            format!(
                                 "Change code fence style from '{}' to '{}'",
                                 found_char, expected_char
                             ),
-                            replacement: Some(fixed_lines.join("\n") + "\n"),
-                            start: Position {
-                                line: start_line,
-                                column: 1,
-                            },
-                            end: Position {
-                                line: end_line,
-                                column: document
-                                    .lines
-                                    .get(end_line - 1)
-                                    .map(|l| l.len() + 1)
-                                    .unwrap_or(1),
-                            },
-                        };
+                            replacement,
+                            start_line,
+                            end_line,
+                            document.lines.get(end_line - 1).map_or("", String::as_str),
+                            document.line_ending(end_line),
+                        );
 
                         violations.push(self.create_violation_with_fix(
                                 format!(

--- a/crates/mdbook-lint-rulesets/src/standard/md049.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md049.rs
@@ -6,7 +6,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check emphasis style consistency
@@ -58,6 +58,7 @@ impl MD049 {
     /// Find emphasis markers in a line and check for style violations
     fn check_line_emphasis(
         &self,
+        document: &Document,
         line: &str,
         line_number: usize,
         expected_style: Option<EmphasisStyle>,
@@ -126,21 +127,16 @@ impl MD049 {
                             fixed_chars[end_pos] = expected_marker;
                             let fixed_str: String = fixed_chars.iter().collect();
 
-                            let fix = Fix {
-                                description: format!(
+                            let fix = Fix::line_replacement(
+                                format!(
                                     "Change emphasis marker from '{}' to '{}'",
                                     marker, expected_marker
                                 ),
-                                replacement: Some(format!("{}\n", fixed_str)),
-                                start: Position {
-                                    line: line_number,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: line_number,
-                                    column: line.len() + 1,
-                                },
-                            };
+                                fixed_str,
+                                line_number,
+                                line,
+                                document.line_ending(line_number),
+                            );
 
                             violations.push(self.create_violation_with_fix(
                                 format!(
@@ -346,7 +342,7 @@ impl Rule for MD049 {
             }
 
             let (line_violations, detected_style, _fixed_line) =
-                self.check_line_emphasis(line, line_number, expected_style);
+                self.check_line_emphasis(document, line, line_number, expected_style);
             violations.extend(line_violations);
 
             // Update expected style if we detected one

--- a/crates/mdbook-lint-rulesets/src/standard/md050.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md050.rs
@@ -6,7 +6,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check strong emphasis style consistency
@@ -58,6 +58,7 @@ impl MD050 {
     /// Find strong emphasis markers in a line and check for style violations
     fn check_line_strong(
         &self,
+        document: &Document,
         line: &str,
         line_number: usize,
         expected_style: Option<StrongStyle>,
@@ -111,21 +112,16 @@ impl MD050 {
                                     .replace_range(pos..pos + original_strong.len(), &fixed_strong);
                             }
 
-                            let fix = Fix {
-                                description: format!(
+                            let fix = Fix::line_replacement(
+                                format!(
                                     "Change strong emphasis style from '{}' to '{}'",
                                     found_marker, expected_marker
                                 ),
-                                replacement: Some(format!("{}\n", fixed_line)),
-                                start: Position {
-                                    line: line_number,
-                                    column: 1,
-                                },
-                                end: Position {
-                                    line: line_number,
-                                    column: line_content.len() + 1,
-                                },
-                            };
+                                fixed_line,
+                                line_number,
+                                line_content,
+                                document.line_ending(line_number),
+                            );
 
                             violations.push(self.create_violation_with_fix(
                                 format!(
@@ -249,7 +245,7 @@ impl Rule for MD050 {
             }
 
             let (line_violations, detected_style) =
-                self.check_line_strong(line, line_number, expected_style);
+                self.check_line_strong(document, line, line_number, expected_style);
             violations.extend(line_violations);
 
             // Update expected style if we detected one

--- a/crates/mdbook-lint-rulesets/src/standard/md055.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md055.rs
@@ -6,7 +6,7 @@ use mdbook_lint_core::error::Result;
 use mdbook_lint_core::rule::{Rule, RuleCategory, RuleMetadata};
 use mdbook_lint_core::{
     Document,
-    violation::{Fix, Position, Severity, Violation},
+    violation::{Fix, Severity, Violation},
 };
 
 /// Rule to check table pipe style consistency
@@ -193,6 +193,7 @@ impl MD055 {
     /// Check a line for table pipe style violations
     fn check_line_pipes(
         &self,
+        document: &Document,
         line: &str,
         line_number: usize,
         expected_style: Option<PipeStyle>,
@@ -248,18 +249,13 @@ impl MD055 {
                     let indent = &line[..leading_whitespace];
                     let final_line = format!("{}{}", indent, fixed_line);
 
-                    let fix = Fix {
-                        description: format!("Change table pipe style to {}", expected_desc),
-                        replacement: Some(format!("{}\n", final_line)),
-                        start: Position {
-                            line: line_number,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: line_number,
-                            column: line.len() + 1,
-                        },
-                    };
+                    let fix = Fix::line_replacement(
+                        format!("Change table pipe style to {}", expected_desc),
+                        final_line,
+                        line_number,
+                        line,
+                        document.line_ending(line_number),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         format!(
@@ -292,18 +288,13 @@ impl MD055 {
             let indent = &line[..leading_whitespace];
             let final_line = format!("{}{}", indent, fixed_line);
 
-            let fix = Fix {
-                description: "Fix inconsistent pipe style by adding missing pipes".to_string(),
-                replacement: Some(format!("{}\n", final_line)),
-                start: Position {
-                    line: line_number,
-                    column: 1,
-                },
-                end: Position {
-                    line: line_number,
-                    column: line.len() + 1,
-                },
-            };
+            let fix = Fix::line_replacement(
+                "Fix inconsistent pipe style by adding missing pipes",
+                final_line,
+                line_number,
+                line,
+                document.line_ending(line_number),
+            );
 
             violations.push(self.create_violation_with_fix(
                 "Table row has inconsistent pipe style (mixed leading/trailing)".to_string(),
@@ -401,7 +392,7 @@ impl Rule for MD055 {
                 // Only check actual table rows (not separators)
                 if self.is_table_row_in_context(line) {
                     let (line_violations, detected_style) =
-                        self.check_line_pipes(line, line_number, expected_style);
+                        self.check_line_pipes(document, line, line_number, expected_style);
                     violations.extend(line_violations);
 
                     // Update expected style if we detected one

--- a/crates/mdbook-lint-rulesets/src/standard/md056.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md056.rs
@@ -239,18 +239,13 @@ impl MD056 {
                         }
                     }
 
-                    let fix = Fix {
-                        description: fix_description,
-                        replacement: Some(format!("{}\n", fixed_line)),
-                        start: Position {
-                            line: line_num + 1,
-                            column: 1,
-                        },
-                        end: Position {
-                            line: line_num + 1,
-                            column: line.len() + 1,
-                        },
-                    };
+                    let fix = Fix::line_replacement(
+                        fix_description,
+                        fixed_line,
+                        line_num + 1,
+                        line,
+                        document.line_ending(line_num + 1),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         message,

--- a/crates/mdbook-lint-rulesets/src/standard/md058.rs
+++ b/crates/mdbook-lint-rulesets/src/standard/md058.rs
@@ -74,18 +74,11 @@ impl MD058 {
             if start_line > 1 {
                 let line_before_idx = start_line - 2; // Convert to 0-based and go back one line
                 if line_before_idx < lines.len() && !Self::is_blank_line(lines[line_before_idx]) {
-                    let fix = Fix {
-                        description: "Add blank line before table".to_string(),
-                        replacement: Some("\n".to_string()),
-                        start: Position {
-                            line: start_line - 1,
-                            column: document.lines[start_line - 2].len() + 1,
-                        },
-                        end: Position {
-                            line: start_line - 1,
-                            column: document.lines[start_line - 2].len() + 1,
-                        },
-                    };
+                    let fix = Fix::insertion(
+                        "Add blank line before table",
+                        document.line_ending(start_line - 1).unwrap_or("\n"),
+                        Position::line_start(start_line),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         "Tables should be preceded by a blank line".to_string(),
@@ -101,18 +94,11 @@ impl MD058 {
             if end_line < lines.len() {
                 let line_after_idx = end_line; // end_line is 1-based, so this is the 0-based index of next line
                 if line_after_idx < lines.len() && !Self::is_blank_line(lines[line_after_idx]) {
-                    let fix = Fix {
-                        description: "Add blank line after table".to_string(),
-                        replacement: Some("\n".to_string()),
-                        start: Position {
-                            line: end_line,
-                            column: document.lines[end_line - 1].len() + 1,
-                        },
-                        end: Position {
-                            line: end_line,
-                            column: document.lines[end_line - 1].len() + 1,
-                        },
-                    };
+                    let fix = Fix::insertion(
+                        "Add blank line after table",
+                        document.line_ending(end_line).unwrap_or("\n"),
+                        Position::line_start(end_line + 1),
+                    );
 
                     violations.push(self.create_violation_with_fix(
                         "Tables should be followed by a blank line".to_string(),

--- a/docs/src/api-documentation.md
+++ b/docs/src/api-documentation.md
@@ -114,6 +114,26 @@ These rules validate mdBook-specific requirements:
 
 Many rules support automatic fixing to correct violations:
 
+The public `Fix` coordinate contract is exact and half-open: `start` is
+included and `end` is excluded. `Position` lines and columns are 1-based, and
+columns count Unicode scalar values—not UTF-8 bytes, grapheme clusters, or
+display cells. Use `Fix::byte_range(content)` to obtain a validated UTF-8 byte
+range instead of maintaining rule-specific conversions.
+
+Line endings are explicit. A position at a line's end is before its terminator;
+column 1 of the following line is after the complete LF or CRLF terminator.
+Therefore:
+
+- `start == end` is an insertion and consumes no source text.
+- Replacing line content without its terminator ends at that line's end column.
+- Replacing a complete terminated line ends at column 1 of the next line.
+- CRLF is atomic; no valid position falls between `\r` and `\n`.
+- At EOF, a replacement adds a newline only when its replacement text contains
+  one explicitly.
+
+Rule authors can use `Fix::insertion`, `Fix::line_replacement`, and
+`Fix::line_range_replacement` to make these distinctions explicit.
+
 #### Whitespace and Formatting
 
 - **MD009**: Remove trailing spaces while preserving line breaks

--- a/docs/src/library-api.md
+++ b/docs/src/library-api.md
@@ -127,6 +127,33 @@ for violation in violations {
 }
 ```
 
+#### Fix coordinates
+
+`Fix` ranges are exact and half-open (`start` included, `end` excluded).
+`Position` uses 1-based lines and 1-based Unicode-scalar columns. Embedders that
+edit UTF-8 strings should call `fix.byte_range(content)` for the canonical,
+validated conversion rather than interpreting columns as byte offsets.
+
+The end-of-line position is before the line terminator. Column 1 of the next
+line is after the entire LF or CRLF terminator, so CRLF cannot be split. An
+equal start and end is a pure insertion; a complete-line replacement consumes
+the terminator only when its end is on the following line. EOF never implies a
+newline.
+
+```rust
+use mdbook_lint_core::{Fix, Position};
+
+let content = "café\r\nnext";
+let fix = Fix {
+    description: "Replace the accented scalar".to_string(),
+    replacement: Some("e".to_string()),
+    start: Position { line: 1, column: 4 },
+    end: Position { line: 1, column: 5 },
+};
+
+assert_eq!(fix.byte_range(content), Some(3..5));
+```
+
 ## Advanced Usage
 
 ### Custom Rule Providers


### PR DESCRIPTION
## Summary

- define `Position` as 1-based Unicode-scalar coordinates and `Fix` as an exact half-open range
- add checked position/byte conversion APIs plus explicit insertion and line-replacement constructors
- remove the engine's replacement-driven newline heuristic and migrate standard fix-producing rules to explicit LF/CRLF/EOF semantics
- extend public documentation and end-to-end fix conformance coverage

## Why

Library embedders currently need rule-specific fix translation because coordinate units, endpoint semantics, and newline intent are ambiguous. The engine also silently expands some ranges based on replacement content. This makes otherwise valid fixes unsafe around multibyte text, CRLF, and EOF.

This keeps the existing public `Fix`/`Position` field layout while making the contract explicit and mechanically resolvable through `Fix::byte_range`.

## Compatibility

Third-party rules that relied on the undocumented behavior where a replacement ending in `\n` caused the engine to consume an adjacent source newline must now express that range explicitly or use the new constructors. Existing struct and serialized shapes remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --doc --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

The mdBook source currently has pre-existing include/link/lint errors, so `mdbook build docs` is not listed as a clean gate; the edited Rust doctests and Markdown content were reviewed separately.

Closes #456