### PR TITLE
feat: add baseline rule preset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Exclude test corpus data from language detection
 tests/corpus/* linguist-detectable=false
 
+# Corpus fixtures are byte-exact inputs; never translate line endings
+tests/corpus/essential/** -text
+
 # Ensure Rust files are detected properly
 *.rs linguist-language=Rust
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ mdbook-lint.toml
 !release-please-config.json
 
 # Keep test fixtures
+!tests/corpus/essential/**/*.md
 !tests/fixtures/**/*.md
 !tests/fixtures/**/*.json
 !tests/fixtures/**/*.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Add the explicit `baseline` preset for low-noise CI adoption, with CLI, configuration, rules-discovery, and mdBook preprocessor support. ([#466](https://github.com/joshrotenberg/mdbook-lint/issues/466))
+
 ### Changed
 
 - Define `Fix` ranges as exact half-open ranges with 1-based Unicode-scalar

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Then run `mdbook build` as usual. The linter will automatically check all your m
 # Lint files
 mdbook-lint lint README.md src/*.md
 
+# Start an existing project with the low-noise baseline
+mdbook-lint lint --preset baseline docs/
+
 # Auto-fix violations (using the fix subcommand)
 mdbook-lint fix src/*.md
 
@@ -115,6 +118,9 @@ mdbook-lint lint --fix src/*.md
 
 # Show available rules
 mdbook-lint rules
+
+# Explain baseline membership
+mdbook-lint rules --preset baseline
 ```
 
 Output uses cargo-style formatting with colors:
@@ -132,6 +138,10 @@ error[MD001]: Expected heading level 2 but got level 3
 Create a `.mdbook-lint.toml` file (also supports YAML/JSON):
 
 ```toml
+# Optional low-noise starting point for incremental CI adoption.
+# Remove it later to use the complete stable default set.
+preset = "baseline"
+
 # Disable rules that don't fit your project
 disabled-rules = ["MD013", "MD033"]
 
@@ -154,6 +164,7 @@ mdbook-lint init --include-all
 
 **Configuration examples:**
 
+- [Baseline](examples/baseline.mdbook-lint.toml) - Incremental adoption in an existing project
 - [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all 84 rules documented
 - [docs/.mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/docs/.mdbook-lint.toml) - Real-world example used by this project's documentation
 - [Strict](examples/strict.mdbook-lint.toml) - Publication and CI gates
@@ -190,8 +201,12 @@ jobs:
           chmod +x mdbook-lint
       
       - name: Lint markdown files
-        run: ./mdbook-lint lint --fail-on-warnings docs/
+        run: ./mdbook-lint lint --preset baseline --fail-on-warnings docs/
 ```
+
+`baseline` is an explicit, versioned rule list rather than a category. Inspect
+it with `mdbook-lint rules --preset baseline`; remove the preset when the
+documentation is ready for the complete stable default ruleset.
 
 ## Compatibility
 

--- a/crates/mdbook-lint-cli/example-mdbook-lint.toml
+++ b/crates/mdbook-lint-cli/example-mdbook-lint.toml
@@ -4,6 +4,10 @@
 # Copy this file to `.mdbook-lint.toml` in your project root and customize as needed.
 #
 # All settings shown here are optional - mdbook-lint works with sensible defaults.
+
+# Start with a curated low-noise rule set for incremental CI adoption.
+# Remove this line later to use the full stable default set.
+# preset = "baseline"
 # Uncomment and modify only the settings you want to change.
 
 # ============================================================================
@@ -23,6 +27,7 @@
 # Experimental rules are off by default because their output may change.
 # Accepts rule IDs, or "*" for all of them. Unlike enabled-rules, this adds
 # to the default set rather than replacing it.
+# This setting is ignored when an exact preset is selected.
 # experimental-rules = ["MDBOOK010"]
 
 # ============================================================================

--- a/crates/mdbook-lint-cli/src/config.rs
+++ b/crates/mdbook-lint-cli/src/config.rs
@@ -1,4 +1,5 @@
 use mdbook_lint_core::{MdBookLintError, Result};
+use mdbook_lint_rulesets::RulePreset;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
@@ -11,6 +12,10 @@ pub struct Config {
     /// Core linting configuration
     #[serde(flatten)]
     pub core: mdbook_lint_core::Config,
+
+    /// Curated rule preset used when no explicit enabled-rules list is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preset: Option<RulePreset>,
 
     /// Whether to fail builds on warnings (CLI-specific)
     #[serde(rename = "fail-on-warnings", alias = "fail_on_warnings", default)]
@@ -66,6 +71,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             core: mdbook_lint_core::Config::default(),
+            preset: None,
             fail_on_warnings: false,
             fail_on_errors: true,
             malformed_markdown: MalformedMarkdownAction::Warn,
@@ -79,6 +85,24 @@ fn default_fail_on_errors() -> bool {
 
 #[allow(dead_code)]
 impl Config {
+    /// Resolve the configured preset into the core engine's exact rule list.
+    ///
+    /// An explicit `enabled-rules` list wins over a preset. Disabled rules are
+    /// retained, so they continue to subtract from the selected base set.
+    pub fn effective_core_config(&self) -> mdbook_lint_core::Config {
+        let mut core = self.core.clone();
+        if core.enabled_rules.is_empty()
+            && let Some(preset) = self.preset
+        {
+            core.enabled_rules = preset
+                .rule_ids()
+                .iter()
+                .map(|rule_id| (*rule_id).to_string())
+                .collect();
+        }
+        core
+    }
+
     /// Load configuration from a file, auto-detecting format by extension
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
@@ -481,18 +505,20 @@ impl Config {
 
     /// Check if a rule should be enabled based on configuration
     pub fn should_run_rule(&self, rule_id: &str) -> bool {
+        let core = self.effective_core_config();
+
         // Explicit disabled rules always take precedence
-        if self.core.disabled_rules.contains(&rule_id.to_string()) {
+        if core.disabled_rules.contains(&rule_id.to_string()) {
             return false;
         }
 
         // If we have explicit enabled rules, only those should run
-        if !self.core.enabled_rules.is_empty() {
-            return self.core.enabled_rules.contains(&rule_id.to_string());
+        if !core.enabled_rules.is_empty() {
+            return core.enabled_rules.contains(&rule_id.to_string());
         }
 
         // Check markdownlint compatibility mode - disable rules that are disabled by default in markdownlint
-        if self.core.markdownlint_compatible && rule_id == "MD044" {
+        if core.markdownlint_compatible && rule_id == "MD044" {
             return false; // proper-names: disabled by default in markdownlint
         }
 
@@ -500,13 +526,13 @@ impl Config {
         let category = self.get_rule_category(rule_id);
         let category_name = self.category_to_string(&category);
 
-        if self.core.disabled_categories.contains(&category_name) {
+        if core.disabled_categories.contains(&category_name) {
             return false;
         }
 
         // If enabled_categories is not empty, only run rules in enabled categories
-        if !self.core.enabled_categories.is_empty() {
-            return self.core.enabled_categories.contains(&category_name);
+        if !core.enabled_categories.is_empty() {
+            return core.enabled_categories.contains(&category_name);
         }
 
         // Default: run all rules except those in disabled categories
@@ -625,6 +651,15 @@ impl Config {
         }
         if other.core.markdownlint_compatible {
             self.core.markdownlint_compatible = other.core.markdownlint_compatible;
+        }
+        if other.preset.is_some() {
+            self.preset = other.preset;
+            if other.core.enabled_rules.is_empty() {
+                // A higher-precedence preset replaces a lower-precedence
+                // explicit base selection. Its own enabled-rules, when
+                // present, is applied below and wins within the same source.
+                self.core.enabled_rules.clear();
+            }
         }
 
         // Merge rule lists
@@ -879,6 +914,7 @@ ignore_paths = ["target/"]
             "preprocessor": {
                 "lint": {
                     "fail-on-warnings": true,
+                    "preset": "baseline",
                     "enabled-rules": ["MD001"],
                     "MD013": {
                         "line-length": 100
@@ -890,7 +926,9 @@ ignore_paths = ["target/"]
         let config = Config::from_preprocessor_config(&json_config).unwrap();
 
         assert!(config.fail_on_warnings);
+        assert_eq!(config.preset, Some(RulePreset::Baseline));
         assert_eq!(config.core.enabled_rules, vec!["MD001"]);
+        assert_eq!(config.effective_core_config().enabled_rules, vec!["MD001"]);
 
         let md013_config = config.get_rule_config("MD013").unwrap();
         assert_eq!(
@@ -927,6 +965,20 @@ ignore_paths = ["target/"]
         assert!(base_config.fail_on_warnings);
         assert_eq!(base_config.core.enabled_rules, vec!["MD013"]);
         assert!(base_config.core.rule_configs.contains_key("MD013"));
+    }
+
+    #[test]
+    fn test_higher_precedence_preset_replaces_enabled_rule_base() {
+        let mut base = Config::from_toml_str("enabled-rules = [\"MD013\"]\n").unwrap();
+        let override_config = Config::from_toml_str("preset = \"baseline\"\n").unwrap();
+
+        base.merge(override_config);
+
+        assert_eq!(base.preset, Some(RulePreset::Baseline));
+        assert_eq!(
+            base.effective_core_config().enabled_rules,
+            RulePreset::Baseline.rule_ids()
+        );
     }
 
     #[test]

--- a/crates/mdbook-lint-cli/src/lsp_server.rs
+++ b/crates/mdbook-lint-cli/src/lsp_server.rs
@@ -60,9 +60,10 @@ impl MdBookLintServer {
         };
 
         let config = self.config.read().await;
+        let effective_core = config.effective_core_config();
         let violations = match self
             .engine
-            .lint_document_with_config(&document, &config.core)
+            .lint_document_with_config(&document, &effective_core)
         {
             Ok(violations) => violations,
             Err(_) => return Vec::new(),
@@ -327,7 +328,7 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    const CONFIG: &str = "disabled-rules = [\"MD013\"]\n";
+    const CONFIG: &str = "preset = \"baseline\"\ndisabled-rules = [\"MD013\"]\n";
 
     #[test]
     fn test_config_loads_without_mdbook_markers() {
@@ -345,6 +346,14 @@ mod tests {
         let (config, path) =
             load_workspace_config(temp.path()).expect("config should load without mdBook markers");
         assert_eq!(config.core.disabled_rules, vec!["MD013"]);
+        assert_eq!(
+            config.preset,
+            Some(mdbook_lint_rulesets::RulePreset::Baseline)
+        );
+        assert_eq!(
+            config.effective_core_config().enabled_rules,
+            mdbook_lint_rulesets::BASELINE_RULE_IDS
+        );
         assert_eq!(path, temp.path().join(".mdbook-lint.toml"));
     }
 

--- a/crates/mdbook-lint-cli/src/main.rs
+++ b/crates/mdbook-lint-cli/src/main.rs
@@ -21,7 +21,7 @@ use mdbook_lint_core::{
 use mdbook_lint_rulesets::AdrRuleProvider;
 #[cfg(feature = "content")]
 use mdbook_lint_rulesets::ContentRuleProvider;
-use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
+use mdbook_lint_rulesets::{MdBookRuleProvider, RulePreset, StandardRuleProvider};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read};
@@ -102,6 +102,13 @@ enum Commands {
         /// Enable only specific rules (comma-separated list, e.g., MD001,MD002)
         #[arg(long, value_delimiter = ',')]
         enable: Option<Vec<String>>,
+        /// Use a curated rule preset
+        #[arg(
+            long,
+            value_name = "NAME",
+            conflicts_with_all = ["enable", "standard_only", "mdbook_only"]
+        )]
+        preset: Option<RulePreset>,
         /// Control colored output (auto, always, never)
         #[arg(long, value_enum, default_value = "auto")]
         color: ColorChoice,
@@ -138,6 +145,13 @@ enum Commands {
         /// Enable only specific rules (comma-separated list, e.g., MD001,MD002)
         #[arg(long, value_delimiter = ',')]
         enable: Option<Vec<String>>,
+        /// Use a curated rule preset
+        #[arg(
+            long,
+            value_name = "NAME",
+            conflicts_with_all = ["enable", "standard_only", "mdbook_only"]
+        )]
+        preset: Option<RulePreset>,
         /// Control colored output (auto, always, never)
         #[arg(long, value_enum, default_value = "auto")]
         color: ColorChoice,
@@ -160,6 +174,13 @@ enum Commands {
         /// Show only mdBook-specific rules
         #[arg(long)]
         mdbook_only: bool,
+        /// Show only rules in a curated preset
+        #[arg(
+            long,
+            value_name = "NAME",
+            conflicts_with_all = ["standard_only", "mdbook_only"]
+        )]
+        preset: Option<RulePreset>,
         /// Output format for rule information
         #[arg(short, long, value_enum, default_value = "default")]
         format: RulesFormat,
@@ -223,6 +244,9 @@ enum Commands {
         /// Enable only specific rules (comma-separated list, e.g., MD001,MD002)
         #[arg(long, value_delimiter = ',')]
         enable: Option<Vec<String>>,
+        /// Use a curated rule preset
+        #[arg(long, value_name = "NAME", conflicts_with = "enable")]
+        preset: Option<RulePreset>,
         /// Control colored output (auto, always, never)
         #[arg(long, value_enum, default_value = "auto")]
         color: ColorChoice,
@@ -311,8 +335,17 @@ enum JsonRuleStability {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct JsonRulesOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preset: Option<JsonPreset>,
     total_rules: usize,
     providers: Vec<JsonRuleProvider>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonPreset {
+    name: String,
+    description: String,
+    rule_ids: Vec<String>,
 }
 
 impl From<&RuleCategory> for JsonRuleCategory {
@@ -478,6 +511,7 @@ const LINT_FLAGS: &[&str] = &[
     "--output",
     "--disable",
     "--enable",
+    "--preset",
 ];
 
 /// Check if an argument looks like a lint target (file path, directory, or glob pattern)
@@ -578,6 +612,7 @@ fn main() {
             no_backup,
             disable,
             enable,
+            preset,
             color,
             output_file,
         }) => {
@@ -601,6 +636,7 @@ fn main() {
                 !no_backup,
                 disable.as_ref(),
                 enable.as_ref(),
+                preset,
                 cli.verbose,
                 cli.quiet,
                 output_file.as_deref(),
@@ -616,6 +652,7 @@ fn main() {
             no_backup,
             disable,
             enable,
+            preset,
             color,
         }) => {
             // Set up color choice before running
@@ -639,6 +676,7 @@ fn main() {
                 !no_backup,
                 disable.as_ref(),
                 enable.as_ref(),
+                preset,
                 cli.verbose,
                 cli.quiet,
                 None, // fix subcommand has no report file
@@ -650,6 +688,7 @@ fn main() {
             provider,
             standard_only,
             mdbook_only,
+            preset,
             format,
             json,
         }) => {
@@ -661,6 +700,7 @@ fn main() {
                 provider.as_deref(),
                 standard_only,
                 mdbook_only,
+                preset,
                 effective_format,
             )
         }
@@ -680,6 +720,7 @@ fn main() {
             output,
             disable,
             enable,
+            preset,
             color,
         }) => {
             match color {
@@ -694,6 +735,7 @@ fn main() {
                 output,
                 disable.as_ref(),
                 enable.as_ref(),
+                preset,
                 cli.verbose,
                 cli.quiet,
             )
@@ -836,6 +878,7 @@ fn run_cli_mode(
     backup: bool,
     disable: Option<&Vec<String>>,
     enable: Option<&Vec<String>>,
+    preset: Option<RulePreset>,
     verbose: bool,
     quiet: bool,
     output_file: Option<&Path>,
@@ -914,6 +957,13 @@ fn run_cli_mode(
         config.core.markdownlint_compatible = true;
     }
 
+    // A CLI preset overrides configured base selectors while retaining
+    // configured disabled-rules as subtractive customizations.
+    if let Some(preset) = preset {
+        config.preset = Some(preset);
+        config.core.enabled_rules.clear();
+    }
+
     // Apply disable/enable flags
     if let Some(disabled_rules) = disable {
         // Add to existing disabled rules
@@ -936,6 +986,8 @@ fn run_cli_mode(
         config.core.disabled_rules.clear();
         config.core.enabled_rules = enabled_rules.clone();
     }
+
+    let effective_core = config.effective_core_config();
 
     // Create appropriate engine based on flags
     let mut registry = PluginRegistry::new();
@@ -962,7 +1014,7 @@ fn run_cli_mode(
         registry.register_provider(Box::new(AdrRuleProvider))?;
     }
 
-    let engine = registry.create_engine_with_config(Some(&config.core))?;
+    let engine = registry.create_engine_with_config(Some(&effective_core))?;
 
     let mut total_violations = 0;
     let mut has_errors = false;
@@ -999,7 +1051,7 @@ fn run_cli_mode(
         let document = Document::new(content, stdin_path.clone())?;
 
         // Lint with configuration
-        let violations = engine.lint_document_with_config(&document, &config.core)?;
+        let violations = engine.lint_document_with_config(&document, &effective_core)?;
 
         if !violations.is_empty() {
             violations_by_file.push(("<stdin>".to_string(), violations.clone()));
@@ -1033,7 +1085,7 @@ fn run_cli_mode(
         }
 
         // Drop any files matching the configured ignore-paths patterns
-        filter_ignored_paths(&mut markdown_files, &config.core.ignore_paths);
+        filter_ignored_paths(&mut markdown_files, &effective_core.ignore_paths);
 
         // Process markdown files in parallel
         let violations_mutex = Mutex::new(Vec::new());
@@ -1062,7 +1114,7 @@ fn run_cli_mode(
             };
 
             // Lint with configuration
-            let violations = match engine.lint_document_with_config(&document, &config.core) {
+            let violations = match engine.lint_document_with_config(&document, &effective_core) {
                 Ok(v) => v,
                 Err(e) => {
                     eprintln!("Failed to lint {}: {e}", path.display());
@@ -1183,7 +1235,7 @@ fn run_cli_mode(
                 current_markdown_files.push(path);
             }
 
-            filter_ignored_paths(&mut current_markdown_files, &config.core.ignore_paths);
+            filter_ignored_paths(&mut current_markdown_files, &effective_core.ignore_paths);
 
             for md_path in current_markdown_files {
                 let file_path = md_path.to_string_lossy().to_string();
@@ -1198,7 +1250,7 @@ fn run_cli_mode(
 
                 // Create document and lint
                 let document = Document::new(content, md_path.clone())?;
-                let violations = engine.lint_document_with_config(&document, &config.core)?;
+                let violations = engine.lint_document_with_config(&document, &effective_core)?;
 
                 if !violations.is_empty() {
                     violations_by_file.push((file_path, violations.clone()));
@@ -1281,6 +1333,7 @@ fn run_rules_command(
     provider_filter: Option<&str>,
     standard_only: bool,
     mdbook_only: bool,
+    preset: Option<RulePreset>,
     format: RulesFormat,
 ) -> Result<()> {
     // Validate mutually exclusive flags
@@ -1317,6 +1370,26 @@ fn run_rules_command(
 
     let engine = registry.create_engine()?;
     let providers = registry.providers();
+    let listed_rule_ids: Vec<String> = all_listed_rule_ids(&engine)
+        .into_iter()
+        .filter(|rule_id| preset.is_none_or(|selected| selected.contains(rule_id)))
+        .filter(|rule_id| {
+            provider_filter.is_none_or(|filter| {
+                providers.iter().any(|provider| {
+                    provider.provider_id() == filter
+                        && provider.rule_ids().contains(&rule_id.as_str())
+                })
+            })
+        })
+        .filter(|rule_id| {
+            let Some(filter) = category_filter else {
+                return true;
+            };
+            resolve_listed_rule(&engine, rule_id).is_some_and(|rule| {
+                format!("{:?}", rule.metadata.category).eq_ignore_ascii_case(filter)
+            })
+        })
+        .collect();
 
     match format {
         RulesFormat::Json => {
@@ -1335,16 +1408,11 @@ fn run_rules_command(
                 let mut json_rules = Vec::new();
 
                 for rule_id in provider.rule_ids() {
+                    if !listed_rule_ids.iter().any(|listed| listed == rule_id) {
+                        continue;
+                    }
                     if let Some(rule) = resolve_listed_rule(&engine, rule_id) {
                         let metadata = &rule.metadata;
-
-                        // Apply category filter
-                        if let Some(filter) = category_filter
-                            && format!("{:?}", metadata.category).to_lowercase()
-                                != filter.to_lowercase()
-                        {
-                            continue;
-                        }
 
                         let json_rule = JsonRule {
                             id: rule.id.to_string(),
@@ -1377,6 +1445,15 @@ fn run_rules_command(
             }
 
             let json_output = JsonRulesOutput {
+                preset: preset.map(|selected| JsonPreset {
+                    name: selected.name().to_string(),
+                    description: selected.description().to_string(),
+                    rule_ids: selected
+                        .rule_ids()
+                        .iter()
+                        .map(|rule_id| (*rule_id).to_string())
+                        .collect(),
+                }),
                 total_rules,
                 providers: json_providers,
             };
@@ -1388,17 +1465,9 @@ fn run_rules_command(
             let mut rows: Vec<_> = Vec::new();
             let mut total_rules = 0;
 
-            for rule_id in all_listed_rule_ids(&engine) {
-                if let Some(rule) = resolve_listed_rule(&engine, &rule_id) {
+            for rule_id in &listed_rule_ids {
+                if let Some(rule) = resolve_listed_rule(&engine, rule_id) {
                     let metadata = &rule.metadata;
-
-                    // Apply category filter
-                    if let Some(filter) = category_filter
-                        && format!("{:?}", metadata.category).to_lowercase()
-                            != filter.to_lowercase()
-                    {
-                        continue;
-                    }
 
                     total_rules += 1;
 
@@ -1430,7 +1499,15 @@ fn run_rules_command(
 
             if detailed {
                 // Print detailed table
-                println!("mdbook-lint Rules\n");
+                if let Some(selected) = preset {
+                    println!(
+                        "mdbook-lint Rules in preset '{}'\n{}\n",
+                        selected.name(),
+                        selected.description()
+                    );
+                } else {
+                    println!("mdbook-lint Rules\n");
+                }
 
                 let table = Table::new(&rows).with(Style::rounded()).to_string();
                 println!("{table}");
@@ -1438,18 +1515,15 @@ fn run_rules_command(
                 println!("\nTotal: {total_rules} rules available");
             } else {
                 // Simple list mode with rule name
-                println!("Available rules:");
-                for rule_id in all_listed_rule_ids(&engine) {
-                    if let Some(rule) = resolve_listed_rule(&engine, &rule_id) {
+                if let Some(selected) = preset {
+                    println!("Rules in preset '{}':", selected.name());
+                    println!("{}", selected.description());
+                } else {
+                    println!("Available rules:");
+                }
+                for rule_id in &listed_rule_ids {
+                    if let Some(rule) = resolve_listed_rule(&engine, rule_id) {
                         let metadata = &rule.metadata;
-
-                        // Apply category filter
-                        if let Some(filter) = category_filter
-                            && format!("{:?}", metadata.category).to_lowercase()
-                                != filter.to_lowercase()
-                        {
-                            continue;
-                        }
 
                         println!(
                             "  {:<11} {:<32} {}{}",
@@ -1461,11 +1535,13 @@ fn run_rules_command(
                     }
                 }
 
-                println!(
-                    "\nRules marked [experimental] do not run by default. Enable them with\n\
-                     --enable <RULE>, or with experimental-rules = [\"<RULE>\"] (or [\"*\"])\n\
-                     in configuration to add them alongside the stable defaults."
-                );
+                if preset.is_none() {
+                    println!(
+                        "\nRules marked [experimental] do not run by default. Enable them with\n\
+                         --enable <RULE>, or with experimental-rules = [\"<RULE>\"] (or [\"*\"])\n\
+                         in configuration to add them alongside the stable defaults."
+                    );
+                }
                 println!("\nUse --detailed for a formatted table with more information.");
             }
         }
@@ -1528,6 +1604,32 @@ fn run_check_command(config_path: &PathBuf) -> Result<()> {
 
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
+
+    if let Some(preset) = config.preset {
+        if !config.core.enabled_rules.is_empty() {
+            warnings.push(format!(
+                "Preset '{preset}' is ignored because enabled-rules is an explicit rule selection"
+            ));
+        } else {
+            if !config.core.experimental_rules.is_empty() {
+                warnings.push(format!(
+                    "experimental-rules is ignored when preset '{preset}' is selected"
+                ));
+            }
+            if !config.core.enabled_categories.is_empty()
+                || !config.core.disabled_categories.is_empty()
+            {
+                warnings.push(format!(
+                    "rule categories are ignored when preset '{preset}' is selected"
+                ));
+            }
+            if config.core.markdownlint_compatible {
+                warnings.push(format!(
+                    "markdownlint-compatible is ignored when preset '{preset}' is selected"
+                ));
+            }
+        }
+    }
 
     // Validate enabled-rules
     for rule_id in &config.core.enabled_rules {
@@ -1835,6 +1937,7 @@ fn run_rustdoc_mode(
     output_format: OutputFormat,
     disable: Option<&Vec<String>>,
     enable: Option<&Vec<String>>,
+    preset: Option<RulePreset>,
     verbose: bool,
     quiet: bool,
 ) -> Result<()> {
@@ -1881,6 +1984,11 @@ fn run_rustdoc_mode(
         config.fail_on_warnings = true;
     }
 
+    if let Some(preset) = preset {
+        config.preset = Some(preset);
+        config.core.enabled_rules.clear();
+    }
+
     // Disable rules that don't make sense for rustdoc by default:
     // - MD041: First line heading - rustdoc often starts with description
     // - MD047: Trailing newline - doc comments don't have trailing newlines
@@ -1901,13 +2009,10 @@ fn run_rustdoc_mode(
 
     if let Some(enabled_rules) = enable {
         config.core.disabled_rules.clear();
-        let all_rule_ids = get_all_available_rule_ids();
-        for rule_id in all_rule_ids {
-            if !enabled_rules.contains(&rule_id) {
-                config.core.disabled_rules.push(rule_id);
-            }
-        }
+        config.core.enabled_rules = enabled_rules.clone();
     }
+
+    let effective_core = config.effective_core_config();
 
     // Create engine with standard rules only (mdBook rules don't apply to rustdoc)
     let mut registry = PluginRegistry::new();
@@ -1917,7 +2022,7 @@ fn run_rustdoc_mode(
     #[cfg(feature = "adr")]
     registry.register_provider(Box::new(AdrRuleProvider))?;
 
-    let engine = registry.create_engine_with_config(Some(&config.core))?;
+    let engine = registry.create_engine_with_config(Some(&effective_core))?;
 
     // Collect Rust files
     let mut rust_files = Vec::new();
@@ -1970,7 +2075,8 @@ fn run_rustdoc_mode(
                 }
             };
 
-            let mut violations = match engine.lint_document_with_config(&document, &config.core) {
+            let mut violations = match engine.lint_document_with_config(&document, &effective_core)
+            {
                 Ok(v) => v,
                 Err(e) => {
                     eprintln!("Failed to lint {}: {}", source_path, e);
@@ -2062,35 +2168,6 @@ fn run_preprocessor_mode() -> Result<()> {
 fn run_lsp_server(stdio: bool, port: Option<u16>) -> Result<()> {
     tokio::runtime::Runtime::new()?
         .block_on(async { lsp_server::run_lsp_server(stdio, port).await })
-}
-
-/// Get all available rule IDs from all providers
-fn get_all_available_rule_ids() -> Vec<String> {
-    let mut registry = PluginRegistry::new();
-
-    // Add all providers
-    registry
-        .register_provider(Box::new(StandardRuleProvider))
-        .unwrap();
-    registry
-        .register_provider(Box::new(MdBookRuleProvider))
-        .unwrap();
-    #[cfg(feature = "content")]
-    registry
-        .register_provider(Box::new(ContentRuleProvider))
-        .unwrap();
-    #[cfg(feature = "adr")]
-    registry
-        .register_provider(Box::new(AdrRuleProvider))
-        .unwrap();
-
-    // Create engine to get available rules
-    let engine = registry.create_engine().unwrap();
-    engine
-        .available_rules()
-        .iter()
-        .map(|s| s.to_string())
-        .collect()
 }
 
 #[cfg(test)]

--- a/crates/mdbook-lint-cli/src/preprocessor.rs
+++ b/crates/mdbook-lint-cli/src/preprocessor.rs
@@ -12,7 +12,7 @@ use mdbook_lint_core::{
 use mdbook_lint_rulesets::AdrRuleProvider;
 #[cfg(feature = "content")]
 use mdbook_lint_rulesets::ContentRuleProvider;
-use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
+use mdbook_lint_rulesets::{MdBookRuleProvider, RulePreset, StandardRuleProvider};
 use serde_json::Value;
 use std::io::{self, Read};
 use std::path::PathBuf;
@@ -72,7 +72,10 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(AdrRuleProvider))
             .expect("Failed to register ADR rules");
-        let engine = registry.create_engine().expect("Failed to create engine");
+        let effective_core = config.effective_core_config();
+        let engine = registry
+            .create_engine_with_config(Some(&effective_core))
+            .expect("Failed to create engine");
 
         Self {
             config,
@@ -123,8 +126,9 @@ impl MdBookLint {
         registry
             .register_provider(Box::new(MdBookRuleProvider))
             .expect("Failed to register mdbook rules");
+        let effective_core = self.config.effective_core_config();
         self.engine = registry
-            .create_engine_with_config(Some(&self.config.core))
+            .create_engine_with_config(Some(&effective_core))
             .expect("Failed to create configured engine");
 
         Ok(())
@@ -176,9 +180,10 @@ impl MdBookLint {
         )?;
 
         // Use optimized checking (single AST parse) with configuration
+        let effective_core = self.config.effective_core_config();
         let violations = self
             .engine
-            .lint_document_with_config(&document, &self.config.core)?;
+            .lint_document_with_config(&document, &effective_core)?;
 
         Ok(violations)
     }
@@ -304,6 +309,17 @@ impl Preprocessor for MdBookLint {
 fn parse_mdbook_config(config: &toml::value::Table) -> mdbook_lint_core::Result<Config> {
     let mut preprocessor_config = Config::default();
 
+    if let Some(preset) = config.get("preset") {
+        let preset = preset
+            .as_str()
+            .ok_or_else(|| MdBookLintError::config_error("preset must be a string"))?;
+        preprocessor_config.preset = Some(
+            preset
+                .parse::<RulePreset>()
+                .map_err(MdBookLintError::config_error)?,
+        );
+    }
+
     if let Some(fail_on_warnings) = config.get("fail-on-warnings") {
         preprocessor_config.fail_on_warnings = fail_on_warnings
             .as_bool()
@@ -391,6 +407,17 @@ fn parse_mdbook_config(config: &toml::value::Table) -> mdbook_lint_core::Result<
 #[allow(dead_code)]
 fn parse_config(config: &Value) -> mdbook_lint_core::Result<Config> {
     let mut preprocessor_config = Config::default();
+
+    if let Some(preset) = config.get("preset") {
+        let preset = preset
+            .as_str()
+            .ok_or_else(|| MdBookLintError::config_error("preset must be a string"))?;
+        preprocessor_config.preset = Some(
+            preset
+                .parse::<RulePreset>()
+                .map_err(MdBookLintError::config_error)?,
+        );
+    }
 
     if let Some(fail_on_warnings) = config.get("fail-on-warnings") {
         preprocessor_config.fail_on_warnings = fail_on_warnings
@@ -943,6 +970,7 @@ count threshold that is required by the linter for content validation.
     #[test]
     fn test_parse_config() {
         let config_json = json!({
+            "preset": "baseline",
             "fail-on-warnings": true,
             "fail-on-errors": false,
             "enabled-rules": ["MD001", "MD013"],
@@ -950,10 +978,23 @@ count threshold that is required by the linter for content validation.
         });
 
         let config = parse_config(&config_json).unwrap();
+        assert_eq!(config.preset, Some(RulePreset::Baseline));
         assert!(config.fail_on_warnings);
         assert!(!config.fail_on_errors);
         assert_eq!(config.core.enabled_rules, vec!["MD001", "MD013"]);
         assert_eq!(config.core.disabled_rules, vec!["MD002"]);
+    }
+
+    #[test]
+    fn test_parse_mdbook_config_accepts_baseline_preset() {
+        let value: toml::Value = toml::from_str("preset = \"baseline\"\n").unwrap();
+        let config = parse_mdbook_config(value.as_table().unwrap()).unwrap();
+
+        assert_eq!(config.preset, Some(RulePreset::Baseline));
+        assert_eq!(
+            config.effective_core_config().enabled_rules,
+            RulePreset::Baseline.rule_ids()
+        );
     }
 
     /// Build a chapter with the given source path.

--- a/crates/mdbook-lint-cli/tests/baseline_preset_test.rs
+++ b/crates/mdbook-lint-cli/tests/baseline_preset_test.rs
@@ -1,0 +1,346 @@
+//! Public contract tests for the baseline preset (issue #466).
+
+mod common;
+
+use common::{cli_command, fixture_path};
+use mdbook_lint::{Config, PluginRegistry, RuleStability};
+use mdbook_lint_rulesets::{BASELINE_RULE_IDS, RulePreset, StandardRuleProvider};
+use predicates::str::contains;
+use serde_json::Value;
+use std::{collections::BTreeSet, fs, path::PathBuf};
+use tempfile::TempDir;
+
+const CONTENT: &str = "# Title\n\n### Skipped heading\n\nThis line is deliberately much longer than eighty characters so the non-baseline MD013 rule reports it.\n";
+
+fn fixture() -> (TempDir, String) {
+    let temp = TempDir::new().unwrap();
+    let document = temp.path().join("document.md");
+    fs::write(&document, CONTENT).unwrap();
+    (temp, document.to_string_lossy().into_owned())
+}
+
+fn write_config(temp: &TempDir, extension: &str, body: &str) -> String {
+    let path = temp.path().join(format!("config.{extension}"));
+    fs::write(&path, body).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+fn json_stdout(assert: &assert_cmd::assert::Assert) -> Value {
+    serde_json::from_slice(&assert.get_output().stdout).expect("stdout should be JSON")
+}
+
+fn violation_ids(output: &Value) -> BTreeSet<String> {
+    output["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|file| file["violations"].as_array().into_iter().flatten())
+        .filter_map(|violation| violation["rule_id"].as_str().map(String::from))
+        .collect()
+}
+
+#[test]
+fn baseline_membership_is_explicit_registered_and_stable() {
+    assert_eq!(
+        BASELINE_RULE_IDS,
+        ["MD001", "MD003", "MD009", "MD010", "MD011", "MD014"]
+    );
+    assert_eq!(
+        BASELINE_RULE_IDS
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>()
+            .len(),
+        BASELINE_RULE_IDS.len(),
+        "preset membership must not contain duplicates"
+    );
+
+    let mut providers = PluginRegistry::new();
+    providers
+        .register_provider(Box::new(StandardRuleProvider))
+        .unwrap();
+    let engine = providers.create_engine().unwrap();
+
+    for rule_id in BASELINE_RULE_IDS {
+        let rule = engine
+            .registry()
+            .get_rule(rule_id)
+            .unwrap_or_else(|| panic!("baseline member {rule_id} is not registered"));
+        let metadata = rule.metadata();
+        assert_eq!(metadata.stability, RuleStability::Stable, "{rule_id}");
+        assert!(!metadata.deprecated, "{rule_id}");
+    }
+}
+
+#[test]
+fn rules_command_explains_exact_baseline_membership() {
+    let assert = cli_command()
+        .args(["rules", "--preset", "baseline", "--json"])
+        .assert()
+        .success();
+    let output = json_stdout(&assert);
+
+    assert_eq!(output["preset"]["name"], "baseline");
+    assert!(
+        output["preset"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("Low-noise")
+    );
+    assert_eq!(output["total_rules"], BASELINE_RULE_IDS.len());
+
+    let listed: Vec<&str> = output["providers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|provider| provider["rules"].as_array().unwrap())
+        .map(|rule| rule["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(listed, BASELINE_RULE_IDS);
+
+    cli_command()
+        .args(["rules", "--preset", "baseline"])
+        .assert()
+        .success()
+        .stdout(contains("Rules in preset 'baseline'"))
+        .stdout(contains("MD001"))
+        .stdout(contains("MD014"));
+}
+
+#[test]
+fn cli_preset_selects_baseline_without_changing_default_behavior() {
+    let (temp, document) = fixture();
+    let default_config = write_config(&temp, "toml", "");
+
+    let default_assert = cli_command()
+        .args([
+            "lint",
+            "--config",
+            &default_config,
+            "--output",
+            "json",
+            &document,
+        ])
+        .assert();
+    let default_ids = violation_ids(&json_stdout(&default_assert));
+    assert!(default_ids.contains("MD001"));
+    assert!(default_ids.contains("MD013"));
+
+    let baseline_assert = cli_command()
+        .args([
+            "lint",
+            "--config",
+            &default_config,
+            "--preset",
+            "baseline",
+            "--output",
+            "json",
+            &document,
+        ])
+        .assert();
+    let baseline_ids = violation_ids(&json_stdout(&baseline_assert));
+    assert!(baseline_ids.contains("MD001"));
+    assert!(!baseline_ids.contains("MD013"));
+    assert!(
+        baseline_ids
+            .iter()
+            .all(|id| BASELINE_RULE_IDS.contains(&id.as_str()))
+    );
+}
+
+#[test]
+fn preset_deserializes_from_every_supported_config_format() {
+    for config in [
+        Config::from_toml_str("preset = \"baseline\"\n").unwrap(),
+        Config::from_yaml_str("preset: baseline\n").unwrap(),
+        Config::from_json_str("{\"preset\":\"baseline\"}").unwrap(),
+    ] {
+        assert_eq!(config.preset, Some(RulePreset::Baseline));
+        assert_eq!(
+            config.effective_core_config().enabled_rules,
+            BASELINE_RULE_IDS
+        );
+    }
+}
+
+#[test]
+fn config_preset_and_disabled_rules_use_public_lint_path() {
+    let (temp, document) = fixture();
+    let config = write_config(
+        &temp,
+        "toml",
+        "preset = \"baseline\"\ndisabled-rules = [\"MD001\"]\n",
+    );
+
+    let assert = cli_command()
+        .args(["lint", "--config", &config, "--output", "json", &document])
+        .assert();
+    let ids = violation_ids(&json_stdout(&assert));
+    assert!(!ids.contains("MD001"));
+    assert!(!ids.contains("MD013"));
+}
+
+#[test]
+fn explicit_config_rule_list_wins_over_config_preset() {
+    let (temp, document) = fixture();
+    let config = write_config(
+        &temp,
+        "toml",
+        "preset = \"baseline\"\nenabled-rules = [\"MD013\"]\n",
+    );
+
+    let assert = cli_command()
+        .args(["lint", "--config", &config, "--output", "json", &document])
+        .assert();
+    let ids = violation_ids(&json_stdout(&assert));
+    assert!(ids.contains("MD013"));
+    assert!(!ids.contains("MD001"));
+
+    cli_command()
+        .args(["check", &config])
+        .assert()
+        .success()
+        .stderr(contains("Preset 'baseline' is ignored"));
+}
+
+#[test]
+fn cli_preset_overrides_configured_rule_list_and_accepts_disable() {
+    let (temp, document) = fixture();
+    let config = write_config(&temp, "toml", "enabled-rules = [\"MD013\"]\n");
+
+    let assert = cli_command()
+        .args([
+            "lint",
+            "--config",
+            &config,
+            "--preset",
+            "baseline",
+            "--disable",
+            "MD001",
+            "--output",
+            "json",
+            &document,
+        ])
+        .assert();
+    let ids = violation_ids(&json_stdout(&assert));
+    assert!(!ids.contains("MD001"));
+    assert!(!ids.contains("MD013"));
+}
+
+#[test]
+fn cli_enable_overrides_config_preset_and_configured_disables() {
+    let (temp, document) = fixture();
+    let config = write_config(
+        &temp,
+        "toml",
+        "preset = \"baseline\"\ndisabled-rules = [\"MD013\"]\n",
+    );
+
+    let assert = cli_command()
+        .args([
+            "lint", "--config", &config, "--enable", "MD013", "--output", "json", &document,
+        ])
+        .assert();
+    let ids = violation_ids(&json_stdout(&assert));
+    assert!(ids.contains("MD013"));
+    assert!(!ids.contains("MD001"));
+}
+
+#[test]
+fn representative_mdbook_fixture_runs_only_baseline_members() {
+    let temp = TempDir::new().unwrap();
+    let config = write_config(&temp, "toml", "preset = \"baseline\"\n");
+    let book_src = fixture_path("real_books/minimal_book", "src");
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(config)
+        .args(["--output", "json"])
+        .arg(book_src)
+        .assert();
+    let ids = violation_ids(&json_stdout(&assert));
+    assert!(
+        ids.iter()
+            .all(|id| BASELINE_RULE_IDS.contains(&id.as_str()))
+    );
+}
+
+#[test]
+fn essential_corpus_runs_through_baseline_config() {
+    let temp = TempDir::new().unwrap();
+    let config = write_config(&temp, "toml", "preset = \"baseline\"\n");
+    let corpus = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/corpus/essential");
+
+    let assert = cli_command()
+        .arg("lint")
+        .arg("--config")
+        .arg(config)
+        .args(["--output", "json"])
+        .arg(corpus)
+        .assert();
+    let ids = violation_ids(&json_stdout(&assert));
+    assert!(ids.contains("MD001"));
+    assert!(ids.contains("MD009"));
+    assert!(
+        ids.iter()
+            .all(|id| BASELINE_RULE_IDS.contains(&id.as_str()))
+    );
+}
+
+#[test]
+fn incompatible_cli_selectors_are_rejected() {
+    cli_command()
+        .args([
+            "lint",
+            "--preset",
+            "baseline",
+            "--enable",
+            "MD001",
+            "document.md",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("cannot be used with '--enable"));
+
+    cli_command()
+        .args(["rules", "--preset", "baseline", "--mdbook-only"])
+        .assert()
+        .failure()
+        .stderr(contains("cannot be used with '--mdbook-only"));
+}
+
+#[test]
+fn check_rejects_unknown_preset_and_warns_about_ignored_selectors() {
+    let temp = TempDir::new().unwrap();
+    let unknown = write_config(&temp, "toml", "preset = \"unknown\"\n");
+    cli_command()
+        .args(["check", &unknown])
+        .assert()
+        .failure()
+        .stderr(contains("unknown preset 'unknown'"));
+
+    let ineffective = write_config(
+        &temp,
+        "yaml",
+        "preset: baseline\nexperimental-rules: [MDBOOK010]\nenabled-categories: [structure]\nmarkdownlint-compatible: true\n",
+    );
+    cli_command()
+        .args(["check", &ineffective])
+        .assert()
+        .success()
+        .stderr(contains("experimental-rules is ignored"))
+        .stderr(contains("rule categories are ignored"))
+        .stderr(contains("markdownlint-compatible is ignored"));
+}
+
+#[test]
+fn linting_subcommands_advertise_preset_support() {
+    for subcommand in ["lint", "fix", "rustdoc", "rules"] {
+        cli_command()
+            .args([subcommand, "--help"])
+            .assert()
+            .success()
+            .stdout(contains("--preset"));
+    }
+}

--- a/crates/mdbook-lint-cli/tests/config_examples_tests.rs
+++ b/crates/mdbook-lint-cli/tests/config_examples_tests.rs
@@ -5,6 +5,7 @@ use std::{fs, path::PathBuf};
 use tempfile::TempDir;
 
 const EXAMPLES: &[&str] = &[
+    "baseline.mdbook-lint.toml",
     "strict.mdbook-lint.toml",
     "relaxed.mdbook-lint.toml",
     "api-docs.mdbook-lint.toml",

--- a/crates/mdbook-lint-cli/tests/simple_corpus_tests.rs
+++ b/crates/mdbook-lint-cli/tests/simple_corpus_tests.rs
@@ -98,12 +98,14 @@ fn test_our_own_documentation() {
 #[test]
 fn test_essential_corpus_files() {
     let engine = create_lint_engine();
-    let corpus_dir = Path::new("tests/corpus/essential");
-
-    if !corpus_dir.exists() {
-        println!("Essential corpus directory not found, skipping");
-        return;
-    }
+    // Integration tests run with the package directory as the working
+    // directory, so the corpus has to be resolved from the manifest path.
+    let corpus_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/corpus/essential");
+    assert!(
+        corpus_dir.is_dir(),
+        "essential corpus is missing at {}; it is checked in and must not be ignored",
+        corpus_dir.display()
+    );
 
     let mut files_tested = 0;
 
@@ -130,8 +132,8 @@ fn test_essential_corpus_files() {
     }
 
     assert!(
-        files_tested > 0,
-        "Should have tested at least one corpus file"
+        files_tested >= 5,
+        "expected the documented essential corpus files, tested only {files_tested}"
     );
     println!("Tested {} essential corpus files", files_tested);
 }

--- a/crates/mdbook-lint-rulesets/src/lib.rs
+++ b/crates/mdbook-lint-rulesets/src/lib.rs
@@ -138,6 +138,10 @@ pub use mdbook_lint_core::{
     RuleMetadata, RuleProvider, RuleRegistry, RuleStability, Severity, Violation,
 };
 
+/// Curated built-in rule presets.
+pub mod presets;
+pub use presets::{BASELINE_RULE_IDS, RulePreset};
+
 /// Create a pre-configured lint engine with all default rules.
 ///
 /// This is the recommended way to create a lint engine for most use cases.

--- a/crates/mdbook-lint-rulesets/src/presets.rs
+++ b/crates/mdbook-lint-rulesets/src/presets.rs
@@ -1,0 +1,102 @@
+//! Built-in rule presets.
+//!
+//! Presets are curated product policy rather than intrinsic rule metadata. The
+//! ordered lists in this module are therefore the single source of truth used
+//! by configuration, CLI selection, and rule discovery.
+
+use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
+use std::{fmt, str::FromStr};
+
+/// Rules in the low-noise baseline for incremental CI adoption.
+///
+/// Membership is deliberately explicit: newly stable rules are not added
+/// automatically. Changes to this list are user-visible and require release
+/// notes plus corpus review.
+pub const BASELINE_RULE_IDS: &[&str] = &["MD001", "MD003", "MD009", "MD010", "MD011", "MD014"];
+
+/// A built-in, named rule preset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RulePreset {
+    /// Low-noise mechanical checks suitable for initial CI adoption.
+    Baseline,
+}
+
+impl RulePreset {
+    /// Canonical configuration and CLI name.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+        }
+    }
+
+    /// Short explanation shown by rule discovery.
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::Baseline => {
+                "Low-noise stable structural, syntax, and whitespace checks for incremental CI adoption"
+            }
+        }
+    }
+
+    /// Ordered rule IDs in this preset.
+    pub const fn rule_ids(self) -> &'static [&'static str] {
+        match self {
+            Self::Baseline => BASELINE_RULE_IDS,
+        }
+    }
+
+    /// Whether a rule belongs to this preset.
+    pub fn contains(self, rule_id: &str) -> bool {
+        self.rule_ids().contains(&rule_id)
+    }
+}
+
+impl fmt::Display for RulePreset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl FromStr for RulePreset {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "baseline" => Ok(Self::Baseline),
+            _ => Err(format!(
+                "unknown preset '{value}'; available presets: baseline"
+            )),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RulePreset {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_membership_is_an_ordered_stable_contract() {
+        assert_eq!(
+            RulePreset::Baseline.rule_ids(),
+            ["MD001", "MD003", "MD009", "MD010", "MD011", "MD014"]
+        );
+    }
+
+    #[test]
+    fn preset_names_round_trip() {
+        let preset: RulePreset = "baseline".parse().unwrap();
+        assert_eq!(preset, RulePreset::Baseline);
+        assert_eq!(preset.to_string(), "baseline");
+    }
+}

--- a/docs/src/ci-vs-preprocessor.md
+++ b/docs/src/ci-vs-preprocessor.md
@@ -95,12 +95,14 @@ jobs:
 **Setup with `.mdbook-lint.toml`:**
 
 ```toml
+# Start existing documentation with the low-noise baseline.
+preset = "baseline"
 fail-on-warnings = true
-disabled-rules = ["MD013", "MD033"]
-
-[MD007]
-indent = 4
 ```
+
+Inspect the exact selection with `mdbook-lint rules --preset baseline`. Remove
+the `preset` line when the project is ready to adopt the complete stable
+ruleset. Project-specific exclusions can be added with `disabled-rules`.
 
 **In CI (GitHub Actions):**
 
@@ -127,7 +129,7 @@ jobs:
         run: |
 
           cargo install mdbook-lint
-          mdbook-lint lint docs/ --fail-on-warnings
+          mdbook-lint lint docs/ --preset baseline --fail-on-warnings
       
 # Optional: Upload SARIF results
 
@@ -245,7 +247,7 @@ jobs:
       - name: Install mdbook-lint
         run: cargo install mdbook-lint
       - name: Lint documentation
-        run: mdbook-lint docs/src/ --fail-on-warnings
+        run: mdbook-lint docs/src/ --preset baseline --fail-on-warnings
 ```
 
 ### For Local Development: Add Preprocessor (Optional)
@@ -263,7 +265,7 @@ Use standalone CLI in CI for control and reliability, with optional preprocessor
 ```yaml
 # .github/workflows/docs.yml - CI uses standalone
 - name: Lint documentation
-  run: mdbook-lint docs/src/ --fail-on-warnings
+  run: mdbook-lint docs/src/ --preset baseline --fail-on-warnings
 - name: Build book
   run: mdbook build docs/
 ```

--- a/docs/src/cli-usage.md
+++ b/docs/src/cli-usage.md
@@ -105,6 +105,7 @@ mdbook-lint help [COMMAND]
 - `--fail-on-warnings`: Exit with error code on warnings
 - `--disable <RULES>`: Disable specific rules (comma-separated)
 - `--enable <RULES>`: Enable only specific rules (comma-separated)
+- `--preset <NAME>`: Use a curated rule preset (`baseline`)
 - `--fix`: Automatically fix violations where possible
 - `--fix-unsafe`: Apply all fixes, including potentially unsafe ones
 - `--dry-run`: Show what would be fixed without applying changes (requires --fix or --fix-unsafe)
@@ -120,8 +121,14 @@ mdbook-lint help [COMMAND]
 - `-p, --provider <PROVIDER>`: Show only rules from a specific provider
 - `--standard-only`: Show only standard rules (MD001-MD059)
 - `--mdbook-only`: Show only mdBook-specific rules
+- `--preset <NAME>`: Show only rules in a curated preset
 - `--format <FORMAT>`: Output format (default, json)
 - `--json`: Output in JSON format (shorthand for `--format json`)
+
+For linting commands, `--preset baseline` may be combined with `--disable`,
+which subtracts rules from the preset. It conflicts with `--enable`,
+`--standard-only`, and `--mdbook-only` where those flags are available because
+they choose a different base rule set.
 
 ## Output Format
 

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -4,6 +4,24 @@ Complete reference for all configuration options in mdbook-lint.
 
 ## Global Configuration Options
 
+### preset
+
+- **Type**: `string`
+- **Default**: not set (use the complete stable default ruleset)
+- **Valid values**: `"baseline"`
+- **Description**: Select a curated, explicit base rule set. The baseline is a
+  low-noise starting point for incremental CI adoption.
+
+```toml
+preset = "baseline"
+```
+
+Run `mdbook-lint rules --preset baseline` to inspect its exact, versioned
+membership: `MD001`, `MD003`, `MD009`, `MD010`, `MD011`, and `MD014`. The list
+is intentionally curated rather than derived from rule categories, so newly
+stable rules are not added implicitly. Removing the setting returns to the
+complete stable default set.
+
 ### fail-on-warnings
 
 - **Type**: `boolean`
@@ -55,6 +73,24 @@ experimental-rules = ["MDBOOK010"]
 Run `mdbook-lint rules` to see which rules are experimental, or
 `mdbook-lint rules --detailed` for a table with a `Default` column showing
 whether each rule runs without configuration.
+
+### Rule-Selection Precedence
+
+Rule selection uses the following precedence, from highest to lowest:
+
+1. CLI `--enable` selects exactly those rules and preserves its existing
+   behavior of clearing configured `disabled-rules`.
+2. CLI `--preset` overrides a configured preset or `enabled-rules` base.
+3. A non-empty configured `enabled-rules` list selects exactly those rules and
+   takes precedence over `preset` in the same file.
+4. Configured `preset` selects its explicit membership.
+5. With none of the above, all stable default rules run.
+
+Configured `disabled-rules` and CLI `--disable` subtract from a preset. CLI
+`--preset` conflicts with CLI `--enable`, `--standard-only`, and
+`--mdbook-only`. Categories, `experimental-rules`, and
+`markdownlint-compatible` do not modify an exact preset; `mdbook-lint check`
+warns when these ineffective combinations are configured.
 
 ### enabled-categories
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -23,6 +23,16 @@ discovery, pass `--config <FILE>` to `lint`, `fix`, or `rustdoc`.
 
 ## Basic Configuration
 
+For incremental adoption in an existing project, select the maintained
+low-noise baseline instead of copying a rule allowlist:
+
+```toml
+preset = "baseline"
+```
+
+Inspect the exact membership with `mdbook-lint rules --preset baseline`. Remove
+the setting to move to the complete stable default ruleset.
+
 ### TOML Format (Recommended)
 
 ```toml
@@ -158,6 +168,7 @@ This disables rules that are disabled by default in markdownlint.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
+| `preset` | string | unset | Curated base rule set (`"baseline"`) |
 | `fail-on-warnings` | boolean | `false` | Exit with error code on warnings |
 | `fail-on-errors` | boolean | `true` | Exit with error code on errors |
 | `disabled-rules` | array | `[]` | List of rule IDs to disable |
@@ -200,6 +211,7 @@ When used as an mdBook preprocessor, configuration can be specified in `book.tom
 
 ```toml
 [preprocessor.lint]
+preset = "baseline"
 fail-on-warnings = true
 disabled-rules = ["MD025"]
 
@@ -209,17 +221,11 @@ line-length = 100
 
 ## Example Configurations
 
-### Minimal - Only Critical Rules
+### Baseline - Incremental Adoption
 
 ```toml
-[rules]
-default = false
-
-[rules.enabled]
-MD001 = true  # Heading levels should increment
-MD003 = true  # Heading style consistency
-MD009 = true  # No trailing spaces
-MD047 = true  # File should end with newline
+preset = "baseline"
+fail-on-warnings = true
 ```
 
 ### Strict - All Rules with Custom Settings
@@ -315,6 +321,7 @@ For real-world configuration examples:
 
 - [example-mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/crates/mdbook-lint-cli/example-mdbook-lint.toml) - Comprehensive reference with all rules documented and commented
 - [docs/.mdbook-lint.toml](https://github.com/joshrotenberg/mdbook-lint/blob/main/docs/.mdbook-lint.toml) - Real-world example used by this project's own documentation
+- [Baseline](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/baseline.mdbook-lint.toml) - Incremental CI adoption
 - [Strict](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/strict.mdbook-lint.toml) - Publication and CI gates
 - [Relaxed](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/relaxed.mdbook-lint.toml) - Personal projects and early drafts
 - [API documentation](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/api-docs.mdbook-lint.toml) - Generated and hand-written API references

--- a/docs/src/example-configuration.md
+++ b/docs/src/example-configuration.md
@@ -16,6 +16,23 @@ This page provides a complete, fully-commented example configuration file for md
 
 ## Common Configuration Patterns
 
+### Baseline for Incremental Adoption
+
+For an existing documentation set, begin with the maintained low-noise preset:
+
+```toml
+preset = "baseline"
+fail-on-warnings = true
+
+# Optional project-specific subtraction.
+# disabled-rules = ["MD014"]
+```
+
+Use `mdbook-lint rules --preset baseline` to explain the exact membership.
+Remove the `preset` setting when the project is ready for every stable default
+rule. See [`examples/baseline.mdbook-lint.toml`](https://github.com/joshrotenberg/mdbook-lint/blob/main/examples/baseline.mdbook-lint.toml)
+for the standalone example.
+
 ### Minimal Configuration
 
 For most projects, a minimal configuration is sufficient:
@@ -142,7 +159,7 @@ disabled-rules = [
 
 ## Tips
 
-1. **Start minimal**: Begin with defaults and add configuration as needed
+1. **Start minimal**: Use `preset = "baseline"` for an existing corpus, then remove it when ready for the full stable set
 2. **Document choices**: Comment why certain rules are disabled
 3. **Version control**: Commit `.mdbook-lint.toml` to your repository
 4. **Team agreement**: Discuss and agree on rules with your team

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -20,6 +20,29 @@ mdbook-lint lint .
 mdbook-lint lint --fix src/*.md
 ```
 
+## Start with the Baseline Preset
+
+Existing documentation often produces too many findings when every stable rule
+is enabled at once. For incremental CI adoption, start with the curated
+`baseline` preset:
+
+```bash
+mdbook-lint lint --preset baseline docs/
+```
+
+Or commit the selection in `.mdbook-lint.toml`:
+
+```toml
+preset = "baseline"
+fail-on-warnings = true
+```
+
+The preset contains a small, versioned set of stable structural, syntax, and
+whitespace checks. Inspect its exact membership with
+`mdbook-lint rules --preset baseline`. You can subtract a project-specific rule
+with `disabled-rules` or `--disable`. When the project is ready for the complete
+stable ruleset, remove `preset = "baseline"`.
+
 ## Understanding the Output
 
 When mdbook-lint finds issues, it will display them like this:
@@ -125,6 +148,9 @@ mdbook-lint rules --detailed
 
 # Filter rules by category
 mdbook-lint rules --category structure
+
+# Explain the low-noise baseline preset
+mdbook-lint rules --preset baseline --detailed
 ```
 
 ## Next Steps

--- a/docs/src/mdbook-integration.md
+++ b/docs/src/mdbook-integration.md
@@ -84,6 +84,7 @@ The `[preprocessor.lint]` table accepts these mdbook-lint settings:
 
 | Setting | Type | Purpose |
 |---------|------|---------|
+| `preset` | string | Select a curated base rule set (`"baseline"`) |
 | `fail-on-warnings` | boolean | Fail the mdBook build when warnings are found |
 | `fail-on-errors` | boolean | Fail the mdBook build when errors are found |
 | `enabled-rules` | array | Run only the listed rule IDs |
@@ -95,8 +96,9 @@ For example:
 
 ```toml
 [preprocessor.lint]
+preset = "baseline"
 fail-on-warnings = true
-disabled-rules = ["MD013", "MD041"]
+disabled-rules = ["MD014"]
 disabled-categories = ["whitespace"]
 ```
 
@@ -152,14 +154,15 @@ control over paths and output format.
 
 ### Progressive adoption
 
-Start with a small allow-list and expand it over time:
+Start with the maintained low-noise preset:
 
 ```toml
 [preprocessor.lint]
-enabled-rules = ["MD001", "MD003", "MD009", "MD040", "MD047"]
+preset = "baseline"
 ```
 
-Remove `enabled-rules` when the book is ready to use the default rule set.
+Inspect the exact list with `mdbook-lint rules --preset baseline`. Remove
+`preset` when the book is ready to use the complete stable default rule set.
 
 ### Rule-specific configuration
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -100,6 +100,7 @@ mdbook-lint rules --detailed
 
 The mdBook preprocessor reads only these settings from `[preprocessor.lint]`:
 
+- `preset`
 - `fail-on-warnings`
 - `fail-on-errors`
 - `enabled-rules`
@@ -115,8 +116,9 @@ For example:
 ```toml
 # book.toml
 [preprocessor.lint]
+preset = "baseline"
 fail-on-warnings = true
-disabled-rules = ["MD041"]
+disabled-rules = ["MD014"]
 ```
 
 ```toml
@@ -254,11 +256,12 @@ copy of `book.toml`:
 time mdbook build
 ```
 
-Then narrow the rule set rather than adding unsupported chapter globs:
+Then select the maintained baseline rather than adding unsupported chapter
+globs:
 
 ```toml
 [preprocessor.lint]
-enabled-rules = ["MD001", "MD003", "MD009", "MD040", "MD047"]
+preset = "baseline"
 ```
 
 Preprocessor mode checks the chapters supplied by mdBook and does not implement

--- a/examples/baseline.mdbook-lint.toml
+++ b/examples/baseline.mdbook-lint.toml
@@ -1,0 +1,12 @@
+# Low-noise configuration for adopting mdbook-lint incrementally in CI.
+# The baseline membership is maintained by mdbook-lint and can be inspected
+# with `mdbook-lint rules --preset baseline`.
+
+preset = "baseline"
+
+# Baseline includes warning-level whitespace and command checks. Enable this
+# when every reported baseline diagnostic should fail CI.
+fail-on-warnings = true
+
+# Individual baseline rules may still be removed for project-specific needs.
+# disabled-rules = ["MD014"]

--- a/tests/corpus/essential/known_violations.md
+++ b/tests/corpus/essential/known_violations.md
@@ -1,0 +1,29 @@
+# Test File with Known Violations
+
+### Skipped H2 level (MD001 violation)
+
+This line has trailing spaces    
+Another line with trailing spaces   
+
+```
+Code block without language tag (MDBOOK001 violation)
+some code here
+```
+
+This line is intentionally very long to exceed typical line length limits and should trigger MD013 violations when that rule is enabled with default settings
+
+#  Multiple spaces after hash (MD018 violation)
+
+- List item 1
+* Mixed list markers (MD004 violation)  
+- List item 3
+
+[Incomplete link](
+
+**Unclosed strong emphasis
+
+Multiple blank lines below (MD012 violation):
+
+
+
+End of violations test file.

--- a/tests/corpus/essential/large_file.md
+++ b/tests/corpus/essential/large_file.md
@@ -1,0 +1,111 @@
+# Large File Performance Test
+
+This file tests performance with a reasonably sized document.
+
+## Introduction
+
+This document contains enough content to test performance without being excessive. It should process quickly but still provide meaningful performance data.
+
+## Sections with Various Content Types
+
+### Section 1: Lists and Basic Formatting
+
+- Item 1 with *emphasis*
+- Item 2 with **strong text**
+- Item 3 with `inline code`
+- Item 4 with [a link](https://example.com)
+
+### Section 2: Code Blocks
+
+```rust
+fn example_function() {
+    println!("This is example Rust code");
+    let x = 42;
+    let message = format!("The answer is {}", x);
+}
+```
+
+```javascript
+function exampleFunction() {
+    console.log("This is example JavaScript code");
+    const x = 42;
+    const message = `The answer is ${x}`;
+}
+```
+
+### Section 3: Tables
+
+| Column 1 | Column 2 | Column 3 |
+|----------|----------|----------|
+| Row 1 Col 1 | Row 1 Col 2 | Row 1 Col 3 |
+| Row 2 Col 1 | Row 2 Col 2 | Row 2 Col 3 |
+
+### Section 4: Blockquotes
+
+> This is a blockquote with some content.
+> 
+> > This is a nested blockquote.
+> > It contains multiple lines.
+>
+> Back to the first level.
+
+### Section 5: Mixed Content
+
+Here's some regular paragraph text with various formatting:
+
+1. Numbered list item
+2. Another numbered item with `code`
+3. Item with **bold** and *italic* text
+
+- Unordered list
+- With mixed content
+- Including [links](https://example.com) and `code`
+
+## Auto-Generated Repetitive Content
+
+The following sections test performance with repetitive content:
+
+### Auto-Generated Section 1
+
+This is section 1 with some content. It includes:
+
+- List item A for section 1
+- List item B with *emphasis* for section 1  
+- List item C with `inline code` for section 1
+
+```bash
+# Command for section 1
+echo "Processing section 1"
+```
+
+Regular paragraph text for section 1 with **bold text** and normal text.
+
+### Auto-Generated Section 2
+
+This is section 2 with some content. It includes:
+
+- List item A for section 2
+- List item B with *emphasis* for section 2  
+- List item C with `inline code` for section 2
+
+```bash
+# Command for section 2
+echo "Processing section 2"
+```
+
+Regular paragraph text for section 2 with **bold text** and normal text.
+
+### Auto-Generated Section 3
+
+This is section 3 with some content. It includes:
+
+- List item A for section 3
+- List item B with *emphasis* for section 3  
+- List item C with `inline code` for section 3
+
+```python
+# Command for section 3
+print("Processing section 3")
+```
+
+Regular paragraph text for section 3 with **bold text** and normal text.

--- a/tests/corpus/essential/mixed_line_endings.md
+++ b/tests/corpus/essential/mixed_line_endings.md
@@ -1,0 +1,16 @@
+# Mixed Line Endings Test
+
+This document tests handling of different line ending styles.
+
+## Windows CRLF
+Content with Windows line endings.
+
+## Unix LF
+Content with Unix line endings.
+
+## Mixed Content
+Some lines have different endings.
+This line might have CRLF.
+This line might have LF only.
+
+The linter should handle all variants gracefully.

--- a/tests/corpus/essential/unicode_content.md
+++ b/tests/corpus/essential/unicode_content.md
@@ -1,0 +1,37 @@
+# Unicode Test Document
+
+This document tests various Unicode characters and edge cases.
+
+## Emoji and Symbols
+
+- List with emoji 📝
+- Mathematical symbols: ∑ ∫ ∂ ∆ ∞ ≠ ≤ ≥  
+- Currency: € £ ¥ ₹ ₽
+
+## International Text
+
+- Chinese: 中文测试内容
+- Arabic: اختبار المحتوى العربي
+- Hebrew: בדיקת תוכן בעברית
+- Russian: Тестирование русского содержания
+- Japanese: 日本語のテスト内容
+
+## Special Characters
+
+Zero-width characters: invisible‌spaces\u{200B}here
+
+Right-to-left override: normal text ‮reversed text‬ normal again
+
+## Smart Quotes and Dashes
+
+"Smart quotes" vs "regular quotes"
+En dash: – Em dash: — Minus: −
+
+## Code with Unicode
+
+```python  
+def greet():
+    print("Hello, 世界!")  # Mixed ASCII and Unicode
+```
+
+This should test Unicode handling across different rules.


### PR DESCRIPTION
## Summary

- add an explicit, curated `baseline` preset for low-noise incremental CI adoption
- support the preset consistently across lint, fix, rustdoc, rules discovery, configuration, LSP, and the mdBook preprocessor
- define and test deterministic precedence with explicit rule selections and disabled rules
- document the preset and add a parse-tested example configuration

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mdbook-lint --test baseline_preset_test --all-features`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --doc --workspace --all-features`
- `git diff --check`

The checked-in essential corpus and representative mdBook fixture are covered. A broader pinned multi-repository corpus and formal noise budgets remain a useful follow-up rather than part of this first preset contract.

Closes #466